### PR TITLE
Upgrade our MCAP Dependency

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -85,9 +85,11 @@ def resim_core_dependencies():
         http_archive,
         name = "mcap",
         build_file = "@resim_open_core//resim/third_party/mcap:mcap.BUILD",
-        sha256 = "5d30a67c0c282e478e9342127129c3b4138c1464f42c25ba083415ced0824437",
-        strip_prefix = "mcap-releases-cpp-v0.5.0",
-        urls = ["https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v0.5.0.zip"],
+        sha256 =
+            "2833f72344308ea58639f3b363a0cf17669580ae7ab435f43f3b104cff6ef548",
+        strip_prefix = "mcap-releases-cpp-v0.8.0/cpp/mcap",
+        urls =
+            ["https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v0.8.0.tar.gz"],
     )
 
     maybe(
@@ -279,7 +281,10 @@ def resim_core_dependencies():
         http_archive,
         name = "com_github_mvukov_rules_ros2",
         patch_args = ["-p1"],
-        patches = ["@resim_open_core//resim/third_party/ros2:flto.patch"],
+        patches = [
+            "@resim_open_core//resim/third_party/ros2:flto.patch",
+            "@resim_open_core//resim/third_party/ros2:copts.patch",
+        ],
         sha256 = "56e78c7910c6684a051c0754cc58739484800b11a64e542194a25c34dc8bc488",
         strip_prefix = "rules_ros2-e5ca0b2f86a3e9f1b97ff8d6b2a8e3e03185ad81",
         url = "https://github.com/mvukov/rules_ros2/archive/e5ca0b2f86a3e9f1b97ff8d6b2a8e3e03185ad81.tar.gz",

--- a/deps.bzl
+++ b/deps.bzl
@@ -85,11 +85,10 @@ def resim_core_dependencies():
         http_archive,
         name = "mcap",
         build_file = "@resim_open_core//resim/third_party/mcap:mcap.BUILD",
-        sha256 =
-            "2833f72344308ea58639f3b363a0cf17669580ae7ab435f43f3b104cff6ef548",
-        strip_prefix = "mcap-releases-cpp-v0.8.0/cpp/mcap",
+        sha256 = "11a6badecac2b10e9687e912648a6e9679ef8731e4ab9570346ae9845ae64a65",
+        strip_prefix = "mcap-releases-cpp-v1.2.0/cpp/mcap",
         urls =
-            ["https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v0.8.0.tar.gz"],
+            ["https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v1.2.0.tar.gz"],
     )
 
     maybe(
@@ -281,10 +280,7 @@ def resim_core_dependencies():
         http_archive,
         name = "com_github_mvukov_rules_ros2",
         patch_args = ["-p1"],
-        patches = [
-            "@resim_open_core//resim/third_party/ros2:flto.patch",
-            "@resim_open_core//resim/third_party/ros2:copts.patch",
-        ],
+        patches = ["@resim_open_core//resim/third_party/ros2:flto.patch"],
         sha256 = "56e78c7910c6684a051c0754cc58739484800b11a64e542194a25c34dc8bc488",
         strip_prefix = "rules_ros2-e5ca0b2f86a3e9f1b97ff8d6b2a8e3e03185ad81",
         url = "https://github.com/mvukov/rules_ros2/archive/e5ca0b2f86a3e9f1b97ff8d6b2a8e3e03185ad81.tar.gz",

--- a/resim/third_party/mcap/mcap.BUILD
+++ b/resim/third_party/mcap/mcap.BUILD
@@ -2,8 +2,8 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 
 cc_library(
     name = "mcap",
-    hdrs = glob(["cpp/mcap/include/mcap/**"]),
-    includes = ["cpp/mcap/include"],
+    hdrs = glob(["include/mcap/**"]),
+    includes = ["include"],
     visibility = ["//visibility:public"],
     deps = [
         "@lz4//:liblz4",


### PR DESCRIPTION
## Description of change
Upgrade our MCAP dependency to a more recent version.

## Guide to reproduce test results.
```bash
full_test () {                                                                                                       
   TARGET="$1"                                                                                                       
   VALGRIND="valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --error-exitcode=1" 

   bazel test --runs_per_test=100 "${TARGET}" && \                                                                   
   bazel test --test_timeout=3600 --run_under="${VALGRIND}" "${TARGET}" --test_output=all                            
}
full_test //resim/utils:mcap_logger_test
```
## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
