### PR TITLE
Add trunk to the open core devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -25,6 +25,9 @@ RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/g
 RUN apt-get update
 RUN apt-get install -y gh
 
+# Install trunk
+RUN curl https://get.trunk.io -fsSL | bash -s -- -y
+
 # configure SSH for communication with Visual Studio 
 RUN mkdir -p /var/run/sshd
 RUN echo 'PasswordAuthentication yes' >> /etc/ssh/sshd_config && \ 


### PR DESCRIPTION
## Description of change
Add trunk to the open core development container.

## Guide to reproduce test results.
Build the container locally to verify that it works.
```bash
./.devcontainer/build.sh
```
Check that trunk is installed in the resulting container.
```
./.devcontainer/run_local.sh
trunk check
```
## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [ ] This change is covered by tests that are already landed, or in this PR.
