### PR TITLE
Call a function on each element of a tuple

### DIFF
--- a/resim/utils/BUILD
+++ b/resim/utils/BUILD
@@ -220,3 +220,20 @@ cc_library(
     deps = [
     ],
 )
+
+cc_library(
+    name = "tuple_utils",
+    hdrs = ["tuple_utils.hh"],
+    visibility = ["//visibility:public"],
+    deps = [
+    ],
+)
+
+cc_test(
+    name = "tuple_utils_test",
+    srcs = ["tuple_utils_test.cc"],
+    deps = [
+        ":tuple_utils",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/resim/utils/tuple_utils.hh
+++ b/resim/utils/tuple_utils.hh
@@ -33,7 +33,7 @@ namespace resim {
 // typically be a concern as tuples containing references are not incredibly
 // common.
 template <typename Callable, typename Tuple>
-auto for_each_in_tuple(const Callable &f, Tuple &&t) {
+constexpr auto for_each_in_tuple(const Callable &f, Tuple &&t) {
   return std::apply(
       [&f](auto &&...elements) {
         // clang-format off

--- a/resim/utils/tuple_utils.hh
+++ b/resim/utils/tuple_utils.hh
@@ -1,0 +1,46 @@
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#pragma once
+
+#include <tuple>
+
+namespace resim {
+
+// This function executes a given Callable object on each element of the given
+// tuple, storing the results of each invocation in a tuple of the same length
+// as the input tuple. The Callable must return something for each input type
+// from the tuple. Take great care when using this function on tuples containing
+// references as the rules are complex. The short version is that the cv
+// qualifiers and references associated with the tuple type are collapsed with
+// those of each element when passed into the callable. For example:
+//
+// A tuple of type const tuple<T, T &, const T &, T &&, const T &&> will result
+// in the following calls to f:
+//
+// f(const T &),
+// f(T &),
+// f(const T &),
+// f(T &),
+// f(const T &),
+//
+// Note that the const from the tuple has no effect on references while it does
+// propgate to values. Further note the & & -> & and & && -> & collapsing rules
+// at play. For other examples, refer to tuple_utils_test.cc. This shouldn't
+// typically be a concern as tuples containing references are not incredibly
+// common.
+template <typename Callable, typename Tuple>
+auto for_each_in_tuple(const Callable &f, Tuple &&t) {
+  return std::apply(
+      [&f](auto &&...elements) {
+        using ResultType = std::tuple<decltype(f(
+            std::forward<decltype(elements)>(elements)))...>;
+        return ResultType(f(std::forward<decltype(elements)>(elements))...);
+      },
+      std::forward<Tuple>(t));
+}
+
+}  // namespace resim

--- a/resim/utils/tuple_utils.hh
+++ b/resim/utils/tuple_utils.hh
@@ -28,7 +28,7 @@ namespace resim {
 // f(const T &),
 //
 // Note that the const from the tuple has no effect on references while it does
-// propgate to values. Further note the & & -> & and & && -> & collapsing rules
+// propagate to values. Further note the & & -> & and & && -> & collapsing rules
 // at play. For other examples, refer to tuple_utils_test.cc. This shouldn't
 // typically be a concern as tuples containing references are not incredibly
 // common.
@@ -36,9 +36,18 @@ template <typename Callable, typename Tuple>
 auto for_each_in_tuple(const Callable &f, Tuple &&t) {
   return std::apply(
       [&f](auto &&...elements) {
-        using ResultType = std::tuple<decltype(f(
-            std::forward<decltype(elements)>(elements)))...>;
-        return ResultType(f(std::forward<decltype(elements)>(elements))...);
+        // clang-format off
+        using ResultType = 
+            std::tuple<
+              decltype(f(
+                std::forward<decltype(elements)>(elements)
+              ))...>;
+
+        return ResultType(
+            f(
+              std::forward<decltype(elements)>(elements)
+            )...);
+        // clang-format on
       },
       std::forward<Tuple>(t));
 }

--- a/resim/utils/tuple_utils_test.cc
+++ b/resim/utils/tuple_utils_test.cc
@@ -1,3 +1,8 @@
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
 
 #include "resim/utils/tuple_utils.hh"
 
@@ -41,8 +46,8 @@ TEST(TupleUtilsTest, TestForEachInTupleReferences) {
   const TestTupleType test_tuple_const{a, b, c, 4, 5};
   const TestTupleType test_tuple_const_to_move{a, b, c, 4, 5};
   // NOLINTEND(readability-magic-numbers)
-  //
-  const auto identity = [](auto &&x) -> decltype(x) {
+
+  const auto identity = [](auto &&x) -> decltype(auto) {
     return std::forward<decltype(x)>(x);
   };
 
@@ -62,13 +67,13 @@ TEST(TupleUtilsTest, TestForEachInTupleReferences) {
 
   // Testing reference collapsing rules. The references from the input tuple are
   // added to the references of the entry. Since result was made from an lvalue
-  // bound by lvalue reference, all rvalues become lvalues.
+  // bound by lvalue reference, all rvalue refs become lvalue refs.
   static_assert(std::is_same_v<
                 decltype(result),
                 std::tuple<int &, int &, const int &, int &, const int &>>);
 
   // Since result was made from an rvalue bound by rvalue refernece, all lvalues
-  // stay lvalues and all rvalues stay rvalues.
+  // stay lvalues and all rvalue refs stay rvalue refs.
   static_assert(std::is_same_v<
                 decltype(result_moved),
                 std::tuple<int &&, int &, const int &, int &&, const int &&>>);

--- a/resim/utils/tuple_utils_test.cc
+++ b/resim/utils/tuple_utils_test.cc
@@ -25,6 +25,9 @@ TEST(TupleUtilsTest, TestForEachInTuple) {
       std::tuple_size_v<decltype(simple_tuple)> ==
       std::tuple_size_v<decltype(result)>);
 
+  static_assert(
+      std::is_same_v<decltype(result), std::tuple<int, double, unsigned>>);
+
   EXPECT_EQ(std::get<0>(simple_tuple) + 1, std::get<0>(result));
   EXPECT_EQ(std::get<1>(simple_tuple) + 1, std::get<1>(result));
   EXPECT_EQ(std::get<2>(simple_tuple) + 1, std::get<2>(result));
@@ -72,7 +75,7 @@ TEST(TupleUtilsTest, TestForEachInTupleReferences) {
                 decltype(result),
                 std::tuple<int &, int &, const int &, int &, const int &>>);
 
-  // Since result was made from an rvalue bound by rvalue refernece, all lvalues
+  // Since result was made from an rvalue bound by rvalue reference, all lvalues
   // stay lvalues and all rvalue refs stay rvalue refs.
   static_assert(std::is_same_v<
                 decltype(result_moved),

--- a/resim/utils/tuple_utils_test.cc
+++ b/resim/utils/tuple_utils_test.cc
@@ -62,7 +62,7 @@ TEST(TupleUtilsTest, TestForEachInTupleReferences) {
 
   // Testing reference collapsing rules. The references from the input tuple are
   // added to the references of the entry. Since result was made from an lvalue
-  // bound by lvalue refernece, all rvalues become rvalues.
+  // bound by lvalue reference, all rvalues become lvalues.
   static_assert(std::is_same_v<
                 decltype(result),
                 std::tuple<int &, int &, const int &, int &, const int &>>);

--- a/resim/utils/tuple_utils_test.cc
+++ b/resim/utils/tuple_utils_test.cc
@@ -1,0 +1,126 @@
+
+#include "resim/utils/tuple_utils.hh"
+
+#include <gtest/gtest.h>
+
+namespace resim {
+
+TEST(TupleUtilsTest, TestForEachInTuple) {
+  // SETUP
+  // NOLINTBEGIN(readability-magic-numbers)
+  auto simple_tuple = std::make_tuple(1, 2., 3U);
+  // NOLINTEND(readability-magic-numbers)
+  const auto add_one = [](auto number) { return number + 1; };
+
+  // ACTION
+  auto result = for_each_in_tuple(add_one, simple_tuple);
+
+  // VERIFICATION
+  static_assert(
+      std::tuple_size_v<decltype(simple_tuple)> ==
+      std::tuple_size_v<decltype(result)>);
+
+  EXPECT_EQ(std::get<0>(simple_tuple) + 1, std::get<0>(result));
+  EXPECT_EQ(std::get<1>(simple_tuple) + 1, std::get<1>(result));
+  EXPECT_EQ(std::get<2>(simple_tuple) + 1, std::get<2>(result));
+}
+
+TEST(TupleUtilsTest, TestForEachInTupleReferences) {
+  // SETUP
+  int a = 1;
+  int b = 2;
+  int c = 3;
+
+  // We can't copy tuples containing rvalue references, so we have to manually
+  // re-construct.
+  using TestTupleType =
+      std::tuple<int, int &, const int &, int &&, const int &&>;
+  // NOLINTBEGIN(readability-magic-numbers)
+  TestTupleType test_tuple{a, b, c, 4, 5};
+  TestTupleType test_tuple_to_move{a, b, c, 4, 5};
+  const TestTupleType test_tuple_const{a, b, c, 4, 5};
+  const TestTupleType test_tuple_const_to_move{a, b, c, 4, 5};
+  // NOLINTEND(readability-magic-numbers)
+  //
+  const auto identity = [](auto &&x) -> decltype(x) {
+    return std::forward<decltype(x)>(x);
+  };
+
+  // ACTION
+  auto result = for_each_in_tuple(identity, test_tuple);
+  auto result_moved =
+      for_each_in_tuple(identity, std::move(test_tuple_to_move));
+  auto result_from_const = for_each_in_tuple(identity, test_tuple_const);
+
+  // This one is a bit weird and you wouldn't really ever do this, but we'll
+  // test it anyway.
+  auto result_moved_from_const = for_each_in_tuple(
+      identity,
+      static_cast<const TestTupleType &&>(test_tuple_const_to_move));
+
+  // VERIFICATION
+
+  // Testing reference collapsing rules. The references from the input tuple are
+  // added to the references of the entry. Since result was made from an lvalue
+  // bound by lvalue refernece, all rvalues become rvalues.
+  static_assert(std::is_same_v<
+                decltype(result),
+                std::tuple<int &, int &, const int &, int &, const int &>>);
+
+  // Since result was made from an rvalue bound by rvalue refernece, all lvalues
+  // stay lvalues and all rvalues stay rvalues.
+  static_assert(std::is_same_v<
+                decltype(result_moved),
+                std::tuple<int &&, int &, const int &, int &&, const int &&>>);
+
+  // Here, we need to be aware of how const interacts with reference collapsing.
+  // The suprising cases are that you can't add const to references,
+  // but you can to normal types. Therefore, collapsing const & from the tuple
+  // with int & or int && leaves these types non-const while mapping int to
+  // const int &.
+  static_assert(
+      std::is_same_v<
+          decltype(result_from_const),
+          std::tuple<const int &, int &, const int &, int &, const int &>>);
+
+  static_assert(
+      std::is_same_v<
+          decltype(result_moved_from_const),
+          std::tuple<const int &&, int &, const int &, int &&, const int &&>>);
+
+  EXPECT_EQ(&std::get<0>(test_tuple), &std::get<0>(result));
+  EXPECT_EQ(&std::get<1>(test_tuple), &std::get<1>(result));
+  EXPECT_EQ(&std::get<2>(test_tuple), &std::get<2>(result));
+  EXPECT_EQ(&std::get<3>(test_tuple), &std::get<3>(result));
+  EXPECT_EQ(&std::get<4>(test_tuple), &std::get<4>(result));
+
+  EXPECT_EQ(&std::get<0>(test_tuple_to_move), &std::get<0>(result_moved));
+  EXPECT_EQ(&std::get<1>(test_tuple_to_move), &std::get<1>(result_moved));
+  EXPECT_EQ(&std::get<2>(test_tuple_to_move), &std::get<2>(result_moved));
+  EXPECT_EQ(&std::get<3>(test_tuple_to_move), &std::get<3>(result_moved));
+  EXPECT_EQ(&std::get<4>(test_tuple_to_move), &std::get<4>(result_moved));
+
+  EXPECT_EQ(&std::get<0>(test_tuple_const), &std::get<0>(result_from_const));
+  EXPECT_EQ(&std::get<1>(test_tuple_const), &std::get<1>(result_from_const));
+  EXPECT_EQ(&std::get<2>(test_tuple_const), &std::get<2>(result_from_const));
+  EXPECT_EQ(&std::get<3>(test_tuple_const), &std::get<3>(result_from_const));
+  EXPECT_EQ(&std::get<4>(test_tuple_const), &std::get<4>(result_from_const));
+
+  EXPECT_EQ(
+      &std::get<0>(test_tuple_const_to_move),
+      &std::get<0>(result_moved_from_const));
+  EXPECT_EQ(
+      &std::get<1>(test_tuple_const_to_move),
+      &std::get<1>(result_moved_from_const));
+  EXPECT_EQ(
+      &std::get<2>(test_tuple_const_to_move),
+      &std::get<2>(result_moved_from_const));
+  EXPECT_EQ(
+      &std::get<3>(test_tuple_const_to_move),
+      &std::get<3>(result_moved_from_const));
+  EXPECT_EQ(
+      &std::get<4>(test_tuple_const_to_move),
+      &std::get<4>(result_moved_from_const));
+}
+
+};  // namespace resim


### PR DESCRIPTION
## Description of change
Add a `for_each_in_tuple()` function which calls a given callable function or object on each element of a given tuple.

## Guide to reproduce test results.
```bash
bazel test //resim/utils:tuple_utils_test
```

## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
