### PR TITLE
Add rules_ros2 as a dependency so we can link ros2 libraries

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,6 +6,16 @@
 
 workspace(name = "resim_open_core")
 
+# Due to the documented shortcomings of the WORKSPACE system (see
+# https://bazel.build/external/overview), we are forced to call four functions
+# in order to set up the workspace. This is because starlark macros cannot load
+# other .bzl files. In other words, we cannot load bzl files from dependency
+# X without first bringing X in with e.g. an http_archive call in a macro, and
+# we cannot bring in X's dependencies without loading bzl files from it. This
+# limitation compounds at each level of transitive dependency.
+
+# In order to depend on this repository, you can simply copy/paste the rest of
+# this file into your WORKSPACE files.
 load("@resim_open_core//:deps.bzl", "resim_core_dependencies")
 
 resim_core_dependencies()
@@ -13,3 +23,11 @@ resim_core_dependencies()
 load("@resim_open_core//:transitive_deps.bzl", "resim_core_transitive_dependencies")
 
 resim_core_transitive_dependencies()
+
+load("@resim_open_core//:ros2_setup_1.bzl", "ros2_setup_1")
+
+ros2_setup_1()
+
+load("@resim_open_core//:ros2_setup_2.bzl", "ros2_setup_2")
+
+ros2_setup_2()

