### PR TITLE
Make sure ros2 patch is properly accessible to deps

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -279,7 +279,7 @@ def resim_core_dependencies():
         http_archive,
         name = "com_github_mvukov_rules_ros2",
         patch_args = ["-p1"],
-        patches = ["//resim/third_party/ros2:flto.patch"],
+        patches = ["@resim_open_core//resim/third_party/ros2:flto.patch"],
         sha256 = "16b01677e2b2df0505504fd104ed082cc3caa9d720d994e369c46f43d94b91f5",
         strip_prefix = "rules_ros2-9b3030feb0538c5491d3f5d8d3d0d483c63938f1",
         url = "https://github.com/mvukov/rules_ros2/archive/9b3030feb0538c5491d3f5d8d3d0d483c63938f1.tar.gz",


### PR DESCRIPTION
## Description of change
Make sure that dependencies of this repo can properly access a patch needed for building ros2

## Guide to reproduce test results.

Build in a private ReSim repo which depends on `open-core`:
```
bazel build //...
```

## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
