### PR TITLE
Oriented Box ROS2 converters

### DIFF
--- a/resim/geometry/proto/BUILD
+++ b/resim/geometry/proto/BUILD
@@ -44,3 +44,33 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+proto_library(
+    name = "oriented_box_proto",
+    srcs = ["oriented_box.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//resim/transforms/proto:se3_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "oriented_box_proto_cc",
+    visibility = ["//visibility:public"],
+    deps = [":oriented_box_proto"],
+)
+
+cc_library(
+    name = "fuzz_helpers",
+    testonly = True,
+    srcs = ["fuzz_helpers.cc"],
+    hdrs = ["fuzz_helpers.hh"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":oriented_box_proto_cc",
+        "//resim/testing:fuzz_helpers",
+        "//resim/transforms:se3",
+        "//resim/transforms/proto:fuzz_helpers",
+        "//resim/utils:inout",
+    ],
+)

--- a/resim/geometry/proto/BUILD
+++ b/resim/geometry/proto/BUILD
@@ -74,3 +74,16 @@ cc_library(
         "//resim/utils:inout",
     ],
 )
+
+cc_test(
+    name = "fuzz_helpers_test",
+    srcs = ["fuzz_helpers_test.cc"],
+    deps = [
+        ":fuzz_helpers",
+        ":oriented_box_proto_cc",
+        "//resim/testing:fuzz_helpers",
+        "//resim/transforms/proto:fuzz_helpers",
+        "//resim/utils:inout",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/resim/geometry/proto/fuzz_helpers.cc
+++ b/resim/geometry/proto/fuzz_helpers.cc
@@ -1,0 +1,25 @@
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include "resim/geometry/proto/fuzz_helpers.hh"
+
+namespace resim::geometry::proto {
+
+bool verify_equality(const OrientedBoxSE3 &a, const OrientedBoxSE3 &b) {
+  if (not verify_equality(a.reference_from_box(), b.reference_from_box())) {
+    return false;
+  }
+
+  for (int ii = 0; ii < transforms::SE3::DIMS; ++ii) {
+    if (not resim::verify_equality(a.extents(ii), b.extents(ii))) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+}  // namespace resim::geometry::proto

--- a/resim/geometry/proto/fuzz_helpers.cc
+++ b/resim/geometry/proto/fuzz_helpers.cc
@@ -6,8 +6,6 @@
 
 #include "resim/geometry/proto/fuzz_helpers.hh"
 
-#include <iostream>
-
 namespace resim::geometry::proto {
 
 bool verify_equality(const OrientedBoxSE3 &a, const OrientedBoxSE3 &b) {
@@ -16,12 +14,10 @@ bool verify_equality(const OrientedBoxSE3 &a, const OrientedBoxSE3 &b) {
   }
 
   for (int ii = 0; ii < transforms::SE3::DIMS; ++ii) {
-    std::cout << a.extents(ii) << " " << b.extents(ii) << std::endl;
     if (not resim::verify_equality(a.extents(ii), b.extents(ii))) {
       return false;
     }
   }
-
   return true;
 }
 

--- a/resim/geometry/proto/fuzz_helpers.cc
+++ b/resim/geometry/proto/fuzz_helpers.cc
@@ -6,6 +6,8 @@
 
 #include "resim/geometry/proto/fuzz_helpers.hh"
 
+#include <iostream>
+
 namespace resim::geometry::proto {
 
 bool verify_equality(const OrientedBoxSE3 &a, const OrientedBoxSE3 &b) {
@@ -14,6 +16,7 @@ bool verify_equality(const OrientedBoxSE3 &a, const OrientedBoxSE3 &b) {
   }
 
   for (int ii = 0; ii < transforms::SE3::DIMS; ++ii) {
+    std::cout << a.extents(ii) << " " << b.extents(ii) << std::endl;
     if (not resim::verify_equality(a.extents(ii), b.extents(ii))) {
       return false;
     }

--- a/resim/geometry/proto/fuzz_helpers.hh
+++ b/resim/geometry/proto/fuzz_helpers.hh
@@ -1,0 +1,35 @@
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#pragma once
+
+#include <cmath>
+
+#include "resim/geometry/proto/oriented_box.pb.h"
+#include "resim/testing/fuzz_helpers.hh"
+#include "resim/transforms/proto/fuzz_helpers.hh"
+#include "resim/transforms/se3.hh"
+#include "resim/utils/inout.hh"
+
+namespace resim::geometry::proto {
+
+template <typename Rng>
+OrientedBoxSE3 random_element(
+    TypeTag<OrientedBoxSE3> /*unused*/,
+    InOut<Rng> rng) {
+  OrientedBoxSE3 result;
+  result.mutable_reference_from_box()->CopyFrom(
+      random_element<transforms::proto::SE3>(rng));
+
+  for (int ii = 0; ii < transforms::SE3::DIMS; ++ii) {
+    result.add_extents(std::fabs(random_element<double>(rng)));
+  }
+  return result;
+}
+
+bool verify_equality(const OrientedBoxSE3 &a, const OrientedBoxSE3 &b);
+
+}  // namespace resim::geometry::proto

--- a/resim/geometry/proto/fuzz_helpers_test.cc
+++ b/resim/geometry/proto/fuzz_helpers_test.cc
@@ -1,0 +1,39 @@
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include "resim/geometry/proto/fuzz_helpers.hh"
+
+#include <gtest/gtest.h>
+
+#include <random>
+
+#include "resim/testing/fuzz_helpers.hh"
+#include "resim/transforms/proto/fuzz_helpers.hh"
+#include "resim/utils/inout.hh"
+
+namespace resim::geometry::proto {
+
+TEST(FuzzHelpersTest, TestOrientedBoxSE3Equal) {
+  // SETUP
+  constexpr std::size_t SEED = 3481U;
+  std::mt19937 rng{SEED};
+
+  const OrientedBoxSE3 box{random_element<OrientedBoxSE3>(InOut{rng})};
+  OrientedBoxSE3 box_different_reference_from_box{box};
+  box_different_reference_from_box.mutable_reference_from_box()->CopyFrom(
+      random_element<transforms::proto::SE3>(InOut{rng}));
+  OrientedBoxSE3 box_different_extents{box};
+  box_different_extents.mutable_extents()->Set(0, -box.extents(0));
+
+  // ACTION / VERIFICATION
+  EXPECT_TRUE(verify_equality(box, box));
+  EXPECT_FALSE(verify_equality(box, box_different_reference_from_box));
+  EXPECT_FALSE(verify_equality(box, box_different_extents));
+  EXPECT_FALSE(verify_equality(box_different_reference_from_box, box));
+  EXPECT_FALSE(verify_equality(box_different_extents, box));
+}
+
+}  // namespace resim::geometry::proto

--- a/resim/geometry/proto/oriented_box.proto
+++ b/resim/geometry/proto/oriented_box.proto
@@ -1,0 +1,16 @@
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+syntax = "proto3";
+
+import "resim/transforms/proto/se3.proto";
+
+package resim.geometry.proto;
+
+message OrientedBoxSE3 {
+    resim.transforms.proto.SE3 reference_from_box = 1;
+    repeated double            extents            = 2;
+}

--- a/resim/msg/BUILD
+++ b/resim/msg/BUILD
@@ -199,6 +199,30 @@ cc_test(
     ],
 )
 
+cc_library(
+    name = "oriented_box_from_ros2",
+    srcs = ["oriented_box_from_ros2.cc"],
+    hdrs = ["oriented_box_from_ros2.hh"],
+    deps = [
+        ":pose_from_ros2",
+        "//resim/assert",
+        "//resim/geometry/proto:oriented_box_proto_cc",
+        "@vision_msgs//:cpp_vision_msgs",
+    ],
+)
+
+cc_test(
+    name = "oriented_box_from_ros2_test",
+    srcs = ["oriented_box_from_ros2_test.cc"],
+    deps = [
+        ":oriented_box_from_ros2",
+        "//resim/geometry/proto:fuzz_helpers",
+        "//resim/testing:fuzz_helpers",
+        "//resim/transforms:frame",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 ################################################################################
 # Helpers
 ################################################################################
@@ -215,7 +239,8 @@ cc_library(
         ":transform_proto_cc",
         "//resim/testing:fuzz_helpers",
         "//resim/testing:random_matrix",
-        "//resim/transforms/proto:se3_to_proto",
+        "//resim/transforms:frame",
+        "//resim/transforms/proto:fuzz_helpers",
         "//resim/utils:inout",
         "//resim/utils:uuid",
     ],

--- a/resim/msg/fuzz_helpers.cc
+++ b/resim/msg/fuzz_helpers.cc
@@ -9,15 +9,15 @@
 namespace resim::msg {
 
 bool verify_equality(const Header &a, const Header &b) {
-  return a.stamp().seconds() == b.stamp().seconds() &&
-         a.stamp().nanos() == b.stamp().nanos() && a.frame_id() == b.frame_id();
+  return a.stamp().seconds() == b.stamp().seconds() and
+         a.stamp().nanos() == b.stamp().nanos() and
+         a.frame_id() == b.frame_id();
 }
 
 bool verify_equality(const TransformStamped &a, const TransformStamped &b) {
-  const bool transforms_equal =
-      unpack(a.transform()).is_approx(unpack(b.transform()));
-  return transforms_equal && verify_equality(a.header(), b.header()) &&
-         a.child_frame_id() == b.child_frame_id();
+  return verify_equality(a.header(), b.header()) and
+         a.child_frame_id() == b.child_frame_id() and
+         verify_equality(a.transform(), b.transform());
 }
 
 bool verify_equality(const TransformArray &a, const TransformArray &b) {
@@ -33,8 +33,7 @@ bool verify_equality(const TransformArray &a, const TransformArray &b) {
 }
 
 bool verify_equality(const PoseWithCovariance &a, const PoseWithCovariance &b) {
-  const bool poses_equal = unpack(a.pose()).is_approx(unpack(b.pose()));
-  if (not poses_equal) {
+  if (not verify_equality(a.pose(), b.pose())) {
     return false;
   }
 

--- a/resim/msg/fuzz_helpers.hh
+++ b/resim/msg/fuzz_helpers.hh
@@ -49,10 +49,11 @@ TransformStamped random_element(
       random_element<transforms::proto::SE3>(rng));
 
   // We don't use these when converting to/from ROS2
+  constexpr int DIMS = 3;
   result.mutable_transform()->mutable_into()->mutable_id()->set_data(
-      transforms::Frame<3>::null_frame().id().to_string());
+      transforms::Frame<DIMS>::null_frame().id().to_string());
   result.mutable_transform()->mutable_from()->mutable_id()->set_data(
-      transforms::Frame<3>::null_frame().id().to_string());
+      transforms::Frame<DIMS>::null_frame().id().to_string());
 
   return result;
 }
@@ -80,10 +81,11 @@ PoseWithCovariance random_element(
   result.mutable_pose()->CopyFrom(random_element<transforms::proto::SE3>(rng));
 
   // We don't use these when converting to/from ROS2
+  constexpr int DIMS = 3;
   result.mutable_pose()->mutable_into()->mutable_id()->set_data(
-      transforms::Frame<3>::null_frame().id().to_string());
+      transforms::Frame<DIMS>::null_frame().id().to_string());
   result.mutable_pose()->mutable_from()->mutable_id()->set_data(
-      transforms::Frame<3>::null_frame().id().to_string());
+      transforms::Frame<DIMS>::null_frame().id().to_string());
 
   constexpr std::size_t N = transforms::SE3::DOF;
   for (int ii = 0; ii < N * N; ++ii) {

--- a/resim/msg/fuzz_helpers.hh
+++ b/resim/msg/fuzz_helpers.hh
@@ -48,7 +48,7 @@ TransformStamped random_element(
   result.mutable_transform()->CopyFrom(
       random_element<transforms::proto::SE3>(rng));
 
-  // We don't use these when converting to/from ROS2
+  // We don't use frame IDs when converting to/from ROS2.
   constexpr int DIMS = 3;
   result.mutable_transform()->mutable_into()->mutable_id()->set_data(
       transforms::Frame<DIMS>::null_frame().id().to_string());
@@ -80,7 +80,7 @@ PoseWithCovariance random_element(
   PoseWithCovariance result;
   result.mutable_pose()->CopyFrom(random_element<transforms::proto::SE3>(rng));
 
-  // We don't use these when converting to/from ROS2
+  // We don't use frame IDs when converting to/from ROS2.
   constexpr int DIMS = 3;
   result.mutable_pose()->mutable_into()->mutable_id()->set_data(
       transforms::Frame<DIMS>::null_frame().id().to_string());

--- a/resim/msg/oriented_box_from_ros2.cc
+++ b/resim/msg/oriented_box_from_ros2.cc
@@ -1,0 +1,39 @@
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include "resim/msg/oriented_box_from_ros2.hh"
+
+#include "resim/assert/assert.hh"
+#include "resim/msg/pose_from_ros2.hh"
+
+namespace resim::msg {
+
+// ROS2 converters for message headers
+
+geometry::proto::OrientedBoxSE3 convert_from_ros2(
+    const vision_msgs::msg::BoundingBox3D &ros2_msg) {
+  geometry::proto::OrientedBoxSE3 result;
+  result.mutable_reference_from_box()->CopyFrom(
+      convert_from_ros2(ros2_msg.center));
+  result.add_extents(ros2_msg.size.x);
+  result.add_extents(ros2_msg.size.y);
+  result.add_extents(ros2_msg.size.z);
+  return result;
+}
+
+vision_msgs::msg::BoundingBox3D convert_to_ros2(
+    const geometry::proto::OrientedBoxSE3 &resim_msg) {
+  vision_msgs::msg::BoundingBox3D result;
+
+  result.center = convert_to_ros2(resim_msg.reference_from_box());
+  REASSERT(resim_msg.extents_size() == 3U);
+  result.size.x = resim_msg.extents(0);
+  result.size.y = resim_msg.extents(1);
+  result.size.z = resim_msg.extents(2);
+  return result;
+}
+
+}  // namespace resim::msg

--- a/resim/msg/oriented_box_from_ros2.hh
+++ b/resim/msg/oriented_box_from_ros2.hh
@@ -1,0 +1,23 @@
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#pragma once
+
+#include <vision_msgs/msg/bounding_box3_d.hpp>
+
+#include "resim/geometry/proto/oriented_box.pb.h"
+
+namespace resim::msg {
+
+// ROS2 converters for message headers
+
+geometry::proto::OrientedBoxSE3 convert_from_ros2(
+    const vision_msgs::msg::BoundingBox3D &ros2_msg);
+
+vision_msgs::msg::BoundingBox3D convert_to_ros2(
+    const geometry::proto::OrientedBoxSE3 &resim_msg);
+
+}  // namespace resim::msg

--- a/resim/msg/oriented_box_from_ros2.hh
+++ b/resim/msg/oriented_box_from_ros2.hh
@@ -12,7 +12,7 @@
 
 namespace resim::msg {
 
-// ROS2 converters for message headers
+// ROS2 converters for bounding boxes
 
 geometry::proto::OrientedBoxSE3 convert_from_ros2(
     const vision_msgs::msg::BoundingBox3D &ros2_msg);

--- a/resim/msg/oriented_box_from_ros2_test.cc
+++ b/resim/msg/oriented_box_from_ros2_test.cc
@@ -25,14 +25,15 @@ TEST(OrientedBoxSE3FromRos2Test, TestRoundTrip) {
   geometry::proto::OrientedBoxSE3 test_oriented_box{
       random_element<geometry::proto::OrientedBoxSE3>(InOut{rng})};
   // We don't use these when converting to/from ROS2
+  constexpr int DIMS = 3;
   test_oriented_box.mutable_reference_from_box()
       ->mutable_into()
       ->mutable_id()
-      ->set_data(transforms::Frame<3>::null_frame().id().to_string());
+      ->set_data(transforms::Frame<DIMS>::null_frame().id().to_string());
   test_oriented_box.mutable_reference_from_box()
       ->mutable_from()
       ->mutable_id()
-      ->set_data(transforms::Frame<3>::null_frame().id().to_string());
+      ->set_data(transforms::Frame<DIMS>::null_frame().id().to_string());
 
   // ACTION
   const geometry::proto::OrientedBoxSE3 round_tripped{

--- a/resim/msg/oriented_box_from_ros2_test.cc
+++ b/resim/msg/oriented_box_from_ros2_test.cc
@@ -1,0 +1,45 @@
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include "resim/msg/oriented_box_from_ros2.hh"
+
+#include <gtest/gtest.h>
+
+#include <random>
+
+#include "resim/geometry/proto/fuzz_helpers.hh"
+#include "resim/geometry/proto/oriented_box.pb.h"
+#include "resim/testing/fuzz_helpers.hh"
+#include "resim/transforms/frame.hh"
+#include "resim/utils/inout.hh"
+
+namespace resim::msg {
+
+TEST(OrientedBoxSE3FromRos2Test, TestRoundTrip) {
+  // SETUP
+  constexpr std::size_t SEED = 913U;
+  std::mt19937 rng{SEED};
+  geometry::proto::OrientedBoxSE3 test_oriented_box{
+      random_element<geometry::proto::OrientedBoxSE3>(InOut{rng})};
+  // We don't use these when converting to/from ROS2
+  test_oriented_box.mutable_reference_from_box()
+      ->mutable_into()
+      ->mutable_id()
+      ->set_data(transforms::Frame<3>::null_frame().id().to_string());
+  test_oriented_box.mutable_reference_from_box()
+      ->mutable_from()
+      ->mutable_id()
+      ->set_data(transforms::Frame<3>::null_frame().id().to_string());
+
+  // ACTION
+  const geometry::proto::OrientedBoxSE3 round_tripped{
+      convert_from_ros2(convert_to_ros2(test_oriented_box))};
+
+  // VERIFICATION
+  EXPECT_TRUE(verify_equality(test_oriented_box, round_tripped));
+}
+
+}  // namespace resim::msg

--- a/resim/msg/oriented_box_from_ros2_test.cc
+++ b/resim/msg/oriented_box_from_ros2_test.cc
@@ -24,7 +24,7 @@ TEST(OrientedBoxSE3FromRos2Test, TestRoundTrip) {
   std::mt19937 rng{SEED};
   geometry::proto::OrientedBoxSE3 test_oriented_box{
       random_element<geometry::proto::OrientedBoxSE3>(InOut{rng})};
-  // We don't use these when converting to/from ROS2
+  // We don't use frame IDs when converting to/from ROS2.
   constexpr int DIMS = 3;
   test_oriented_box.mutable_reference_from_box()
       ->mutable_into()

--- a/resim/transforms/proto/BUILD
+++ b/resim/transforms/proto/BUILD
@@ -172,3 +172,19 @@ cc_library(
         "//resim/transforms:se3",
     ],
 )
+
+cc_library(
+    name = "fuzz_helpers",
+    testonly = True,
+    srcs = ["fuzz_helpers.cc"],
+    hdrs = ["fuzz_helpers.hh"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":se3_proto_cc",
+        ":se3_to_proto",
+        "//resim/testing:fuzz_helpers",
+        "//resim/testing:random_matrix",
+        "//resim/transforms:se3",
+        "//resim/utils:inout",
+    ],
+)

--- a/resim/transforms/proto/BUILD
+++ b/resim/transforms/proto/BUILD
@@ -188,3 +188,15 @@ cc_library(
         "//resim/utils:inout",
     ],
 )
+
+cc_test(
+    name = "fuzz_helpers_test",
+    srcs = ["fuzz_helpers_test.cc"],
+    deps = [
+        ":fuzz_helpers",
+        ":se3_proto_cc",
+        "//resim/testing:fuzz_helpers",
+        "//resim/utils:inout",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/resim/transforms/proto/fuzz_helpers.cc
+++ b/resim/transforms/proto/fuzz_helpers.cc
@@ -1,0 +1,15 @@
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include "resim/transforms/proto/fuzz_helpers.hh"
+
+namespace resim::transforms::proto {
+
+bool verify_equality(const SE3 &a, const SE3 &b) {
+  return unpack(a).is_approx(unpack(b));
+}
+
+}  // namespace resim::transforms::proto

--- a/resim/transforms/proto/fuzz_helpers.hh
+++ b/resim/transforms/proto/fuzz_helpers.hh
@@ -1,0 +1,31 @@
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#pragma once
+
+#include "resim/testing/fuzz_helpers.hh"
+#include "resim/testing/random_matrix.hh"
+#include "resim/transforms/proto/se3.pb.h"
+#include "resim/transforms/proto/se3_to_proto.hh"
+#include "resim/transforms/se3.hh"
+#include "resim/utils/inout.hh"
+
+namespace resim::transforms::proto {
+
+template <typename Rng>
+SE3 random_element(TypeTag<SE3> /*unused*/, InOut<Rng> rng) {
+  SE3 result;
+  const transforms::SE3 pose{transforms::SE3::exp(
+      testing::random_vector<transforms::SE3::TangentVector>(*rng),
+      Frame<transforms::SE3::DIMS>::new_frame(),
+      Frame<transforms::SE3::DIMS>::new_frame())};
+  pack(pose, &result);
+  return result;
+}
+
+bool verify_equality(const SE3 &a, const SE3 &b);
+
+}  // namespace resim::transforms::proto

--- a/resim/transforms/proto/fuzz_helpers_test.cc
+++ b/resim/transforms/proto/fuzz_helpers_test.cc
@@ -1,0 +1,32 @@
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include "resim/transforms/proto/fuzz_helpers.hh"
+
+#include <gtest/gtest.h>
+
+#include <random>
+
+#include "resim/testing/fuzz_helpers.hh"
+#include "resim/utils/inout.hh"
+
+namespace resim::transforms::proto {
+
+TEST(FuzzHelpersTest, TestSE3Equal) {
+  // SETUP
+  constexpr std::size_t SEED = 3481U;
+  std::mt19937 rng{SEED};
+
+  const SE3 se3{random_element<SE3>(InOut{rng})};
+  const SE3 different_se3{random_element<SE3>(InOut{rng})};
+
+  // ACTION / VERIFICATION
+  EXPECT_TRUE(verify_equality(se3, se3));
+  EXPECT_FALSE(verify_equality(se3, different_se3));
+  EXPECT_FALSE(verify_equality(different_se3, se3));
+}
+
+}  // namespace resim::transforms::proto


### PR DESCRIPTION
## Description of change
Add ROS2 Converters for Oriented Boxes

## Guide to reproduce test results.
```bash
bazel test //resim/msg:oriented_box_from_ros2_test
bazel test //resim/transforms/proto:fuzz_helpers_test
bazel test //resim/geometry/proto:fuzz_helpers_test
bazel test //resim/msg:fuzz_helpers_test
```

## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
