### PR TITLE
"Devcontainer scripts allow for users renaming their base dir"

### DIFF
--- a/.devcontainer/run.sh
+++ b/.devcontainer/run.sh
@@ -4,11 +4,13 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
+DIRPATH="/workspaces/${PWD##*/}"
+
 docker run -it \
        --platform linux/amd64 \
        -p 8080:8080 \
        -p 443:443 \
-       --volume $(pwd):/workspaces/open-core \
+       --volume $(pwd):$DIRPATH \
        --volume root-home:/root \
        --volume /var/run/docker.sock:/var/run/docker.sock \
-       public.ecr.aws/resim/core:latest /bin/bash -c "cd /workspaces/open-core; $SHELL"
+       public.ecr.aws/resim/core:latest /bin/bash -c "cd $DIRPATH; $SHELL"

--- a/.devcontainer/run_dotfiles.sh
+++ b/.devcontainer/run_dotfiles.sh
@@ -4,12 +4,14 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
+DIRPATH="/workspaces/${PWD##*/}"
+
 docker run -it \
        --platform linux/amd64 \
        -p 8080:8080 \
        -p 443:443 \
-       --volume $(pwd):/workspaces/open-core \
+       --volume $(pwd):$DIRPATH \
        --volume root-home:/root \
        --volume /var/run/docker.sock:/var/run/docker.sock \
        --volume $HOME/dotfiles:/workspaces/dotfiles \
-       public.ecr.aws/resim/core:latest /bin/bash -c "cd /workspaces/dotfiles; /workspaces/dotfiles/install.sh; cd /workspaces/open-core; $SHELL"
+       public.ecr.aws/resim/core:latest /bin/bash -c "cd /workspaces/dotfiles; /workspaces/dotfiles/install.sh; cd $DIRPATH; $SHELL"

--- a/.devcontainer/run_dotfiles_local.sh
+++ b/.devcontainer/run_dotfiles_local.sh
@@ -4,12 +4,14 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
+DIRPATH="/workspaces/${PWD##*/}"
+
 docker run -it \
        --platform linux/amd64
        -p 8080:8080 \
        -p 443:443 \
-       --volume $(pwd):/workspaces/open-core \
+       --volume $(pwd):$DIRPATH \
        --volume root-home:/root \
        --volume /var/run/docker.sock:/var/run/docker.sock \
        --volume $HOME/dotfiles:/workspaces/dotfiles \
-       core-local:latest /bin/bash -c "cd /workspaces/dotfiles; /workspaces/dotfiles/install.sh; cd /workspaces/open-core; $SHELL"
+       core-local:latest /bin/bash -c "cd /workspaces/dotfiles; /workspaces/dotfiles/install.sh; cd $DIRPATH; $SHELL"

--- a/.devcontainer/run_local.sh
+++ b/.devcontainer/run_local.sh
@@ -4,11 +4,13 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
+DIRPATH="/workspaces/${PWD##*/}"
+
 docker run -it \
        --platform linux/amd64 \
        -p 8080:8080 \
        -p 443:443 \
-       --volume $(pwd):/workspaces/open-core \
+       --volume $(pwd):$DIRPATH \
        --volume root-home:/root \
        --volume /var/run/docker.sock:/var/run/docker.sock \
-       core-local:latest /bin/bash -c "cd /workspaces/open-core; $SHELL"
+       core-local:latest /bin/bash -c "cd $DIRPATH; $SHELL"


### PR DESCRIPTION
## Description of change
This PR assumes that users cloning open-core, will fairly regularly rename the directory to 
something more meaningful to them. In this case it would be nice if the change were 
reflected in the devcontainer workflow.

There is a slight fragility to this implementation in that the user could call `.devcontainer/*` 
from another directory e.g. `../devcontainer/*`, but we are already making use of `$(pwd)` 
so this at least does not make the situation worse.

## Guide to reproduce test results.
1. Rename `open-core` e.g. `mv open-core test-core`
2. Run `.devcontainer/run.sh` and verify that the working directory is `test_core`
3. Repeat for other affected scripts
## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [ ] This change is covered by tests that are already landed, or in this PR.
