### PR TITLE
Add tool for trimming MCAP logs to an interval

### DIFF
--- a/resim/time/BUILD
+++ b/resim/time/BUILD
@@ -10,7 +10,8 @@ cc_library(
     name = "timestamp",
     hdrs = ["timestamp.hh"],
     visibility = ["//visibility:public"],
-    deps = [],
+    deps = [
+    ],
 )
 
 cc_test(

--- a/resim/time/BUILD
+++ b/resim/time/BUILD
@@ -10,8 +10,7 @@ cc_library(
     name = "timestamp",
     hdrs = ["timestamp.hh"],
     visibility = ["//visibility:public"],
-    deps = [
-    ],
+    deps = [],
 )
 
 cc_test(

--- a/resim/time/timestamp.hh
+++ b/resim/time/timestamp.hh
@@ -26,7 +26,18 @@ constexpr double as_seconds(const Duration duration) {
   return std::chrono::duration<double>(duration).count();
 }
 
+// Convert a duration to seconds as a long double
+constexpr long double as_seconds_ld(const Duration duration) {
+  return std::chrono::duration<long double>(duration).count();
+}
+
 // Create a duration from seconds as a double
+constexpr Duration as_duration(const double t_s) {
+  return std::chrono::duration_cast<Duration>(
+      std::chrono::duration<double>(t_s));
+}
+
+// Create a duration from seconds as a long double
 constexpr Duration as_duration(const long double t_s) {
   return std::chrono::duration_cast<Duration>(
       std::chrono::duration<long double>(t_s));

--- a/resim/time/timestamp.hh
+++ b/resim/time/timestamp.hh
@@ -27,9 +27,9 @@ constexpr double as_seconds(const Duration duration) {
 }
 
 // Create a duration from seconds as a double
-constexpr Duration as_duration(const double t_s) {
+constexpr Duration as_duration(const long double t_s) {
   return std::chrono::duration_cast<Duration>(
-      std::chrono::duration<double>(t_s));
+      std::chrono::duration<long double>(t_s));
 }
 
 // A timestamp represented as integer seconds and nanoseconds. This

--- a/resim/time/timestamp_test.cc
+++ b/resim/time/timestamp_test.cc
@@ -97,9 +97,11 @@ TEST(TimestampTest, TestAsDuration) {
 
     // We can use this since it's tested above:
     const double result_s = as_seconds(test_duration);
+    const long double result_s_ld = as_seconds_ld(test_duration);
 
     // ACTION
     const Duration result = as_duration(result_s);
+    const Duration result_ld = as_duration(result_s_ld);
 
     // VERIFICATION
     // We need a tolerance here because the conversion to and from
@@ -111,6 +113,11 @@ TEST(TimestampTest, TestAsDuration) {
 
     EXPECT_LE(result, test_duration + tolerance);
     EXPECT_GE(result, test_duration - tolerance);
+
+    // These would always match exactly if we didn't divide and multiply by 1e9
+    // in the round trip to convert from seconds to nanos.
+    EXPECT_LE(result_ld.count(), test_duration.count() + 1);
+    EXPECT_GE(result_ld.count(), test_duration.count() - 1);
   }
 }
 

--- a/resim/utils/BUILD
+++ b/resim/utils/BUILD
@@ -4,7 +4,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 
 exports_files(
     [
@@ -218,5 +218,65 @@ cc_library(
     hdrs = ["http_response.hh"],
     visibility = ["//visibility:public"],
     deps = [
+    ],
+)
+
+cc_library(
+    name = "mcap_test_helpers",
+    testonly = 1,
+    srcs = ["mcap_test_helpers.cc"],
+    hdrs = ["mcap_test_helpers.hh"],
+    deps = [
+        "//resim/third_party/mcap:mcap_impl",
+    ],
+)
+
+cc_test(
+    name = "mcap_test_helpers_test",
+    srcs = ["mcap_test_helpers_test.cc"],
+    deps = [
+        ":mcap_logger",
+        ":mcap_test_helpers",
+        "//resim/third_party/mcap:mcap_impl",
+        "//resim/utils/proto/testing:message_a_proto_cc",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "snippet_mcap",
+    srcs = ["snippet_mcap.cc"],
+    hdrs = ["snippet_mcap.hh"],
+    deps = [
+        "//resim/assert",
+        "//resim/third_party/mcap:mcap_impl",
+        "//resim/time:timestamp",
+        "//resim/utils:inout",
+    ],
+)
+
+cc_test(
+    name = "snippet_mcap_test",
+    srcs = ["snippet_mcap_test.cc"],
+    deps = [
+        ":inout",
+        ":mcap_logger",
+        ":mcap_test_helpers",
+        ":snippet_mcap",
+        "//resim/third_party/mcap:mcap_impl",
+        "//resim/utils/proto/testing:message_a_proto_cc",
+        "//resim/utils/proto/testing:message_b_proto_cc",
+        "//resim/utils/proto/testing:message_c_proto_cc",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_binary(
+    name = "trim_mcap",
+    srcs = ["trim_mcap.cc"],
+    deps = [
+        ":snippet_mcap",
+        "@cxxopts",
+        "@fmt",
     ],
 )

--- a/resim/utils/mcap_test_helpers.cc
+++ b/resim/utils/mcap_test_helpers.cc
@@ -1,3 +1,8 @@
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
 
 #include "resim/utils/mcap_test_helpers.hh"
 

--- a/resim/utils/mcap_test_helpers.cc
+++ b/resim/utils/mcap_test_helpers.cc
@@ -1,0 +1,43 @@
+
+#include "resim/utils/mcap_test_helpers.hh"
+
+#include <cstring>
+#include <string>
+
+namespace resim {
+
+StreamReader::StreamReader(std::istream& stream) : stream_{stream} {
+  stream_.seekg(0, std::istream::end);
+  size_ = stream_.tellg();
+  stream_.seekg(0, std::istream::beg);
+}
+
+uint64_t StreamReader::size() const { return size_; }
+
+uint64_t
+StreamReader::read(std::byte** output, uint64_t offset, uint64_t size) {
+  if (offset >= size_) {
+    return 0;
+  }
+
+  if (offset != position_) {
+    stream_.seekg(static_cast<std::streamoff>(offset));
+    position_ = offset;
+  }
+
+  if (size > buffer_.size()) {
+    buffer_.resize(size);
+  }
+
+  // We need to use memcpy to avoid a pointer cast, which clang-tidy doesn't
+  // like:
+  std::string tmp(size, '\0');
+  stream_.read(tmp.data(), static_cast<std::streamoff>(size));
+  std::memcpy(buffer_.data(), tmp.data(), size);
+  *output = buffer_.data();
+
+  const uint64_t bytesRead = stream_.gcount();
+  position_ += bytesRead;
+  return bytesRead;
+}
+}  // namespace resim

--- a/resim/utils/mcap_test_helpers.hh
+++ b/resim/utils/mcap_test_helpers.hh
@@ -1,0 +1,25 @@
+
+#pragma once
+
+#include <istream>
+#include <mcap/reader.hpp>
+
+namespace resim {
+
+// A more generic version of mcap::FileStreamReader so we can read a log from a
+// string. This implements the basic functionality required by mcap::IReadable
+// using the stored std::istream.
+class StreamReader final : public mcap::IReadable {
+ public:
+  explicit StreamReader(std::istream& stream);
+
+  uint64_t size() const override;
+  uint64_t read(std::byte** output, uint64_t offset, uint64_t size) override;
+
+ private:
+  std::istream& stream_;
+  std::vector<std::byte> buffer_;
+  uint64_t size_{};
+  uint64_t position_{};
+};
+}  // namespace resim

--- a/resim/utils/mcap_test_helpers.hh
+++ b/resim/utils/mcap_test_helpers.hh
@@ -1,3 +1,8 @@
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
 
 #pragma once
 

--- a/resim/utils/mcap_test_helpers_test.cc
+++ b/resim/utils/mcap_test_helpers_test.cc
@@ -1,0 +1,52 @@
+
+#include "resim/utils/mcap_test_helpers.hh"
+
+#include <gtest/gtest.h>
+
+#include <mcap/reader.hpp>
+
+#include "resim/utils/mcap_logger.hh"
+#include "resim/utils/proto/testing/message_a.pb.h"
+
+namespace resim::utils {
+
+// Make a test log containing a message
+std::string make_test_log() {
+  std::ostringstream sstream;
+
+  // Separate scope so the logger gets flushed
+  {
+    McapLogger logger{sstream};
+
+    logger.add_proto_channel<proto::testing::MessageA>("channel_a");
+    logger.log_proto(
+        "channel_a",
+        time::Timestamp(),
+        proto::testing::MessageA());
+  }
+  return sstream.str();
+}
+
+TEST(TestHelpersTest, TestStreamReader) {
+  // SETUP
+  std::ostringstream sstream;
+  std::istringstream input_log{make_test_log()};
+
+  // ACTION
+  StreamReader stream_reader{input_log};
+  mcap::McapReader reader;
+  ASSERT_TRUE(reader.open(stream_reader).ok());
+  ASSERT_TRUE(reader.readSummary(mcap::ReadSummaryMethod::NoFallbackScan).ok());
+  ASSERT_EQ(reader.channels().size(), 1U);
+  EXPECT_EQ(reader.channels().cbegin()->second->topic, "channel_a");
+}
+
+// This is mainly here for coverage purproses. Primary test is that the reader
+// works with the mcap::McapReader above.
+TEST(TestHelpersTest, TestOffsetGreaterThanSize) {
+  std::stringstream sstream{""};
+  StreamReader stream_reader{sstream};
+  EXPECT_EQ(stream_reader.read(nullptr, 1, 0), 0);
+}
+
+}  // namespace resim::utils

--- a/resim/utils/mcap_test_helpers_test.cc
+++ b/resim/utils/mcap_test_helpers_test.cc
@@ -1,3 +1,8 @@
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
 
 #include "resim/utils/mcap_test_helpers.hh"
 

--- a/resim/utils/snippet_mcap.cc
+++ b/resim/utils/snippet_mcap.cc
@@ -1,3 +1,8 @@
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
 
 #include "resim/utils/snippet_mcap.hh"
 
@@ -14,6 +19,8 @@ void snippet_mcap(
     time::Timestamp end_time,
     InOut<mcap::McapReader> input_mcap,
     InOut<mcap::McapWriter> output_mcap) {
+  // Keep mappings from the old schema ids to new ones so we can adjust them
+  // appropriately
   std::unordered_map<mcap::SchemaId, mcap::SchemaId> old_to_new_schema_map_;
   std::unordered_map<mcap::ChannelId, mcap::ChannelId> old_to_new_channel_map_;
 
@@ -24,6 +31,7 @@ void snippet_mcap(
       "End time must be later than start time!");
   REASSERT(start_time_count >= 0, "Start time must be after epoch!");
 
+  // Read the messages in the interval and write them to the output log.
   for (const auto &view : input_mcap->readMessages(
            static_cast<mcap::Timestamp>(start_time_count),
            static_cast<mcap::Timestamp>(end_time_count))) {

--- a/resim/utils/snippet_mcap.cc
+++ b/resim/utils/snippet_mcap.cc
@@ -1,0 +1,49 @@
+
+#include "resim/utils/snippet_mcap.hh"
+
+#include <cstdint>
+#include <mcap/types.hpp>
+#include <unordered_map>
+
+#include "resim/assert/assert.hh"
+
+namespace resim {
+
+void snippet_mcap(
+    time::Timestamp start_time,
+    time::Timestamp end_time,
+    InOut<mcap::McapReader> input_mcap,
+    InOut<mcap::McapWriter> output_mcap) {
+  std::unordered_map<mcap::SchemaId, mcap::SchemaId> old_to_new_schema_map_;
+  std::unordered_map<mcap::ChannelId, mcap::ChannelId> old_to_new_channel_map_;
+
+  const int64_t start_time_count = start_time.time_since_epoch().count();
+  const int64_t end_time_count = end_time.time_since_epoch().count();
+  REASSERT(
+      start_time_count < end_time_count,
+      "End time must be later than start time!");
+  REASSERT(start_time_count >= 0, "Start time must be after epoch!");
+
+  for (const auto &view : input_mcap->readMessages(
+           static_cast<mcap::Timestamp>(start_time_count),
+           static_cast<mcap::Timestamp>(end_time_count))) {
+    const mcap::SchemaId old_schema_id = view.schema->id;
+    const mcap::ChannelId old_channel_id = view.channel->id;
+    if (not old_to_new_schema_map_.contains(old_schema_id)) {
+      mcap::Schema schema = *view.schema;
+      output_mcap->addSchema(schema);
+      old_to_new_schema_map_.emplace(old_schema_id, schema.id);
+    }
+    if (not old_to_new_channel_map_.contains(old_channel_id)) {
+      mcap::Channel channel = *view.channel;
+      channel.schemaId = old_to_new_schema_map_.at(old_schema_id);
+      output_mcap->addChannel(channel);
+      old_to_new_channel_map_.emplace(old_channel_id, channel.id);
+    }
+    mcap::Message message{view.message};
+    message.channelId = old_to_new_channel_map_.at(old_channel_id);
+    REASSERT(output_mcap->write(message).ok());
+  }
+}
+
+}  // namespace resim

--- a/resim/utils/snippet_mcap.hh
+++ b/resim/utils/snippet_mcap.hh
@@ -21,7 +21,8 @@ namespace resim {
 // @param[in] start_time - The start of the interval. This end is inclusive.
 // @param[in] end_time - The end of the interval. This end is exclusive.
 // @param[in] input_mcap - The input mcap to read from.
-// @param[in] output_mcap - The output mcap to write to. This should be empty to
+// @param[out] output_mcap - The output mcap to write to. This should be empty
+// to
 //                          avoid channel + schema collisions.
 void snippet_mcap(
     time::Timestamp start_time,

--- a/resim/utils/snippet_mcap.hh
+++ b/resim/utils/snippet_mcap.hh
@@ -1,0 +1,19 @@
+
+
+#pragma once
+
+#include <mcap/reader.hpp>
+#include <mcap/writer.hpp>
+
+#include "resim/time/timestamp.hh"
+#include "resim/utils/inout.hh"
+
+namespace resim {
+
+void snippet_mcap(
+    time::Timestamp start_time,
+    time::Timestamp end_time,
+    InOut<mcap::McapReader> input_mcap,
+    InOut<mcap::McapWriter> output_mcap);
+
+}

--- a/resim/utils/snippet_mcap.hh
+++ b/resim/utils/snippet_mcap.hh
@@ -1,4 +1,8 @@
-
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
 
 #pragma once
 
@@ -10,10 +14,19 @@
 
 namespace resim {
 
+// This function takes all messages (along with their channels and schemas) from
+// the interval [start_time, end_time) in the input_mcap and writes them to the
+// output_mcap. It does not copy attachements.
+// TODO(mikebauer) Support attachements.
+// @param[in] start_time - The start of the interval. This end is inclusive.
+// @param[in] end_time - The end of the interval. This end is exclusive.
+// @param[in] input_mcap - The input mcap to read from.
+// @param[in] output_mcap - The output mcap to write to. This should be empty to
+//                          avoid channel + schema collisions.
 void snippet_mcap(
     time::Timestamp start_time,
     time::Timestamp end_time,
     InOut<mcap::McapReader> input_mcap,
     InOut<mcap::McapWriter> output_mcap);
 
-}
+}  // namespace resim

--- a/resim/utils/snippet_mcap_test.cc
+++ b/resim/utils/snippet_mcap_test.cc
@@ -1,3 +1,8 @@
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
 
 #include "resim/utils/snippet_mcap.hh"
 

--- a/resim/utils/snippet_mcap_test.cc
+++ b/resim/utils/snippet_mcap_test.cc
@@ -1,0 +1,121 @@
+
+#include "resim/utils/snippet_mcap.hh"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <mcap/reader.hpp>
+#include <mcap/writer.hpp>
+#include <sstream>
+
+#include "resim/utils/inout.hh"
+#include "resim/utils/mcap_logger.hh"
+#include "resim/utils/mcap_test_helpers.hh"
+#include "resim/utils/proto/testing/message_a.pb.h"
+#include "resim/utils/proto/testing/message_b.pb.h"
+#include "resim/utils/proto/testing/message_c.pb.h"
+
+namespace resim {
+using std::literals::chrono_literals::operator""s;
+using std::literals::chrono_literals::operator""ns;
+
+constexpr time::Timestamp START_TIME;
+constexpr time::Timestamp END_TIME{10s};
+
+// Create a test log containing:
+// One message on channel_a with type MessageA before the interval
+// One message on chanenl_b_out with type MessageB before the interval
+// One message on chanenl_b_in with type MessageB before the interval
+// Two messages on chanenl_b_in with type MessageB in the interval
+// One message on chanenl_c with type MessageC in the interval
+// One message on chanenl_c with type MessageC after the interval
+std::string make_test_log() {
+  std::ostringstream sstream;
+
+  // Separate scope so the logger gets flushed
+  {
+    McapLogger logger{sstream};
+
+    logger.add_proto_channel<proto::testing::MessageA>("channel_a");
+    logger.log_proto("channel_a", START_TIME - 1s, proto::testing::MessageA());
+
+    logger.add_proto_channel<proto::testing::MessageB>("channel_b_out");
+    logger.log_proto(
+        "channel_b_out",
+        START_TIME - 1ns,
+        proto::testing::MessageB());
+
+    logger.add_proto_channel<proto::testing::MessageB>("channel_b_in");
+    logger.log_proto(
+        "channel_b_in",
+        START_TIME - 1ns,
+        proto::testing::MessageB());
+    logger.log_proto("channel_b_in", START_TIME, proto::testing::MessageB());
+    logger.log_proto(
+        "channel_b_in",
+        START_TIME + 1ns,
+        proto::testing::MessageB());
+
+    logger.add_proto_channel<proto::testing::MessageC>("channel_c");
+    logger.log_proto("channel_c", END_TIME - 1ns, proto::testing::MessageC());
+    logger.log_proto("channel_c", END_TIME, proto::testing::MessageC());
+  }
+  return sstream.str();
+}
+
+// Verify that the snippeted log contains:
+// Two messages on chanenl_b_in with type MessageB in the interval
+// One message on chanenl_c with type MessageC in the interval
+void verify_snippeted_log(const std::string &log) {
+  std::istringstream istream{log};
+  mcap::McapReader reader;
+  StreamReader streamreader{istream};
+  ASSERT_TRUE(reader.open(streamreader).ok());
+
+  int message_count = 0;
+  for (const auto &view : reader.readMessages()) {
+    (void)view;
+    ++message_count;
+  }
+  EXPECT_EQ(message_count, 3);  // Two from channel_b_in and one from channel_c
+
+  std::set<std::string> schemas;
+  std::set<std::string> channels;
+
+  for (const auto &[id, schema_ptr] : reader.schemas()) {
+    schemas.insert(schema_ptr->name);
+  }
+
+  for (const auto &[id, channel_ptr] : reader.channels()) {
+    channels.insert(channel_ptr->topic);
+  }
+  EXPECT_EQ(schemas.size(), 2U);  // MessageB and MessageC
+
+  EXPECT_EQ(channels.size(), 2U);  // channel_b_in and channel_c
+}
+
+TEST(SnippetMcapTest, TestSnippeting) {
+  // SETUP
+  // Input
+  const std::string input_log = make_test_log();
+  std::istringstream istream{input_log};
+  mcap::McapReader input_mcap;
+  StreamReader reader{istream};
+  ASSERT_TRUE(input_mcap.open(reader).ok());
+
+  // Output
+  constexpr auto PROFILE = "resim_mcap";
+  const mcap::McapWriterOptions writer_options{PROFILE};
+  std::ostringstream ostream;
+  mcap::McapWriter output_mcap;
+  output_mcap.open(ostream, writer_options);
+
+  // ACTION
+  snippet_mcap(START_TIME, END_TIME, InOut{input_mcap}, InOut{output_mcap});
+  output_mcap.close();
+
+  // VERIFICATION
+  verify_snippeted_log(ostream.str());
+}
+
+}  // namespace resim

--- a/resim/utils/trim_mcap.cc
+++ b/resim/utils/trim_mcap.cc
@@ -1,3 +1,8 @@
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
 
 #include <fmt/core.h>
 
@@ -18,7 +23,7 @@ int trim_mcap(int argc, char **argv) {
       "trim_mcap",
       "A simple program for trimming mcap logs.\n\nSaves a log to <output> "
       "containing all messages from <input> (along with channels and schemas) "
-      "which fall within the interval [start_time, end_time]. Does not yet "
+      "which fall within the interval [start_time, end_time). Does not yet "
       "support copying over attachments."};
 
   const auto default_start = std::to_string(0.0);
@@ -37,9 +42,8 @@ int trim_mcap(int argc, char **argv) {
       cxxopts::value<std::string>()->default_value(default_end))
     ("h,help", "Print usage")
   ;
-
-options.positional_help("<input> <output>").show_positional_help();
   // clang-format on
+  options.positional_help("<input> <output>").show_positional_help();
   options.parse_positional({"input", "output"});
   auto options_result = options.parse(argc, argv);
 
@@ -65,9 +69,11 @@ options.positional_help("<input> <output>").show_positional_help();
   const mcap::McapWriterOptions writer_options{
       input_mcap.header().has_value() ? input_mcap.header()->profile
                                       : "resim_mcap"};
-  REASSERT(output_mcap
-               .open(options_result["output"].as<std::string>(), writer_options)
-               .ok());
+  REASSERT(
+      output_mcap
+          .open(options_result["output"].as<std::string>(), writer_options)
+          .ok(),
+      "Failed to open output log!");
 
   snippet_mcap(start_time, end_time, InOut{input_mcap}, InOut{output_mcap});
 

--- a/resim/utils/trim_mcap.cc
+++ b/resim/utils/trim_mcap.cc
@@ -1,0 +1,79 @@
+
+#include <fmt/core.h>
+
+#include <cstdint>
+#include <cstdlib>
+#include <cxxopts.hpp>
+#include <limits>
+#include <mcap/reader.hpp>
+#include <mcap/writer.hpp>
+
+#include "resim/assert/assert.hh"
+#include "resim/utils/snippet_mcap.hh"
+
+namespace resim {
+
+int trim_mcap(int argc, char **argv) {
+  cxxopts::Options options{
+      "trim_mcap",
+      "A simple program for trimming mcap logs.\n\nSaves a log to <output> "
+      "containing all messages from <input> (along with channels and schemas) "
+      "which fall within the interval [start_time, end_time]. Does not yet "
+      "support copying over attachments."};
+
+  const auto default_start = std::to_string(0.0);
+  const auto default_end = fmt::format(
+      "{:.9f}",
+      static_cast<long double>(std::numeric_limits<int64_t>::max()) / 1e9L);
+
+  // clang-format off
+  options.add_options()
+    ("input", "Input log location", cxxopts::value<std::string>())
+    ("output", "Output log location", cxxopts::value<std::string>())
+    // cxxopts doesn't natively support floating point
+    ("start_time", "Snippet start time", 
+      cxxopts::value<std::string>()->default_value(default_start))
+    ("end_time", "Snippet end time", 
+      cxxopts::value<std::string>()->default_value(default_end))
+    ("h,help", "Print usage")
+  ;
+
+options.positional_help("<input> <output>").show_positional_help();
+  // clang-format on
+  options.parse_positional({"input", "output"});
+  auto options_result = options.parse(argc, argv);
+
+  if (options_result.count("help") > 0U or
+      options_result.count("input") == 0U or
+      options_result.count("output") == 0U) {
+    std::cout << options.help() << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  time::Timestamp start_time{time::as_duration(
+      std::stold(options_result["start_time"].as<std::string>()))};
+  time::Timestamp end_time{time::as_duration(
+      std::stold(options_result["end_time"].as<std::string>()))};
+
+  mcap::McapReader input_mcap;
+  REASSERT(
+      input_mcap.open(options_result["input"].as<std::string>()).ok(),
+      "Failed to open input log!");
+  REASSERT(
+      input_mcap.readSummary(mcap::ReadSummaryMethod::NoFallbackScan).ok());
+  mcap::McapWriter output_mcap;
+  const mcap::McapWriterOptions writer_options{
+      input_mcap.header().has_value() ? input_mcap.header()->profile
+                                      : "resim_mcap"};
+  REASSERT(output_mcap
+               .open(options_result["output"].as<std::string>(), writer_options)
+               .ok());
+
+  snippet_mcap(start_time, end_time, InOut{input_mcap}, InOut{output_mcap});
+
+  return EXIT_SUCCESS;
+}
+
+}  // namespace resim
+
+int main(int argc, char **argv) { return resim::trim_mcap(argc, argv); }


### PR DESCRIPTION
## Description of change
Add a command line tool which allows a user to trim an MCAP log to a specific time interval. In other words, this removes all messages that are before the start time and all messages which aren't before the end time.

## Guide to reproduce test results.
```bash
bazel test //resim/utils:mcap_test_helpers_test
bazel test //resim/utils:snippet_mcap_test
bazel run //resim/utils:trim_mcap -- --help
bazel run //resim/utils:trim_mcap -- \
    path/to/in.mcap \
    path/to/out.mcap \
    --start_time 1687370440.709534246 \
    --end_time 1687370450.709534246
```
## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
