### PR TITLE
Add detection arrays as a convertible type

### DIFF
--- a/docs/resim/curves/index.md
+++ b/docs/resim/curves/index.md
@@ -89,8 +89,8 @@ first and second derivatives. There are two varieties of `TwoJet`, namely
 `TwoJetR` and `TwoJetL`. The distinction between them is that `TwoJetR`
 represents its first and second derivatives as *right tangent vectors*
 (described fully in [Using SO(3) and
-SE(3)](/resim/transforms/using_liegroups) and [Lie Group
-Derivatives](/resim/transforms/liegroup_derivatives)), whereas `TwoJetL`
+SE(3)](../transforms/using_liegroups.md) and [Lie Group
+Derivatives](../transforms/liegroup_derivatives.md)), whereas `TwoJetL`
 uses *left tangent vectors*. For simplicity, we'll use the
 `actor::state::RigidBodyState` abstraction in our example to make defining
 these easy. That way, we can write clearer code that doesn't require us reason

--- a/resim/msg/converter_plugin.hh
+++ b/resim/msg/converter_plugin.hh
@@ -33,7 +33,9 @@ namespace resim::msg {
 //
 //
 // // This function performs the message conversion and returns an ERROR status
-// // if this plugin doesn't know how to do it.
+// // if this plugin doesn't know how to do it. This function is expected to
+// // assign an allocator to resim_message and use it to alloc the contents
+// // thereof. The ConverterPlugin will dealloc the contents after calling this.
 // // @param[in] ros2_message_type - The message type we want to try to convert
 // // @param[in] ros2_message - A pointer to a ROS-style byte array containing
 // //                           a serialized ros2 message to convert.
@@ -53,7 +55,10 @@ namespace resim::msg {
 // // This function returns the schema info for the type that this plugin
 // // converts ros2_message_type to. This schema info is designed so we can
 // // write the result to an MCAP file and so it should fit one of the profiles
-// // here: https://mcap.dev/spec/registry#schema-encodings
+// // here: https://mcap.dev/spec/registry#schema-encodings. This function is
+// // expected to assign allocators to the schema_info and use them to alloc its
+// // contents. The ConverterPlugin will dealloc the contents of schema_info
+// // after.
 // // @param[in] ros2_message_type - We want the schema info for the type we
 // //                                convert to *from* this type.
 // // @param[out] schema_info - The schema info for the type converted to.

--- a/resim/msg/default_converter_plugin.cc
+++ b/resim/msg/default_converter_plugin.cc
@@ -10,7 +10,6 @@
 #include <rclcpp/serialization.hpp>
 #include <rclcpp/serialized_message.hpp>
 #include <string>
-#include <string_view>
 #include <unordered_map>
 
 #include "resim/assert/assert.hh"

--- a/resim/msg/default_converter_plugin.cc
+++ b/resim/msg/default_converter_plugin.cc
@@ -140,7 +140,9 @@ const std::unordered_map<std::string, ConverterFunctions> converters_map = {
     {"vision_msgs/msg/Detection3D",
      {convert_message<vision_msgs::msg::Detection3D>,
       generate_type_schema<vision_msgs::msg::Detection3D>}},
-
+    {"vision_msgs/msg/Detection3DArray",
+     {convert_message<vision_msgs::msg::Detection3DArray>,
+      generate_type_schema<vision_msgs::msg::Detection3DArray>}},
 };
 
 }  // namespace

--- a/resim/msg/default_converter_plugin_test.cc
+++ b/resim/msg/default_converter_plugin_test.cc
@@ -47,7 +47,8 @@ using Ros2Types = ::testing::Types<
     std_msgs::msg::Header,
     tf2_msgs::msg::TFMessage,
     vision_msgs::msg::BoundingBox3D,
-    vision_msgs::msg::Detection3D>;
+    vision_msgs::msg::Detection3D,
+    vision_msgs::msg::Detection3DArray>;
 
 template <typename T>
 struct DefaultConverterPluginTest : public ::testing::Test {

--- a/resim/msg/detection.proto
+++ b/resim/msg/detection.proto
@@ -22,3 +22,8 @@ message Detection3D {
     // TODO(mikebauer) Add source_cloud field when we need it to match ROS
     // vision_msgs::msg::Detection3D message.
 }
+
+message Detection3DArray {
+    Header               header     = 1;
+    repeated Detection3D detections = 2;
+}

--- a/resim/msg/detection_from_ros2.cc
+++ b/resim/msg/detection_from_ros2.cc
@@ -25,4 +25,25 @@ vision_msgs::msg::Detection3D convert_to_ros2(const Detection3D &resim_msg) {
   return result;
 }
 
+Detection3DArray convert_from_ros2(
+    const vision_msgs::msg::Detection3DArray &ros2_msg) {
+  Detection3DArray result;
+  result.mutable_header()->CopyFrom(convert_from_ros2(ros2_msg.header));
+  for (const auto &detection : ros2_msg.detections) {
+    result.add_detections()->CopyFrom(convert_from_ros2(detection));
+  }
+  return result;
+}
+
+vision_msgs::msg::Detection3DArray convert_to_ros2(
+    const Detection3DArray &resim_msg) {
+  vision_msgs::msg::Detection3DArray result;
+  result.header = convert_to_ros2(resim_msg.header());
+  result.detections.reserve(resim_msg.detections_size());
+  for (const auto &detection : resim_msg.detections()) {
+    result.detections.push_back(convert_to_ros2(detection));
+  }
+  return result;
+}
+
 }  // namespace resim::msg

--- a/resim/msg/detection_from_ros2.hh
+++ b/resim/msg/detection_from_ros2.hh
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <vision_msgs/msg/detection3_d.hpp>
+#include <vision_msgs/msg/detection3_d_array.hpp>
 
 #include "resim/msg/detection.pb.h"
 
@@ -17,5 +18,11 @@ namespace resim::msg {
 Detection3D convert_from_ros2(const vision_msgs::msg::Detection3D &ros2_msg);
 
 vision_msgs::msg::Detection3D convert_to_ros2(const Detection3D &resim_msg);
+
+Detection3DArray convert_from_ros2(
+    const vision_msgs::msg::Detection3DArray &ros2_msg);
+
+vision_msgs::msg::Detection3DArray convert_to_ros2(
+    const Detection3DArray &resim_msg);
 
 }  // namespace resim::msg

--- a/resim/msg/detection_from_ros2_test.cc
+++ b/resim/msg/detection_from_ros2_test.cc
@@ -15,18 +15,25 @@
 
 namespace resim::msg {
 
-TEST(Detection3DFromRos2Test, TestRoundTrip) {
+using Types = ::testing::Types<Detection3D, Detection3DArray>;
+
+template <typename T>
+class Detection3DFromRos2Test : public ::testing::Test {};
+
+TYPED_TEST_SUITE(Detection3DFromRos2Test, Types);
+
+TYPED_TEST(Detection3DFromRos2Test, TestRoundTrip) {
   // SETUP
   constexpr std::size_t SEED = 913U;
   std::mt19937 rng{SEED};
-  const Detection3D test_detection{random_element<Detection3D>(InOut{rng})};
+  const TypeParam test_element{random_element<TypeParam>(InOut{rng})};
 
   // ACTION
-  const Detection3D round_tripped{
-      convert_from_ros2(convert_to_ros2(test_detection))};
+  const TypeParam round_tripped{
+      convert_from_ros2(convert_to_ros2(test_element))};
 
   // VERIFICATION
-  EXPECT_TRUE(verify_equality(test_detection, round_tripped));
+  EXPECT_TRUE(verify_equality(test_element, round_tripped));
 }
 
 }  // namespace resim::msg

--- a/resim/msg/fuzz_helpers.cc
+++ b/resim/msg/fuzz_helpers.cc
@@ -101,6 +101,19 @@ bool verify_equality(const Detection3D &a, const Detection3D &b) {
          verify_equality(a.bbox(), b.bbox());
 }
 
+bool verify_equality(const Detection3DArray &a, const Detection3DArray &b) {
+  if (not verify_equality(a.header(), b.header()) or
+      a.detections_size() != b.detections_size()) {
+    return false;
+  }
+  for (int ii = 0; ii < a.detections_size(); ++ii) {
+    if (not verify_equality(a.detections(ii), b.detections(ii))) {
+      return false;
+    }
+  }
+  return true;
+}
+
 bool verify_equality(const NavSatFix &a, const NavSatFix &b) {
   constexpr int COV_DIM = 9;
   for (int ii = 0; ii < COV_DIM; ++ii) {

--- a/resim/msg/fuzz_helpers.hh
+++ b/resim/msg/fuzz_helpers.hh
@@ -146,6 +146,24 @@ Detection3D random_element(TypeTag<Detection3D> /*unused*/, InOut<Rng> rng) {
 }
 
 template <typename Rng>
+Detection3DArray random_element(
+    TypeTag<Detection3DArray> /*unused*/,
+    InOut<Rng> rng) {
+  Detection3DArray result;
+  result.mutable_header()->CopyFrom(random_element<Header>(rng));
+
+  constexpr int MIN_ELEMENTS = 1;
+  constexpr int MAX_ELEMENTS = 10;
+  std::uniform_int_distribution<int> dist{MIN_ELEMENTS, MAX_ELEMENTS};
+  const int num_elements = dist(*rng);
+  for (int ii = 0; ii < num_elements; ++ii) {
+    result.add_detections()->CopyFrom(random_element<Detection3D>(rng));
+  }
+
+  return result;
+}
+
+template <typename Rng>
 NavSatFix random_element(TypeTag<NavSatFix> /*unused*/, InOut<Rng> rng) {
   constexpr std::array STATUSES = {
       NavSatFix::STATUS_NO_FIX,
@@ -199,6 +217,8 @@ bool verify_equality(
 bool verify_equality(const Odometry &a, const Odometry &b);
 
 bool verify_equality(const Detection3D &a, const Detection3D &b);
+
+bool verify_equality(const Detection3DArray &a, const Detection3DArray &b);
 
 bool verify_equality(const NavSatFix &a, const NavSatFix &b);
 

--- a/resim/msg/fuzz_helpers_test.cc
+++ b/resim/msg/fuzz_helpers_test.cc
@@ -243,6 +243,37 @@ TEST(FuzzHelpersTest, TestDetectionEqual) {
   EXPECT_FALSE(verify_equality(detection_different_bbox, detection));
 }
 
+TEST(FuzzHelpersTest, TestDetectionArrayEqual) {
+  // SETUP
+  constexpr std::size_t SEED = 913U;
+  std::mt19937 rng{SEED};
+
+  const Detection3DArray array{random_element<Detection3DArray>(InOut{rng})};
+
+  Detection3DArray array_different_header{array};
+  array_different_header.mutable_header()->CopyFrom(
+      random_element<Header>(InOut{rng}));
+
+  Detection3DArray array_different_size{array};
+  ASSERT_GT(array_different_size.detections_size(), 0U);
+  array_different_size.mutable_detections()->erase(
+      array_different_size.detections().begin());
+
+  Detection3DArray array_different_element{array};
+  ASSERT_GT(array_different_element.detections_size(), 0U);
+  array_different_element.mutable_detections(0)->CopyFrom(
+      random_element<Detection3D>(InOut{rng}));
+
+  // ACTION / VERIFICATION
+  EXPECT_TRUE(verify_equality(array, array));
+  EXPECT_FALSE(verify_equality(array, array_different_header));
+  EXPECT_FALSE(verify_equality(array, array_different_size));
+  EXPECT_FALSE(verify_equality(array, array_different_element));
+  EXPECT_FALSE(verify_equality(array_different_header, array));
+  EXPECT_FALSE(verify_equality(array_different_size, array));
+  EXPECT_FALSE(verify_equality(array_different_element, array));
+}
+
 TEST(FuzzHelpersTest, TestNavSatFixEqual) {
   // SETUP
   constexpr std::size_t SEED = 913U;


### PR DESCRIPTION
## Description of change
Make it so we can convert `vision_msgs/msg/Detection3DArray` messages.
Prev PRs:
 - #32

## Guide to reproduce test results.
```
bazel test //resim/msg/...
```
## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
