### PR TITLE
Add Pose and Odometry Converters

### DIFF
--- a/resim/math/is_approx.hh
+++ b/resim/math/is_approx.hh
@@ -27,4 +27,16 @@ bool is_approx(
          precision * std::max(1.0, std::min(a.norm(), b.norm()));
 }
 
+// Overload for the above for scalars rather than matrices or vectors.
+// @param[in] a - The first scalar to compare.
+// @param[in] b - The second scalar to compare.
+// @param[in] precision - The precision to use in the fuzzy comparison.
+inline bool is_approx(
+    const double a,
+    const double b,
+    const double precision = DEFAULT_PRECISION) {
+  return std::fabs(a - b) <=
+         precision * std::max(1.0, std::min(std::fabs(a), std::fabs(b)));
+}
+
 }  // namespace resim::math

--- a/resim/math/is_approx_test.cc
+++ b/resim/math/is_approx_test.cc
@@ -25,16 +25,15 @@ TEST(IsApproxTest, TestIsApproxSmall) {
   constexpr double EPSILON = 1e-12;
 
   const Vec3 a{MAGNITUDE * testing::random_matrix<Vec3>(rng).normalized()};
-  const Vec3 should_match_a{
-      a +
-      (TOLERANCE - EPSILON) * testing::random_matrix<Vec3>(rng).normalized()};
-  const Vec3 shouldnt_match_a{
-      a +
-      (TOLERANCE + EPSILON) * testing::random_matrix<Vec3>(rng).normalized()};
+  const Vec3 should_match_a{a + (TOLERANCE - EPSILON) * a.normalized()};
+  const Vec3 shouldnt_match_a{a + (TOLERANCE + EPSILON) * a.normalized()};
 
   // ACTION / VERIFICATION
   EXPECT_TRUE(is_approx(a, should_match_a, TOLERANCE));
   EXPECT_FALSE(is_approx(a, shouldnt_match_a, TOLERANCE));
+
+  EXPECT_TRUE(is_approx(a.norm(), should_match_a.norm(), TOLERANCE));
+  EXPECT_FALSE(is_approx(a.norm(), shouldnt_match_a.norm(), TOLERANCE));
 }
 
 // Test that is_approx() works relatively rather than absolutely when large.
@@ -54,6 +53,9 @@ TEST(IsApproxTest, TestIsApproxLarge) {
   // ACTION / VERIFICATION
   EXPECT_TRUE(is_approx(a, should_match_a, TOLERANCE));
   EXPECT_FALSE(is_approx(a, shouldnt_match_a, TOLERANCE));
+
+  EXPECT_TRUE(is_approx(a.norm(), should_match_a.norm(), TOLERANCE));
+  EXPECT_FALSE(is_approx(a.norm(), shouldnt_match_a.norm(), TOLERANCE));
 }
 
 }  // namespace resim::math

--- a/resim/msg/BUILD
+++ b/resim/msg/BUILD
@@ -41,6 +41,21 @@ cc_proto_library(
     ],
 )
 
