### PR TITLE
Replace references to re-core in the docs with open-core

### DIFF
--- a/docs/resim/assert/index.md
+++ b/docs/resim/assert/index.md
@@ -237,5 +237,5 @@ which terminates the program.
 
 !!! Note
     Feel free to play around with the [source
-    code](https://github.com/resim-ai/re-core/blob/main/resim/examples/assert_and_status.cc)
+    code](https://github.com/resim-ai/open-core/blob/main/resim/examples/assert_and_status.cc)
     for the examples above.

--- a/docs/resim/curves/index.md
+++ b/docs/resim/curves/index.md
@@ -180,5 +180,5 @@ The resulting curve looks like this:
 
 !!! Note
     Feel free to play around with the [source
-    code](https://github.com/resim-ai/re-core/blob/main/resim/examples/curves.cc)
+    code](https://github.com/resim-ai/open-core/blob/main/resim/examples/curves.cc)
     for the examples above.

--- a/docs/resim/curves/rigid_body_state.md
+++ b/docs/resim/curves/rigid_body_state.md
@@ -142,5 +142,5 @@ Running this code shows us our unit circle trajectory which looks like this:
 
 !!! Note
     Feel free to play around with the [source
-    code](https://github.com/resim-ai/re-core/blob/main/resim/examples/trajectory.cc)
+    code](https://github.com/resim-ai/open-core/blob/main/resim/examples/trajectory.cc)
     for the example above.

--- a/docs/resim/index.md
+++ b/docs/resim/index.md
@@ -1,6 +1,6 @@
 # ReSim Open Libraries
 
-ReSim's `re-core` repository contains the open source subset of ReSim's C++
+ReSim's `open-core` repository contains the open source subset of ReSim's C++
 code intended to accelerate robotics development.
 
 ## Getting Started
@@ -17,7 +17,7 @@ These instructions vary by host platform:
 ### Get the Code
 
 ```
-git clone git@github.com:resim-ai/re-core.git
+git clone git@github.com:resim-ai/open-core.git
 ```
 
 ### Setting up the Environment
@@ -27,7 +27,7 @@ development docker image. To fetch this image, navigate to the open source repo
 and call the following script.
 
 ```bash
-cd re-core
+cd open-core
 ./.devcontainer/pull.sh
 ```
 

--- a/docs/resim/math/gaussian.md
+++ b/docs/resim/math/gaussian.md
@@ -85,5 +85,5 @@ can be used in production code.
 
 !!! Note
     Feel free to play around with the [source
-    code](https://github.com/resim-ai/re-core/blob/main/resim/examples/gaussian.cc)
+    code](https://github.com/resim-ai/open-core/blob/main/resim/examples/gaussian.cc)
     for the example above.

--- a/docs/resim/time/time.md
+++ b/docs/resim/time/time.md
@@ -173,5 +173,5 @@ REASSERT(std::fabs(integral - analytical_result) < 1e-4);
 
 !!! Note
     Feel free to play around with the [source
-    code](https://github.com/resim-ai/re-core/blob/main/resim/examples/time.cc)
+    code](https://github.com/resim-ai/open-core/blob/main/resim/examples/time.cc)
     for the examples above.

--- a/docs/resim/transforms/using_liegroups.md
+++ b/docs/resim/transforms/using_liegroups.md
@@ -430,5 +430,5 @@ about using framed objects.
 
 !!! Note
     Feel free to play around with the [source
-    code](https://github.com/resim-ai/re-core/blob/main/resim/examples/liegroups.cc)
+    code](https://github.com/resim-ai/open-core/blob/main/resim/examples/liegroups.cc)
     for the examples above.

--- a/docs/resim/utils/match.md
+++ b/docs/resim/utils/match.md
@@ -98,5 +98,5 @@ std::cout
 
 !!! Note
     Feel free to play around with the [source
-    code](https://github.com/resim-ai/re-core/blob/main/resim/examples/match.cc)
+    code](https://github.com/resim-ai/open-core/blob/main/resim/examples/match.cc)
     for the example above.

--- a/docs/resim/utils/output_parameters.md
+++ b/docs/resim/utils/output_parameters.md
@@ -135,5 +135,5 @@ clear that the function **will** output something there) or `NullableReference`
 
 !!! Note
     Feel free to play around with the [source
-    code](https://github.com/resim-ai/re-core/blob/main/resim/examples/output_parameters.cc)
+    code](https://github.com/resim-ai/open-core/blob/main/resim/examples/output_parameters.cc)
     for the examples above.

--- a/docs/resim/visualization/index.md
+++ b/docs/resim/visualization/index.md
@@ -146,5 +146,5 @@ button in Foxglove Studio when working with the time parameterized `TCurve` or
 
 !!! Note
     Feel free to play around with the [source
-    code](https://github.com/resim-ai/re-core/blob/main/resim/examples/view.cc)
+    code](https://github.com/resim-ai/open-core/blob/main/resim/examples/view.cc)
     for the examples above.


### PR DESCRIPTION
## Description of change
We renamed out repo from re-core to open-core, so we need to propagate this change to the docs.

Asana task: https://app.asana.com/0/1205228215063249/1205229151902156/f

## Guide to reproduce test results.
Search the docs for references to re-core and confirm that they are no longer there.
Search the docs for references to open-core and confirm that they are there.
## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [ ] This change is covered by tests that are already landed, or in this PR.