--- a/deps.bzl
+++ b/deps.bzl
@@ -15,6 +15,14 @@ def resim_core_dependencies():
     """
     maybe(
         http_archive,
+        name = "rules_cc",
+        urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.8/rules_cc-0.0.8.tar.gz"],
+        sha256 = "ae46b722a8b8e9b62170f83bfb040cbf12adb732144e689985a66b26410a7d6f",
+        strip_prefix = "rules_cc-0.0.8",
+    )
+
+    maybe(
+        http_archive,
         name = "bazel_skylib",
         sha256 = "66ffd9315665bfaafc96b52278f57c7e2dd09f5ede279ea6d39b2be471e7e3aa",
         urls = [
@@ -265,4 +273,14 @@ def resim_core_dependencies():
         url = "https://github.com/nelhage/rules_boost/archive/96e9b631f104b43a53c21c87b01ac538ad6f3b48.tar.gz",
         sha256 = "5ea00abc70cdf396a23fb53201db19ebce2837d28887a08544429d27783309ed",
         strip_prefix = "rules_boost-96e9b631f104b43a53c21c87b01ac538ad6f3b48",
+    )
+
+    maybe(
+        http_archive,
+        name = "com_github_mvukov_rules_ros2",
+        patch_args = ["-p1"],
+        patches = ["//resim/third_party/ros2:flto.patch"],
+        sha256 = "16b01677e2b2df0505504fd104ed082cc3caa9d720d994e369c46f43d94b91f5",
+        strip_prefix = "rules_ros2-9b3030feb0538c5491d3f5d8d3d0d483c63938f1",
+        url = "https://github.com/mvukov/rules_ros2/archive/9b3030feb0538c5491d3f5d8d3d0d483c63938f1.tar.gz",
     )

--- a/resim/third_party/ros2/BUILD
+++ b/resim/third_party/ros2/BUILD
@@ -1,0 +1,21 @@
+# Copyright 2023 ReSim, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+exports_files(
+    glob(["*.BUILD"]),
+    visibility = ["//visibility:public"],
+)
+
+cc_test(
+    name = "ros2_test",
+    srcs = ["ros2_test.cc"],
+    deps = [
+        "@com_google_googletest//:gtest_main",
+        "@ros2_rcpputils//:rcpputils",
+    ],
+)

--- a/resim/third_party/ros2/flto.patch
+++ b/resim/third_party/ros2/flto.patch
@@ -1,0 +1,15 @@
+t a/repositories/cyclonedds.BUILD.bazel b/repositories/cyclonedds.BUILD.bazel
+index ebad2de..6b82bfa 100644
+--- a/repositories/cyclonedds.BUILD.bazel
++++ b/repositories/cyclonedds.BUILD.bazel
+@@ -146,8 +146,8 @@ cmake(
+     lib_source = ":all_srcs",
+     linkopts = select(
+         {
+-            "@platforms//os:linux": ["-lpthread"],
+-            "@platforms//os:macos": ["-lpthread"],
++            "@platforms//os:linux": ["-lpthread", "-flto=thin"],
++            "@platforms//os:macos": ["-lpthread", "-flto=thin"],
+             "@platforms//os:qnx": [],
+         },
+         no_match_error = "Only Linux, macOS and QNX are supported!",

--- a/resim/third_party/ros2/ros2_test.cc
+++ b/resim/third_party/ros2/ros2_test.cc
@@ -1,3 +1,8 @@
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
 
 #include <gtest/gtest.h>
 

--- a/resim/third_party/ros2/ros2_test.cc
+++ b/resim/third_party/ros2/ros2_test.cc
@@ -1,0 +1,9 @@
+
+#include <gtest/gtest.h>
+
+#include <rcpputils/asserts.hpp>
+
+TEST(Ros2Test, TestLinksRos2) {
+  // Check that we can use ros2 code
+  rcpputils::assert_true(true);
+}

--- a/ros2_setup_1.bzl
+++ b/ros2_setup_1.bzl
@@ -1,0 +1,25 @@
+# Copyright 2023 ReSim, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+"""Macro to help bring in ros2 transitive dependendencies at the third level.
+"""
+
+load(
+    "@com_github_mvukov_rules_ros2//repositories:deps.bzl",
+    "PIP_ANNOTATIONS",
+)
+load("@rules_python//python:pip.bzl", "pip_parse")
+load("@rules_ros2_python//:defs.bzl", python_interpreter_target = "interpreter")
+
+def ros2_setup_1():
+    """Macro to help bring in ros2 transitive dependendencies at the third level.
+    """
+    pip_parse(
+        name = "rules_ros2_pip_deps",
+        annotations = PIP_ANNOTATIONS,
+        python_interpreter_target = python_interpreter_target,
+        requirements_lock = "@com_github_mvukov_rules_ros2//:requirements_lock.txt",
+    )

--- a/ros2_setup_2.bzl
+++ b/ros2_setup_2.bzl
@@ -1,0 +1,18 @@
+# Copyright 2023 ReSim, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+"""Macro to help bring in ros2 transitive dependendencies at the fourth level.
+"""
+
+load(
+    "@rules_ros2_pip_deps//:requirements.bzl",
+    install_rules_ros2_pip_deps = "install_deps",
+)
+
+def ros2_setup_2():
+    """Macro to help bring in ros2 transitive dependendencies at the fourth level.
+    """
+    install_rules_ros2_pip_deps()

--- a/transitive_deps.bzl
+++ b/transitive_deps.bzl
@@ -8,6 +8,14 @@
 """
 
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+load(
+    "@com_github_mvukov_rules_ros2//repositories:deps.bzl",
+    "ros2_deps",
+)
+load(
+    "@com_github_mvukov_rules_ros2//repositories:repositories.bzl",
+    "ros2_repositories",
+)
 load("@hedron_compile_commands//:workspace_setup.bzl", "hedron_compile_commands_setup")
 load("@hedron_make_cc_https_easy//:transitive_workspace_setup.bzl", "hedron_keep_cc_https_easy")
 load("@hedron_make_cc_https_easy//:workspace_setup.bzl", "hedron_make_cc_https_easy")
@@ -44,3 +52,12 @@ def resim_core_transitive_dependencies():
 
     # Requires the com_github_nelhage_rules_boost dep
     hedron_keep_cc_https_easy()
+
+    ros2_repositories()
+
+    ros2_deps()
+
+    python_register_toolchains(
+        name = "rules_ros2_python",
+        python_version = "3.10",
+    )


### PR DESCRIPTION
## Description of change

Add mvukov/rules_ros2 as a dependency.

## Guide to reproduce test results.
```
bazel test //resim/third_party/ros2:ros2_test
```

## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [ ] This change is covered by tests that are already landed, or in this PR.