+proto_library(
+    name = "pose_proto",
+    srcs = ["pose.proto"],
+    deps = [
+        "//resim/transforms/proto:se3_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "pose_proto_cc",
+    deps = [
+        ":pose_proto",
+    ],
+)
+
 ################################################################################
 # Converters
 ################################################################################
@@ -114,6 +129,31 @@ cc_test(
         ":transform_proto_cc",
         "//resim/testing:fuzz_helpers",
         "//resim/utils:inout",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "pose_from_ros2",
+    srcs = ["pose_from_ros2.cc"],
+    hdrs = ["pose_from_ros2.hh"],
+    deps = [
+        ":pose_proto_cc",
+        "//resim/assert",
+        "//resim/transforms:se3",
+        "//resim/transforms:so3",
+        "//resim/transforms/proto:se3_proto_cc",
+        "//resim/transforms/proto:se3_to_proto",
+        "@libeigen//:eigen",
+        "@ros2_common_interfaces//:cpp_geometry_msgs",
+    ],
+)
+
+cc_test(
+    name = "pose_from_ros2_test",
+    srcs = ["pose_from_ros2_test.cc"],
+    deps = [
+        ":pose_from_ros2",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/resim/msg/BUILD
+++ b/resim/msg/BUILD
@@ -56,6 +56,22 @@ cc_proto_library(
     ],
 )
 
+proto_library(
+    name = "odometry_proto",
+    srcs = ["odometry.proto"],
+    deps = [
+        ":header_proto",
+        ":pose_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "odometry_proto_cc",
+    deps = [
+        ":odometry_proto",
+    ],
+)
+
 ################################################################################
 # Converters
 ################################################################################
@@ -153,7 +169,32 @@ cc_test(
     name = "pose_from_ros2_test",
     srcs = ["pose_from_ros2_test.cc"],
     deps = [
+        ":fuzz_helpers",
         ":pose_from_ros2",
+        "//resim/testing:fuzz_helpers",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "odometry_from_ros2",
+    srcs = ["odometry_from_ros2.cc"],
+    hdrs = ["odometry_from_ros2.hh"],
+    deps = [
+        ":header_from_ros2",
+        ":odometry_proto_cc",
+        ":pose_from_ros2",
+        "@ros2_common_interfaces//:cpp_nav_msgs",
+    ],
+)
+
+cc_test(
+    name = "odometry_from_ros2_test",
+    srcs = ["odometry_from_ros2_test.cc"],
+    deps = [
+        ":fuzz_helpers",
+        ":odometry_from_ros2",
+        "//resim/testing:fuzz_helpers",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -169,6 +210,8 @@ cc_library(
     hdrs = ["fuzz_helpers.hh"],
     deps = [
         ":header_proto_cc",
+        ":odometry_proto_cc",
+        ":pose_proto_cc",
         ":transform_proto_cc",
         "//resim/testing:fuzz_helpers",
         "//resim/testing:random_matrix",
@@ -185,6 +228,8 @@ cc_test(
     deps = [
         ":fuzz_helpers",
         ":header_proto_cc",
+        ":odometry_proto_cc",
+        ":pose_proto_cc",
         ":transform_proto_cc",
         "@com_google_googletest//:gtest_main",
     ],

--- a/resim/msg/fuzz_helpers.cc
+++ b/resim/msg/fuzz_helpers.cc
@@ -32,4 +32,70 @@ bool verify_equality(const TransformArray &a, const TransformArray &b) {
   return true;
 }
 
+bool verify_equality(const PoseWithCovariance &a, const PoseWithCovariance &b) {
+  const bool poses_equal = unpack(a.pose()).is_approx(unpack(b.pose()));
+  if (not poses_equal) {
+    return false;
+  }
+
+  constexpr std::size_t N = transforms::SE3::DOF;
+  REASSERT(
+      a.covariance().size() == N * N,
+      "Incorrect covariance size detected!");
+  REASSERT(
+      b.covariance().size() == N * N,
+      "Incorrect covariance size detected!");
+
+  for (int ii = 0; ii < N * N; ++ii) {
+    if (not resim::verify_equality(a.covariance(ii), b.covariance(ii))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool verify_equality(const Twist &a, const Twist &b) {
+  constexpr std::size_t N = transforms::SE3::DOF;
+  REASSERT(a.algebra().size() == N, "Incorrect twist size detected!");
+  REASSERT(b.algebra().size() == N, "Incorrect twist size detected!");
+
+  for (int ii = 0; ii < N; ++ii) {
+    if (not resim::verify_equality(a.algebra(ii), b.algebra(ii))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool verify_equality(
+    const TwistWithCovariance &a,
+    const TwistWithCovariance &b) {
+  const bool twists_equal = verify_equality(a.twist(), b.twist());
+  if (not twists_equal) {
+    return false;
+  }
+
+  constexpr std::size_t N = transforms::SE3::DOF;
+  REASSERT(
+      a.covariance().size() == N * N,
+      "Incorrect covariance size detected!");
+  REASSERT(
+      b.covariance().size() == N * N,
+      "Incorrect covariance size detected!");
+
+  for (int ii = 0; ii < N * N; ++ii) {
+    if (not resim::verify_equality(a.covariance(ii), b.covariance(ii))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool verify_equality(const Odometry &a, const Odometry &b) {
+  return verify_equality(a.header(), b.header()) and
+         a.child_frame_id() == b.child_frame_id() and
+         verify_equality(a.pose(), b.pose()) and
+         verify_equality(a.twist(), b.twist());
+}
+
 }  // namespace resim::msg

--- a/resim/msg/fuzz_helpers_test.cc
+++ b/resim/msg/fuzz_helpers_test.cc
@@ -11,6 +11,8 @@
 #include <random>
 
 #include "resim/msg/header.pb.h"
+#include "resim/msg/odometry.pb.h"
+#include "resim/msg/pose.pb.h"
 #include "resim/msg/transform.pb.h"
 
 namespace resim::msg {
@@ -97,6 +99,125 @@ TEST(FuzzHelpersTest, TestTransformArrayEqual) {
       verify_equality(transform_array_different_size, transform_array));
   EXPECT_FALSE(
       verify_equality(transform_array_different_element, transform_array));
+}
+
+TEST(FuzzHelpersTest, TestPoseWithCovarianceEqual) {
+  // SETUP
+  constexpr std::size_t SEED = 913U;
+  std::mt19937 rng{SEED};
+
+  const PoseWithCovariance pose_with_covariance{
+      random_element<PoseWithCovariance>(InOut{rng})};
+
+  PoseWithCovariance pose_with_covariance_different_pose{pose_with_covariance};
+  pose_with_covariance_different_pose.mutable_pose()->CopyFrom(
+      random_element<PoseWithCovariance>(InOut{rng}).pose());
+
+  PoseWithCovariance pose_with_covariance_different_covariance{
+      pose_with_covariance};
+  pose_with_covariance_different_covariance.mutable_covariance()->Set(
+      0,
+      -pose_with_covariance.covariance(0));
+
+  // ACTION / VERIFICATION
+  EXPECT_TRUE(verify_equality(pose_with_covariance, pose_with_covariance));
+  EXPECT_FALSE(verify_equality(
+      pose_with_covariance,
+      pose_with_covariance_different_pose));
+  EXPECT_FALSE(verify_equality(
+      pose_with_covariance,
+      pose_with_covariance_different_covariance));
+  EXPECT_FALSE(verify_equality(
+      pose_with_covariance_different_pose,
+      pose_with_covariance));
+  EXPECT_FALSE(verify_equality(
+      pose_with_covariance_different_covariance,
+      pose_with_covariance));
+}
+
+TEST(FuzzHelpersTest, TestTwistEqual) {
+  // SETUP
+  constexpr std::size_t SEED = 913U;
+  std::mt19937 rng{SEED};
+
+  const Twist twist{random_element<Twist>(InOut{rng})};
+
+  Twist twist_different_algebra{twist};
+  twist_different_algebra.mutable_algebra()->Set(0, -twist.algebra(0));
+
+  // ACTION / VERIFICATION
+  EXPECT_TRUE(verify_equality(twist, twist));
+  EXPECT_FALSE(verify_equality(twist, twist_different_algebra));
+  EXPECT_FALSE(verify_equality(twist_different_algebra, twist));
+}
+
+TEST(FuzzHelpersTest, TestTwistWithCovarianceEqual) {
+  // SETUP
+  constexpr std::size_t SEED = 913U;
+  std::mt19937 rng{SEED};
+
+  const TwistWithCovariance twist_with_covariance{
+      random_element<TwistWithCovariance>(InOut{rng})};
+
+  TwistWithCovariance twist_with_covariance_different_twist{
+      twist_with_covariance};
+  twist_with_covariance_different_twist.mutable_twist()->CopyFrom(
+      random_element<Twist>(InOut{rng}));
+
+  TwistWithCovariance twist_with_covariance_different_covariance{
+      twist_with_covariance};
+  twist_with_covariance_different_covariance.mutable_covariance()->Set(
+      0,
+      -twist_with_covariance.covariance(0));
+
+  // ACTION / VERIFICATION
+  EXPECT_TRUE(verify_equality(twist_with_covariance, twist_with_covariance));
+  EXPECT_FALSE(verify_equality(
+      twist_with_covariance,
+      twist_with_covariance_different_twist));
+  EXPECT_FALSE(verify_equality(
+      twist_with_covariance,
+      twist_with_covariance_different_covariance));
+  EXPECT_FALSE(verify_equality(
+      twist_with_covariance_different_twist,
+      twist_with_covariance));
+  EXPECT_FALSE(verify_equality(
+      twist_with_covariance_different_covariance,
+      twist_with_covariance));
+}
+
+TEST(FuzzHelpersTest, TestOdometryEqual) {
+  // SETUP
+  constexpr std::size_t SEED = 913U;
+  std::mt19937 rng{SEED};
+
+  const Odometry odometry{random_element<Odometry>(InOut{rng})};
+
+  Odometry odometry_different_header{odometry};
+  odometry_different_header.mutable_header()->CopyFrom(
+      random_element<Header>(InOut{rng}));
+
+  Odometry odometry_different_child_frame_id{odometry};
+  odometry_different_child_frame_id.set_child_frame_id(
+      odometry.child_frame_id() + "_different");
+
+  Odometry odometry_different_pose{odometry};
+  odometry_different_pose.mutable_pose()->CopyFrom(
+      random_element<PoseWithCovariance>(InOut{rng}));
+
+  Odometry odometry_different_twist{odometry};
+  odometry_different_twist.mutable_twist()->CopyFrom(
+      random_element<TwistWithCovariance>(InOut{rng}));
+
+  // ACTION / VERIFICATION
+  EXPECT_TRUE(verify_equality(odometry, odometry));
+  EXPECT_FALSE(verify_equality(odometry, odometry_different_header));
+  EXPECT_FALSE(verify_equality(odometry, odometry_different_child_frame_id));
+  EXPECT_FALSE(verify_equality(odometry, odometry_different_pose));
+  EXPECT_FALSE(verify_equality(odometry_different_twist, odometry));
+  EXPECT_FALSE(verify_equality(odometry_different_child_frame_id, odometry));
+  EXPECT_FALSE(verify_equality(odometry_different_pose, odometry));
+  EXPECT_FALSE(verify_equality(odometry_different_twist, odometry));
 }
 
 }  // namespace resim::msg

--- a/resim/msg/odometry.proto
+++ b/resim/msg/odometry.proto
@@ -1,0 +1,19 @@
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+syntax = "proto3";
+
+import "resim/msg/pose.proto";
+import "resim/msg/header.proto";
+
+package resim.msg;
+
+message Odometry {
+    Header              header         = 1;
+    string              child_frame_id = 2;
+    PoseWithCovariance  pose           = 3;
+    TwistWithCovariance twist          = 4;
+}

--- a/resim/msg/odometry_from_ros2.cc
+++ b/resim/msg/odometry_from_ros2.cc
@@ -1,0 +1,36 @@
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include "resim/msg/odometry_from_ros2.hh"
+
+#include "resim/msg/header_from_ros2.hh"
+#include "resim/msg/pose_from_ros2.hh"
+
+namespace resim::msg {
+
+// ROS2 converters for odometry
+
+Odometry convert_from_ros2(const nav_msgs::msg::Odometry &ros2_msg) {
+  Odometry result;
+
+  result.mutable_header()->CopyFrom(convert_from_ros2(ros2_msg.header));
+  result.set_child_frame_id(ros2_msg.child_frame_id);
+  result.mutable_pose()->CopyFrom(convert_from_ros2(ros2_msg.pose));
+  result.mutable_twist()->CopyFrom(convert_from_ros2(ros2_msg.twist));
+
+  return result;
+}
+
+nav_msgs::msg::Odometry convert_to_ros2(const Odometry &resim_msg) {
+  nav_msgs::msg::Odometry result;
+  result.header = convert_to_ros2(resim_msg.header());
+  result.child_frame_id = resim_msg.child_frame_id();
+  result.pose = convert_to_ros2(resim_msg.pose());
+  result.twist = convert_to_ros2(resim_msg.twist());
+  return result;
+}
+
+}  // namespace resim::msg

--- a/resim/msg/odometry_from_ros2.hh
+++ b/resim/msg/odometry_from_ros2.hh
@@ -1,0 +1,21 @@
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#pragma once
+
+#include <nav_msgs/msg/odometry.hpp>
+
+#include "resim/msg/odometry.pb.h"
+
+namespace resim::msg {
+
+// ROS2 converters for odometry
+
+Odometry convert_from_ros2(const nav_msgs::msg::Odometry &ros2_msg);
+
+nav_msgs::msg::Odometry convert_to_ros2(const Odometry &resim_msg);
+
+}  // namespace resim::msg

--- a/resim/msg/odometry_from_ros2_test.cc
+++ b/resim/msg/odometry_from_ros2_test.cc
@@ -1,0 +1,32 @@
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include "resim/msg/odometry_from_ros2.hh"
+
+#include <gtest/gtest.h>
+
+#include "resim/msg/fuzz_helpers.hh"
+#include "resim/msg/odometry.pb.h"
+#include "resim/testing/fuzz_helpers.hh"
+#include "resim/utils/inout.hh"
+
+namespace resim::msg {
+
+TEST(OdometryFromRos2Test, TestRoundTrip) {
+  // SETUP
+  constexpr std::size_t SEED = 913U;
+  std::mt19937 rng{SEED};
+  const Odometry test_odometry{random_element<Odometry>(InOut{rng})};
+
+  // ACTION
+  const Odometry round_tripped{
+      convert_from_ros2(convert_to_ros2(test_odometry))};
+
+  // VERIFICATION
+  EXPECT_TRUE(verify_equality(test_odometry, round_tripped));
+}
+
+}  // namespace resim::msg

--- a/resim/msg/pose.proto
+++ b/resim/msg/pose.proto
@@ -10,6 +10,13 @@ import "resim/transforms/proto/se3.proto";
 
 package resim.msg;
 
+// This message represents an observation-based estimate of
+// a six-degree-of-freedom rigid-body transform (or pose) between two coordinate
+// frames along with the estimate of its covariance based on a statistical model
+// of its evolution over time. One might get these, for instance, out of
+// a Kalman filter. We represent the pose using the protobuf representation of
+// our SE3 type since all 3D rigid body transforms are elements of the Lie Group
+// SE3.
 message PoseWithCovariance {
     resim.transforms.proto.SE3 pose = 1;
 
@@ -17,11 +24,22 @@ message PoseWithCovariance {
     repeated double covariance = 2;
 }
 
+// This message represents the time derivative of a six-degree-of-freedom
+// rigid body transform (or pose) between two coordinate frames.
 message Twist {
     // This has six elements with angular components first and linear second.
+    // These are expressed in the input coordinates of the transform. In other
+    // words, if the transform converts robot coordinates to world coordinates,
+    // then the linear components express the robot's velocity in its own
+    // coordinates.
     repeated double algebra = 1;
 }
 
+// This message represents an observation-based estimate of
+// the time derivative of a six-degree-of-freedom transform (or pose) between
+// two coordinate frames along with the estimate of its covariance based on
+// a statistical model of its evolution over time. One might get these, for
+// instance, out of a Kalman filter.
 message TwistWithCovariance {
     Twist twist = 1;
 

--- a/resim/msg/pose.proto
+++ b/resim/msg/pose.proto
@@ -11,15 +11,20 @@ import "resim/transforms/proto/se3.proto";
 package resim.msg;
 
 message PoseWithCovariance {
-    resim.transforms.proto.SE3 pose       = 1;
-    repeated double            covariance = 2;
+    resim.transforms.proto.SE3 pose = 1;
+
+    // This is a 6x6 matrix in row-major order
+    repeated double covariance = 2;
 }
 
 message Twist {
+    // This has six elements with angular components first and linear second.
     repeated double algebra = 1;
 }
 
 message TwistWithCovariance {
-    Twist           twist      = 1;
+    Twist twist = 1;
+
+    // This is a 6x6 matrix in row-major order
     repeated double covariance = 2;
 }

--- a/resim/msg/pose.proto
+++ b/resim/msg/pose.proto
@@ -1,0 +1,25 @@
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+syntax = "proto3";
+
+import "resim/transforms/proto/se3.proto";
+
+package resim.msg;
+
+message PoseWithCovariance {
+    resim.transforms.proto.SE3 pose       = 1;
+    repeated double            covariance = 2;
+}
+
+message Twist {
+    repeated double algebra = 1;
+}
+
+message TwistWithCovariance {
+    Twist           twist      = 1;
+    repeated double covariance = 2;
+}

--- a/resim/msg/pose_from_ros2.cc
+++ b/resim/msg/pose_from_ros2.cc
@@ -1,0 +1,141 @@
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include "resim/msg/pose_from_ros2.hh"
+
+#include "resim/assert/assert.hh"
+#include "resim/transforms/proto/se3_to_proto.hh"
+#include "resim/transforms/se3.hh"
+#include "resim/transforms/so3.hh"
+
+namespace resim::msg {
+
+transforms::proto::SE3 convert_from_ros2(
+    const geometry_msgs::msg::Pose &ros2_msg) {
+  const transforms::SO3 rotation{Eigen::Quaterniond{
+      ros2_msg.orientation.w,
+      ros2_msg.orientation.x,
+      ros2_msg.orientation.y,
+      ros2_msg.orientation.z,
+  }};
+
+  const transforms::SE3 transform{
+      rotation,
+      Eigen::Vector3d{
+          ros2_msg.position.x,
+          ros2_msg.position.y,
+          ros2_msg.position.z,
+      }};
+
+  transforms::proto::SE3 result;
+  pack(transform, &result);
+  return result;
+}
+
+geometry_msgs::msg::Pose convert_to_ros2(
+    const transforms::proto::SE3 &resim_msg) {
+  const transforms::SE3 pose{unpack(resim_msg)};
+  geometry_msgs::msg::Pose result;
+
+  result.position.x = pose.translation().x();
+  result.position.y = pose.translation().y();
+  result.position.z = pose.translation().z();
+
+  const Eigen::Quaterniond rotation_quaternion = pose.rotation().quaternion();
+
+  result.orientation.w = rotation_quaternion.w();
+  result.orientation.x = rotation_quaternion.x();
+  result.orientation.y = rotation_quaternion.y();
+  result.orientation.z = rotation_quaternion.z();
+
+  return result;
+}
+
+PoseWithCovariance convert_from_ros2(
+    const geometry_msgs::msg::PoseWithCovariance &ros2_msg) {
+  PoseWithCovariance result;
+
+  result.mutable_pose()->CopyFrom(convert_from_ros2(ros2_msg.pose));
+
+  constexpr int N = transforms::SE3::DOF;
+  REASSERT(ros2_msg.covariance.size() == N * N, "Covariance has wrong size!");
+  for (int ii = 0; ii < N * N; ++ii) {
+    result.add_covariance(ros2_msg.covariance.at(ii));
+  }
+  return result;
+}
+
+geometry_msgs::msg::PoseWithCovariance convert_to_ros2(
+    const PoseWithCovariance &resim_msg) {
+  geometry_msgs::msg::PoseWithCovariance result;
+  result.pose = convert_to_ros2(resim_msg.pose());
+
+  constexpr int N = transforms::SE3::DOF;
+  REASSERT(resim_msg.covariance_size() == N * N, "Covariance has wrong size!");
+  for (int ii = 0; ii < N * N; ++ii) {
+    result.covariance.at(ii) = resim_msg.covariance(ii);
+  }
+  return result;
+}
+
+Twist convert_from_ros2(const geometry_msgs::msg::Twist &ros2_msg) {
+  Twist result;
+
+  result.add_algebra(ros2_msg.angular.x);
+  result.add_algebra(ros2_msg.angular.y);
+  result.add_algebra(ros2_msg.angular.z);
+
+  result.add_algebra(ros2_msg.linear.x);
+  result.add_algebra(ros2_msg.linear.y);
+  result.add_algebra(ros2_msg.linear.z);
+
+  return result;
+}
+
+geometry_msgs::msg::Twist convert_to_ros2(const Twist &resim_msg) {
+  geometry_msgs::msg::Twist result;
+  constexpr int N = transforms::SE3::DOF;
+  REASSERT(resim_msg.algebra_size() == N, "Algebra has wrong size!");
+
+  result.angular.x = resim_msg.algebra(0);
+  result.angular.y = resim_msg.algebra(1);
+  result.angular.z = resim_msg.algebra(2);
+
+  result.linear.x = resim_msg.algebra(3);
+  result.linear.y = resim_msg.algebra(4);
+  result.linear.z = resim_msg.algebra(5);
+
+  return result;
+}
+
+TwistWithCovariance convert_from_ros2(
+    const geometry_msgs::msg::TwistWithCovariance &ros2_msg) {
+  TwistWithCovariance result;
+
+  result.mutable_twist()->CopyFrom(convert_from_ros2(ros2_msg.twist));
+
+  constexpr int N = transforms::SE3::DOF;
+  REASSERT(ros2_msg.covariance.size() == N * N, "Covariance has wrong size!");
+  for (int ii = 0; ii < N * N; ++ii) {
+    result.add_covariance(ros2_msg.covariance.at(ii));
+  }
+  return result;
+}
+
+geometry_msgs::msg::TwistWithCovariance convert_to_ros2(
+    const TwistWithCovariance &resim_msg) {
+  geometry_msgs::msg::TwistWithCovariance result;
+  result.twist = convert_to_ros2(resim_msg.twist());
+
+  constexpr int N = transforms::SE3::DOF;
+  REASSERT(resim_msg.covariance_size() == N * N, "Covariance has wrong size!");
+  for (int ii = 0; ii < N * N; ++ii) {
+    result.covariance.at(ii) = resim_msg.covariance(ii);
+  }
+  return result;
+}
+
+}  // namespace resim::msg

--- a/resim/msg/pose_from_ros2.cc
+++ b/resim/msg/pose_from_ros2.cc
@@ -6,6 +6,8 @@
 
 #include "resim/msg/pose_from_ros2.hh"
 
+#include <cstdint>
+
 #include "resim/assert/assert.hh"
 #include "resim/transforms/proto/se3_to_proto.hh"
 #include "resim/transforms/se3.hh"
@@ -60,7 +62,7 @@ PoseWithCovariance convert_from_ros2(
 
   result.mutable_pose()->CopyFrom(convert_from_ros2(ros2_msg.pose));
 
-  constexpr int N = transforms::SE3::DOF;
+  constexpr std::size_t N = transforms::SE3::DOF;
   REASSERT(ros2_msg.covariance.size() == N * N, "Covariance has wrong size!");
   for (int ii = 0; ii < N * N; ++ii) {
     result.add_covariance(ros2_msg.covariance.at(ii));
@@ -73,7 +75,7 @@ geometry_msgs::msg::PoseWithCovariance convert_to_ros2(
   geometry_msgs::msg::PoseWithCovariance result;
   result.pose = convert_to_ros2(resim_msg.pose());
 
-  constexpr int N = transforms::SE3::DOF;
+  constexpr std::size_t N = transforms::SE3::DOF;
   REASSERT(resim_msg.covariance_size() == N * N, "Covariance has wrong size!");
   for (int ii = 0; ii < N * N; ++ii) {
     result.covariance.at(ii) = resim_msg.covariance(ii);
@@ -97,9 +99,10 @@ Twist convert_from_ros2(const geometry_msgs::msg::Twist &ros2_msg) {
 
 geometry_msgs::msg::Twist convert_to_ros2(const Twist &resim_msg) {
   geometry_msgs::msg::Twist result;
-  constexpr int N = transforms::SE3::DOF;
+  constexpr std::size_t N = transforms::SE3::DOF;
   REASSERT(resim_msg.algebra_size() == N, "Algebra has wrong size!");
 
+  // NOLINTBEGIN(readability-magic-numbers)
   result.angular.x = resim_msg.algebra(0);
   result.angular.y = resim_msg.algebra(1);
   result.angular.z = resim_msg.algebra(2);
@@ -107,6 +110,7 @@ geometry_msgs::msg::Twist convert_to_ros2(const Twist &resim_msg) {
   result.linear.x = resim_msg.algebra(3);
   result.linear.y = resim_msg.algebra(4);
   result.linear.z = resim_msg.algebra(5);
+  // NOLINTEND(readability-magic-numbers)
 
   return result;
 }
@@ -117,7 +121,7 @@ TwistWithCovariance convert_from_ros2(
 
   result.mutable_twist()->CopyFrom(convert_from_ros2(ros2_msg.twist));
 
-  constexpr int N = transforms::SE3::DOF;
+  constexpr std::size_t N = transforms::SE3::DOF;
   REASSERT(ros2_msg.covariance.size() == N * N, "Covariance has wrong size!");
   for (int ii = 0; ii < N * N; ++ii) {
     result.add_covariance(ros2_msg.covariance.at(ii));
@@ -130,7 +134,7 @@ geometry_msgs::msg::TwistWithCovariance convert_to_ros2(
   geometry_msgs::msg::TwistWithCovariance result;
   result.twist = convert_to_ros2(resim_msg.twist());
 
-  constexpr int N = transforms::SE3::DOF;
+  constexpr std::size_t N = transforms::SE3::DOF;
   REASSERT(resim_msg.covariance_size() == N * N, "Covariance has wrong size!");
   for (int ii = 0; ii < N * N; ++ii) {
     result.covariance.at(ii) = resim_msg.covariance(ii);

--- a/resim/msg/pose_from_ros2.hh
+++ b/resim/msg/pose_from_ros2.hh
@@ -1,0 +1,43 @@
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#pragma once
+
+#include <geometry_msgs/msg/pose.hpp>
+#include <geometry_msgs/msg/pose_with_covariance.hpp>
+#include <geometry_msgs/msg/twist.hpp>
+#include <geometry_msgs/msg/twist_with_covariance.hpp>
+
+#include "resim/msg/pose.pb.h"
+#include "resim/transforms/proto/se3.pb.h"
+
+namespace resim::msg {
+
+// ROS2 converters for transforms
+
+transforms::proto::SE3 convert_from_ros2(
+    const geometry_msgs::msg::Pose &ros2_msg);
+
+geometry_msgs::msg::Pose convert_to_ros2(
+    const transforms::proto::SE3 &resim_msg);
+
+PoseWithCovariance convert_from_ros2(
+    const geometry_msgs::msg::PoseWithCovariance &ros2_msg);
+
+geometry_msgs::msg::PoseWithCovariance convert_to_ros2(
+    const PoseWithCovariance &resim_msg);
+
+Twist convert_from_ros2(const geometry_msgs::msg::Twist &ros2_msg);
+
+geometry_msgs::msg::Twist convert_to_ros2(const Twist &resim_msg);
+
+TwistWithCovariance convert_from_ros2(
+    const geometry_msgs::msg::TwistWithCovariance &ros2_msg);
+
+geometry_msgs::msg::TwistWithCovariance convert_to_ros2(
+    const TwistWithCovariance &resim_msg);
+
+}  // namespace resim::msg

--- a/resim/msg/pose_from_ros2.hh
+++ b/resim/msg/pose_from_ros2.hh
@@ -16,7 +16,7 @@
 
 namespace resim::msg {
 
-// ROS2 converters for transforms
+// ROS2 converters for poses and twists
 
 transforms::proto::SE3 convert_from_ros2(
     const geometry_msgs::msg::Pose &ros2_msg);

--- a/resim/msg/pose_from_ros2_test.cc
+++ b/resim/msg/pose_from_ros2_test.cc
@@ -1,0 +1,39 @@
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include "resim/msg/pose_from_ros2.hh"
+
+#include <gtest/gtest.h>
+
+#include "resim/msg/fuzz_helpers.hh"
+#include "resim/msg/pose.pb.h"
+#include "resim/testing/fuzz_helpers.hh"
+#include "resim/utils/inout.hh"
+
+namespace resim::msg {
+
+using Types = ::testing::Types<PoseWithCovariance, Twist, TwistWithCovariance>;
+
+template <typename T>
+struct PoseFromRos2Test : public ::testing::Test {};
+
+TYPED_TEST_SUITE(PoseFromRos2Test, Types);
+
+TYPED_TEST(PoseFromRos2Test, TestRoundTrip) {
+  // SETUP
+  constexpr std::size_t SEED = 913U;
+  std::mt19937 rng{SEED};
+  const TypeParam test_element{random_element<TypeParam>(InOut{rng})};
+
+  // ACTION
+  const TypeParam round_tripped{
+      convert_from_ros2(convert_to_ros2(test_element))};
+
+  // VERIFICATION
+  EXPECT_TRUE(verify_equality(test_element, round_tripped));
+}
+
+}  // namespace resim::msg

--- a/resim/testing/BUILD
+++ b/resim/testing/BUILD
@@ -87,6 +87,7 @@ cc_library(
     hdrs = ["fuzz_helpers.hh"],
     visibility = ["//visibility:public"],
     deps = [
+        "//resim/math:is_approx",
         "//resim/utils:inout",
     ],
 )

--- a/resim/testing/BUILD
+++ b/resim/testing/BUILD
@@ -83,6 +83,7 @@ cc_library(
 cc_library(
     name = "fuzz_helpers",
     testonly = True,
+    srcs = ["fuzz_helpers.cc"],
     hdrs = ["fuzz_helpers.hh"],
     visibility = ["//visibility:public"],
     deps = [

--- a/resim/testing/fuzz_helpers.cc
+++ b/resim/testing/fuzz_helpers.cc
@@ -1,0 +1,13 @@
+
+#include "resim/testing/fuzz_helpers.hh"
+
+#include <cmath>
+
+namespace resim {
+
+bool verify_equality(double a, double b) {
+  constexpr double TOLERANCE = 1e-12;
+  return std::fabs(b - a) < TOLERANCE;
+}
+
+}  // namespace resim

--- a/resim/testing/fuzz_helpers.cc
+++ b/resim/testing/fuzz_helpers.cc
@@ -1,3 +1,8 @@
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
 
 #include "resim/testing/fuzz_helpers.hh"
 

--- a/resim/testing/fuzz_helpers.cc
+++ b/resim/testing/fuzz_helpers.cc
@@ -8,11 +8,10 @@
 
 #include <cmath>
 
+#include "resim/math/is_approx.hh"
+
 namespace resim {
 
-bool verify_equality(double a, double b) {
-  constexpr double TOLERANCE = 1e-12;
-  return std::fabs(b - a) < TOLERANCE;
-}
+bool verify_equality(double a, double b) { return math::is_approx(a, b); }
 
 }  // namespace resim

--- a/resim/testing/fuzz_helpers.hh
+++ b/resim/testing/fuzz_helpers.hh
@@ -86,4 +86,19 @@ Int random_element(TypeTag<Int> /*unused*/, InOut<Rng> rng) {
   return dist(*rng);
 }
 
+// random_element overload with an implementation for floating point types. This
+// is done here so it is in the same namespace as TypeTag and can be found by
+// ADL
+// when called in generic code.
+template <std::floating_point Float, typename Rng>
+Float random_element(TypeTag<Float> /*unused*/, InOut<Rng> rng) {
+  std::uniform_real_distribution<Float> dist{
+      std::numeric_limits<Float>::min(),
+      std::numeric_limits<Float>::max()};
+  return dist(*rng);
+}
+
+// verify_equality overload with an implementation for doubles.
+bool verify_equality(double a, double b);
+
 }  // namespace resim

--- a/resim/testing/fuzz_helpers.hh
+++ b/resim/testing/fuzz_helpers.hh
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <concepts>
+#include <iostream>
 #include <random>
 
 #include "resim/utils/inout.hh"
@@ -88,13 +89,13 @@ Int random_element(TypeTag<Int> /*unused*/, InOut<Rng> rng) {
 
 // random_element overload with an implementation for floating point types. This
 // is done here so it is in the same namespace as TypeTag and can be found by
-// ADL
-// when called in generic code.
+// ADL when called in generic code.
 template <std::floating_point Float, typename Rng>
 Float random_element(TypeTag<Float> /*unused*/, InOut<Rng> rng) {
+  constexpr double TWO = 2.;
   std::uniform_real_distribution<Float> dist{
-      std::numeric_limits<Float>::min(),
-      std::numeric_limits<Float>::max()};
+      -std::numeric_limits<Float>::max() / TWO,
+      std::numeric_limits<Float>::max() / TWO};
   return dist(*rng);
 }
 


### PR DESCRIPTION
## Description of change
Add ROS2 converters for Pose, PoseWithCovariance, Twist, TwistWithCovariance, and Odometry.

## Guide to reproduce test results.
```bash
bazel test //resim/msg:pose_from_ros2_test
bazel test //resim/msg:odometry_from_ros2_test
```
## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
