### PR TITLE
Add Transform Messages and ROS2 Converters

### DIFF
--- a/resim/msg/BUILD
+++ b/resim/msg/BUILD
@@ -7,6 +7,10 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_proto_library", "cc_test")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 
+################################################################################
+# Protos
+################################################################################
+
 proto_library(
     name = "header_proto",
     srcs = ["header.proto"],
@@ -21,6 +25,26 @@ cc_proto_library(
         ":header_proto",
     ],
 )
+
+proto_library(
+    name = "transform_proto",
+    srcs = ["transform.proto"],
+    deps = [
+        ":header_proto",
+        "//resim/transforms/proto:se3_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "transform_proto_cc",
+    deps = [
+        ":transform_proto",
+    ],
+)
+
+################################################################################
+# Converters
+################################################################################
 
 cc_library(
     name = "header_from_ros2",
@@ -62,5 +86,17 @@ cc_test(
         ":time_from_ros2",
         "@com_google_googletest//:gtest_main",
         "@ros2_rcl_interfaces//:cpp_builtin_interfaces",
+    ],
+)
+
+cc_library(
+    name = "transform_from_ros2",
+    srcs = ["transform_from_ros2.cc"],
+    hdrs = ["transform_from_ros2.hh"],
+    deps = [
+        ":transform_proto_cc",
+        "//resim/transforms/proto:se3_to_proto",
+        "@ros2_common_interfaces//:cpp_geometry_msgs",
+        "@ros2_geometry2//:cpp_tf2_msgs",
     ],
 )

--- a/resim/msg/BUILD
+++ b/resim/msg/BUILD
@@ -94,8 +94,13 @@ cc_library(
     srcs = ["transform_from_ros2.cc"],
     hdrs = ["transform_from_ros2.hh"],
     deps = [
+        ":header_from_ros2",
         ":transform_proto_cc",
+        "//resim/transforms:se3",
+        "//resim/transforms:so3",
+        "//resim/transforms/proto:se3_proto_cc",
         "//resim/transforms/proto:se3_to_proto",
+        "@libeigen//:eigen",
         "@ros2_common_interfaces//:cpp_geometry_msgs",
         "@ros2_geometry2//:cpp_tf2_msgs",
     ],

--- a/resim/msg/BUILD
+++ b/resim/msg/BUILD
@@ -3,7 +3,6 @@
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
-
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_proto_library", "cc_test")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 
@@ -103,5 +102,42 @@ cc_library(
         "@libeigen//:eigen",
         "@ros2_common_interfaces//:cpp_geometry_msgs",
         "@ros2_geometry2//:cpp_tf2_msgs",
+    ],
+)
+
+cc_test(
+    name = "transform_from_ros2_test",
+    srcs = ["transform_from_ros2_test.cc"],
+    deps = [
+        ":fuzz_helpers",
+        ":transform_from_ros2",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "fuzz_helpers",
+    testonly = True,
+    srcs = ["fuzz_helpers.cc"],
+    hdrs = ["fuzz_helpers.hh"],
+    deps = [
+        ":header_proto_cc",
+        ":transform_proto_cc",
+        "//resim/testing:fuzz_helpers",
+        "//resim/testing:random_matrix",
+        "//resim/transforms/proto:se3_to_proto",
+        "//resim/utils:uuid",
+    ],
+)
+
+cc_test(
+    name = "fuzz_helpers_test",
+    testonly = True,
+    srcs = ["fuzz_helpers_test.cc"],
+    deps = [
+        ":fuzz_helpers",
+        ":header_proto_cc",
+        ":transform_proto_cc",
+        "@com_google_googletest//:gtest_main",
     ],
 )

--- a/resim/msg/fuzz_helpers.cc
+++ b/resim/msg/fuzz_helpers.cc
@@ -1,0 +1,30 @@
+
+#include "resim/msg/fuzz_helpers.hh"
+
+namespace resim::msg {
+
+bool verify_equality(const Header &a, const Header &b) {
+  return a.stamp().seconds() == b.stamp().seconds() &&
+         a.stamp().nanos() == b.stamp().nanos() && a.frame_id() == b.frame_id();
+}
+
+bool verify_equality(const TransformStamped &a, const TransformStamped &b) {
+  const bool transforms_equal =
+      unpack(a.transform()).is_approx(unpack(b.transform()));
+  return transforms_equal && verify_equality(a.header(), b.header()) &&
+         a.child_frame_id() == b.child_frame_id();
+}
+
+bool verify_equality(const TransformArray &a, const TransformArray &b) {
+  if (a.transforms_size() != b.transforms_size()) {
+    return false;
+  }
+  for (int ii = 0; ii < a.transforms_size(); ++ii) {
+    if (not verify_equality(a.transforms(ii), b.transforms(ii))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+}  // namespace resim::msg

--- a/resim/msg/fuzz_helpers.hh
+++ b/resim/msg/fuzz_helpers.hh
@@ -1,0 +1,66 @@
+
+
+#pragma once
+
+#include <cstdint>
+#include <random>
+
+#include "resim/msg/header.pb.h"
+#include "resim/msg/transform.pb.h"
+#include "resim/testing/fuzz_helpers.hh"
+#include "resim/testing/random_matrix.hh"
+#include "resim/transforms/proto/se3_to_proto.hh"
+#include "resim/utils/uuid.hh"
+
+namespace resim::msg {
+
+template <typename Rng>
+Header random_element(TypeTag<Header> /*unused*/, InOut<Rng> rng) {
+  Header result;
+
+  // Need to use int32 since that's all ROS supports
+  result.mutable_stamp()->set_seconds(random_element(TypeTag<int32_t>(), rng));
+  constexpr int32_t NANOS_LB = 0;
+  constexpr int32_t NANOS_UB = 1000000000;
+  std::uniform_int_distribution<int32_t> dist{NANOS_LB, NANOS_UB};
+  result.mutable_stamp()->set_nanos(dist(*rng));
+  result.set_frame_id(UUID::new_uuid().to_string());
+  return result;
+}
+
+template <typename Rng>
+TransformStamped random_element(
+    TypeTag<TransformStamped> /*unused*/,
+    InOut<Rng> rng) {
+  TransformStamped result;
+
+  result.mutable_header()->CopyFrom(random_element<Header>(rng));
+  result.set_child_frame_id(UUID::new_uuid().to_string());
+  const transforms::SE3 transform{transforms::SE3::exp(
+      testing::random_vector<transforms::SE3::TangentVector>(*rng))};
+  pack(transform, result.mutable_transform());
+  return result;
+}
+
+template <typename Rng>
+TransformArray random_element(
+    TypeTag<TransformArray> /*unused*/,
+    InOut<Rng> rng) {
+  TransformArray result;
+  constexpr int MIN_ELEMENTS = 1;
+  constexpr int MAX_ELEMENTS = 10;
+  std::uniform_int_distribution<int> dist{MIN_ELEMENTS, MAX_ELEMENTS};
+  const int num_elements = dist(*rng);
+  for (int ii = 0; ii < num_elements; ++ii) {
+    result.add_transforms()->CopyFrom(random_element<TransformStamped>(rng));
+  }
+  return result;
+}
+
+bool verify_equality(const Header &a, const Header &b);
+
+bool verify_equality(const TransformStamped &a, const TransformStamped &b);
+
+bool verify_equality(const TransformArray &a, const TransformArray &b);
+
+}  // namespace resim::msg

--- a/resim/msg/fuzz_helpers_test.cc
+++ b/resim/msg/fuzz_helpers_test.cc
@@ -1,0 +1,97 @@
+
+#include "resim/msg/fuzz_helpers.hh"
+
+#include <gtest/gtest.h>
+
+#include <random>
+
+#include "resim/msg/header.pb.h"
+#include "resim/msg/transform.pb.h"
+
+namespace resim::msg {
+
+TEST(FuzzHelpersTest, TestHeaderEqual) {
+  // SETUP
+  constexpr std::size_t SEED = 913U;
+  std::mt19937 rng{SEED};
+
+  const Header header{random_element<Header>(InOut{rng})};
+  Header header_different_secs{header};
+  header_different_secs.mutable_stamp()->set_seconds(
+      header.stamp().seconds() + 1);
+  Header header_different_nanos{header};
+  header_different_nanos.mutable_stamp()->set_nanos(header.stamp().nanos() + 1);
+  Header header_different_frame{header};
+  header_different_frame.set_frame_id(header.frame_id() + "_different");
+
+  // ACTION / VERIFICATION
+  EXPECT_TRUE(verify_equality(header, header));
+  EXPECT_FALSE(verify_equality(header, header_different_secs));
+  EXPECT_FALSE(verify_equality(header, header_different_nanos));
+  EXPECT_FALSE(verify_equality(header, header_different_frame));
+  EXPECT_FALSE(verify_equality(header_different_secs, header));
+  EXPECT_FALSE(verify_equality(header_different_nanos, header));
+  EXPECT_FALSE(verify_equality(header_different_frame, header));
+}
+
+TEST(FuzzHelpersTest, TestTransformStampedEqual) {
+  // SETUP
+  constexpr std::size_t SEED = 913U;
+  std::mt19937 rng{SEED};
+
+  const TransformStamped transform{
+      random_element<TransformStamped>(InOut{rng})};
+
+  TransformStamped transform_different_header{transform};
+  transform_different_header.mutable_header()->CopyFrom(
+      random_element<Header>(InOut{rng}));
+
+  TransformStamped transform_different_child{transform};
+  transform_different_child.set_child_frame_id(
+      transform.child_frame_id() + "_different");
+
+  TransformStamped transform_different_transform{transform};
+  transform_different_transform.mutable_transform()->CopyFrom(
+      random_element<TransformStamped>(InOut{rng}).transform());
+
+  // ACTION / VERIFICATION
+  EXPECT_TRUE(verify_equality(transform, transform));
+  EXPECT_FALSE(verify_equality(transform, transform_different_header));
+  EXPECT_FALSE(verify_equality(transform, transform_different_child));
+  EXPECT_FALSE(verify_equality(transform, transform_different_transform));
+  EXPECT_FALSE(verify_equality(transform_different_header, transform));
+  EXPECT_FALSE(verify_equality(transform_different_child, transform));
+  EXPECT_FALSE(verify_equality(transform_different_transform, transform));
+}
+
+TEST(FuzzHelpersTest, TestTransformArrayEqual) {
+  // SETUP
+  constexpr std::size_t SEED = 913U;
+  std::mt19937 rng{SEED};
+
+  const TransformArray transform_array{
+      random_element<TransformArray>(InOut{rng})};
+
+  TransformArray transform_array_different_size{transform_array};
+  ASSERT_GT(transform_array_different_size.transforms_size(), 0U);
+  transform_array_different_size.mutable_transforms()->erase(
+      transform_array_different_size.transforms().begin());
+
+  TransformArray transform_array_different_element{transform_array};
+  ASSERT_GT(transform_array_different_element.transforms_size(), 0U);
+  transform_array_different_element.mutable_transforms(0)->CopyFrom(
+      random_element<TransformStamped>(InOut{rng}));
+
+  // ACTION / VERIFICATION
+  EXPECT_TRUE(verify_equality(transform_array, transform_array));
+  EXPECT_FALSE(
+      verify_equality(transform_array, transform_array_different_size));
+  EXPECT_FALSE(
+      verify_equality(transform_array, transform_array_different_element));
+  EXPECT_FALSE(
+      verify_equality(transform_array_different_size, transform_array));
+  EXPECT_FALSE(
+      verify_equality(transform_array_different_element, transform_array));
+}
+
+}  // namespace resim::msg

--- a/resim/msg/transform.proto
+++ b/resim/msg/transform.proto
@@ -1,0 +1,22 @@
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+syntax = "proto3";
+
+import "resim/msg/header.proto";
+import "resim/transforms/proto/se3.proto";
+
+package resim.msg;
+
+message TransformStamped {
+    Header                     header         = 1;
+    string                     child_frame_id = 2;
+    resim.transforms.proto.SE3 transform      = 3;
+}
+
+message TransformArray {
+    repeated TransformStamped transforms = 1;
+}

--- a/resim/msg/transform_from_ros2.cc
+++ b/resim/msg/transform_from_ros2.cc
@@ -1,0 +1,39 @@
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include "resim/msg/transform_from_ros2.hh"
+
+namespace resim::msg {
+
+transforms::proto::SE3 convert_from_ros2(
+    const geometry_msgs::msg::Transform &ros2_msg) {
+  return transforms::proto::SE3();
+}
+
+geometry_msgs::msg::Transform convert_to_ros2(
+    const transforms::proto::SE3 &resim_msg) {
+  return geometry_msgs::msg::Transform();
+}
+
+TransformStamped convert_from_ros2(
+    const geometry_msgs::msg::TransformStamped &ros2_msg) {
+  return TransformStamped();
+}
+
+geometry_msgs::msg::TransformStamped convert_to_ros2(
+    const TransformStamped &resim_msg) {
+  return geometry_msgs::msg::TransformStamped();
+}
+
+TransformArray convert_from_ros2(const tf2_msgs::msg::TFMessage &ros2_msg) {
+  return TransformArray();
+}
+
+tf2_msgs::msg::TFMessage convert_to_ros2(const TransformArray &resim_msg) {
+  return tf2_msgs::msg::TFMessage();
+}
+
+}  // namespace resim::msg

--- a/resim/msg/transform_from_ros2.cc
+++ b/resim/msg/transform_from_ros2.cc
@@ -6,34 +6,89 @@
 
 #include "resim/msg/transform_from_ros2.hh"
 
+#include <Eigen/Dense>
+
+#include "resim/msg/header_from_ros2.hh"
+#include "resim/transforms/proto/se3_to_proto.hh"
+#include "resim/transforms/se3.hh"
+#include "resim/transforms/so3.hh"
+
 namespace resim::msg {
 
 transforms::proto::SE3 convert_from_ros2(
     const geometry_msgs::msg::Transform &ros2_msg) {
-  return transforms::proto::SE3();
+  const transforms::SO3 rotation{Eigen::Quaterniond{
+      ros2_msg.rotation.w,
+      ros2_msg.rotation.x,
+      ros2_msg.rotation.y,
+      ros2_msg.rotation.z,
+  }};
+
+  const transforms::SE3 transform{
+      rotation,
+      Eigen::Vector3d{
+          ros2_msg.translation.x,
+          ros2_msg.translation.y,
+          ros2_msg.translation.z,
+      }};
+
+  transforms::proto::SE3 result;
+  pack(transform, &result);
+  return result;
 }
 
 geometry_msgs::msg::Transform convert_to_ros2(
     const transforms::proto::SE3 &resim_msg) {
-  return geometry_msgs::msg::Transform();
+  const transforms::SE3 pose{unpack(resim_msg)};
+  geometry_msgs::msg::Transform result;
+
+  result.translation.x = pose.translation().x();
+  result.translation.y = pose.translation().y();
+  result.translation.z = pose.translation().z();
+
+  const Eigen::Quaterniond rotation_quaternion = pose.rotation().quaternion();
+
+  result.rotation.w = rotation_quaternion.w();
+  result.rotation.x = rotation_quaternion.x();
+  result.rotation.y = rotation_quaternion.y();
+  result.rotation.z = rotation_quaternion.z();
+
+  return result;
 }
 
 TransformStamped convert_from_ros2(
     const geometry_msgs::msg::TransformStamped &ros2_msg) {
-  return TransformStamped();
+  TransformStamped result;
+  result.mutable_header()->CopyFrom(convert_from_ros2(ros2_msg.header));
+  result.set_child_frame_id(ros2_msg.child_frame_id);
+  result.mutable_transform()->CopyFrom(convert_from_ros2(ros2_msg.transform));
+  return result;
 }
 
 geometry_msgs::msg::TransformStamped convert_to_ros2(
     const TransformStamped &resim_msg) {
-  return geometry_msgs::msg::TransformStamped();
+  geometry_msgs::msg::TransformStamped result;
+  result.header = convert_to_ros2(resim_msg.header());
+  result.child_frame_id = resim_msg.child_frame_id();
+  result.transform = convert_to_ros2(resim_msg.transform());
+  return result;
 }
 
 TransformArray convert_from_ros2(const tf2_msgs::msg::TFMessage &ros2_msg) {
-  return TransformArray();
+  TransformArray result;
+  for (const auto &transform : ros2_msg.transforms) {
+    result.add_transforms()->CopyFrom(convert_from_ros2(transform));
+  }
+  return result;
 }
 
 tf2_msgs::msg::TFMessage convert_to_ros2(const TransformArray &resim_msg) {
-  return tf2_msgs::msg::TFMessage();
+  tf2_msgs::msg::TFMessage result;
+  result.transforms.reserve(resim_msg.transforms_size());
+  for (const auto &transform : resim_msg.transforms()) {
+    result.transforms.push_back(convert_to_ros2(transform));
+  }
+  return result;
 }
 
 }  // namespace resim::msg

--- a/resim/msg/transform_from_ros2.hh
+++ b/resim/msg/transform_from_ros2.hh
@@ -1,0 +1,34 @@
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#pragma once
+
+#include <geometry_msgs/msg/transform.hpp>
+#include <tf2_msgs/msg/tf_message.hpp>
+
+#include "resim/msg/transform.pb.h"
+
+namespace resim::msg {
+
+// ROS2 converters for transforms
+
+transforms::proto::SE3 convert_from_ros2(
+    const geometry_msgs::msg::Transform &ros2_msg);
+
+geometry_msgs::msg::Transform convert_to_ros2(
+    const transforms::proto::SE3 &resim_msg);
+
+TransformStamped convert_from_ros2(
+    const geometry_msgs::msg::TransformStamped &ros2_msg);
+
+geometry_msgs::msg::TransformStamped convert_to_ros2(
+    const TransformStamped &resim_msg);
+
+TransformArray convert_from_ros2(const tf2_msgs::msg::TFMessage &ros2_msg);
+
+tf2_msgs::msg::TFMessage convert_to_ros2(const TransformArray &resim_msg);
+
+}  // namespace resim::msg

--- a/resim/msg/transform_from_ros2.hh
+++ b/resim/msg/transform_from_ros2.hh
@@ -10,6 +10,7 @@
 #include <tf2_msgs/msg/tf_message.hpp>
 
 #include "resim/msg/transform.pb.h"
+#include "resim/transforms/proto/se3.pb.h"
 
 namespace resim::msg {
 

--- a/resim/msg/transform_from_ros2_test.cc
+++ b/resim/msg/transform_from_ros2_test.cc
@@ -1,0 +1,26 @@
+
+#include "resim/msg/transform_from_ros2.hh"
+
+#include <gtest/gtest.h>
+
+#include "resim/msg/fuzz_helpers.hh"
+#include "resim/msg/transform.pb.h"
+#include "resim/testing/fuzz_helpers.hh"
+#include "resim/utils/inout.hh"
+
+namespace resim::msg {
+
+TEST(TransformFromRos2Test, TestRoundTrip) {
+  // SETUP
+  constexpr std::size_t SEED = 913U;
+  std::mt19937 rng{SEED};
+  const TransformArray test_array{random_element<TransformArray>(InOut{rng})};
+  // ACTION
+  const TransformArray round_tripped{
+      convert_from_ros2(convert_to_ros2(test_array))};
+
+  // VERIFICATION
+  EXPECT_TRUE(verify_equality(test_array, round_tripped));
+}
+
+}  // namespace resim::msg

--- a/resim/testing/BUILD
+++ b/resim/testing/BUILD
@@ -79,3 +79,13 @@ cc_library(
         "@httplib",
     ],
 )
+
+cc_library(
+    name = "fuzz_helpers",
+    testonly = True,
+    hdrs = ["fuzz_helpers.hh"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//resim/utils:inout",
+    ],
+)

--- a/resim/testing/fuzz_helpers.hh
+++ b/resim/testing/fuzz_helpers.hh
@@ -1,0 +1,39 @@
+
+#pragma once
+
+#include <concepts>
+#include <random>
+
+#include "resim/utils/inout.hh"
+
+namespace resim {
+
+// A type tag that allows us to find helpers via argument-dependent lookup
+// (ADL). Note that we aren't using resim::Type since that template explicitly
+// disables ADL. The utility of using ADL here is that it becomes possible to
+// write generic helpers (i.e. ones that work on vectors of any type T. For this
+// to work, the helpers always need to be defined in the same namspace as T *or*
+// in the same namespace as this tag.
+template <typename T>
+struct TypeTag {};
+
+template <typename T, typename Rng>
+T random_element(TypeTag<T>, InOut<Rng> rng);
+
+template <typename T, typename Rng>
+T random_element(InOut<Rng> rng) {
+  return random_element(TypeTag<T>(), rng);
+}
+
+template <typename T>
+bool verify_equality(const T &a, const T &b);
+
+template <std::integral Int, typename Rng>
+Int random_element(TypeTag<Int> /*unused*/, InOut<Rng> rng) {
+  std::uniform_int_distribution<Int> dist{
+      std::numeric_limits<Int>::min(),
+      std::numeric_limits<Int>::max()};
+  return dist(*rng);
+}
+
+}  // namespace resim


### PR DESCRIPTION
## Description of change
Add converters for some ROS2 transform messages to ReSim message types.

## Guide to reproduce test results.
```
bazel test //resim/msg:fuzz_helpers_test
bazel test //resim/msg:transforms_test_helpers
```

## Checklist:
- [ ] I have self-reviewed this change.
- [ ] I have tested this change.
- [ ] This change is covered by tests that are already landed, or in this PR.
