### PR TITLE
Remove unused variable warnings from examples

### DIFF
--- a/resim/examples/assert_and_status.cc
+++ b/resim/examples/assert_and_status.cc
@@ -104,6 +104,7 @@ int main(int argc, char **argv) {
     REASSERT(good_status.what() == "OKAY");
 
     Status bad_status = my_outer_wrapper(Arg::BAD_ARGUMENT);
+    (void)bad_status;
     // CHECK_STATUS_OK(bad_status);
   }
 

--- a/resim/examples/liegroups.cc
+++ b/resim/examples/liegroups.cc
@@ -120,9 +120,11 @@ int main(int argc, char **argv) {
   const Vec3 robot_angular_velocity_in_scene_coordinates{
       scene_from_robot.rotation() *
       robot_angular_velocity_in_robot_coordinates};
+  (void)robot_angular_velocity_in_scene_coordinates;
 
   const Vec3 robot_velocity_in_scene_coordinates{
       scene_from_robot.rotation() * robot_velocity_in_robot_coordinates};
+  (void)robot_velocity_in_scene_coordinates;
 
   REASSERT(
       d_scene_from_robot == SE3::tangent_vector_from_parts(


### PR DESCRIPTION
## Description of change
Get rid of some pesky warnings that crop up when building the examples.

## Guide to reproduce test results.
```bash
bazel build //resim/examples/...
```
## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
