### PR TITLE
Add resim CLI to the public docker image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -76,7 +76,7 @@ RUN pip install pymdown-extensions
 RUN apt -y install valgrind
 
 # Install the ReSim CLI
-RUN go install github.com/resim-ai/api-client/cmd/resim@latest
+RUN go install -v github.com/resim-ai/api-client/cmd/resim@latest
 
 # Install AWS
 RUN wget -O awscliv2.zip https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -75,6 +75,9 @@ RUN pip install pymdown-extensions
 # Install Valgrind
 RUN apt -y install valgrind
 
+# Install the ReSim CLI
+RUN go install github.com/resim-ai/api-client/cmd/resim@latest
+
 # Install AWS
 RUN wget -O awscliv2.zip https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip
 RUN unzip awscliv2.zip && aws/install && rm -rf aws awscliv2.zip


### PR DESCRIPTION
## Description of change
So users of our pubic image get the CLI by default.

[Asana task](https://app.asana.com/0/1205228215063249/1205253425039961/f)

## Guide to reproduce test results.
```
.devcontainer/build.sh
.devcontainer/run_local.sh
resim
```
## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [ ] This change is covered by tests that are already landed, or in this PR.
