### PR TITLE
Ignore vim temporary files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,10 @@ terraform.tfstate*
 # Emacs backup files
 *~
 
+# Vim temporary files 
+*.swp
+*.swo
+
 # Mkdocs build output
 /site/
 


### PR DESCRIPTION
## Description of change
Add .swp and .swo files to .gitignore.

## Guide to reproduce test results.
Open some files in vim and run `git status` to verify that no temporary files show up.

## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [ ] This change is covered by tests that are already landed, or in this PR.
