### PR TITLE
Set up protobuf generated python

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -94,9 +94,9 @@ def resim_core_dependencies():
     maybe(
         http_archive,
         name = "rules_python",
-        sha256 = "cdf6b84084aad8f10bf20b46b77cb48d83c319ebe6458a18e9d2cebf57807cdd",
-        strip_prefix = "rules_python-0.8.1",
-        url = "https://github.com/bazelbuild/rules_python/archive/refs/tags/0.8.1.tar.gz",
+        sha256 = "5868e73107a8e85d8f323806e60cad7283f34b32163ea6ff1020cf27abef6036",
+        strip_prefix = "rules_python-0.25.0",
+        url = "https://github.com/bazelbuild/rules_python/archive/refs/tags/0.25.0.tar.gz",
     )
 
     # Hedron's Compile Commands Extractor for Bazel
@@ -114,10 +114,10 @@ def resim_core_dependencies():
     maybe(
         http_archive,
         name = "rules_proto",
-        sha256 = "e017528fd1c91c5a33f15493e3a398181a9e821a804eb7ff5acdd1d2d6c2b18d",
-        strip_prefix = "rules_proto-4.0.0-3.20.0",
+        sha256 = "dc3fb206a2cb3441b485eb1e423165b231235a1ea9b031b4433cf7bc1fa460dd",
+        strip_prefix = "rules_proto-5.3.0-21.7",
         urls = [
-            "https://github.com/bazelbuild/rules_proto/archive/refs/tags/4.0.0-3.20.0.tar.gz",
+            "https://github.com/bazelbuild/rules_proto/archive/refs/tags/5.3.0-21.7.tar.gz",
         ],
     )
 

--- a/resim/msg/BUILD
+++ b/resim/msg/BUILD
@@ -6,6 +6,7 @@
 load("@com_github_mvukov_rules_ros2//ros2:cc_defs.bzl", "ros2_cpp_binary", "ros2_cpp_test")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_proto_library", "cc_test")
 load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_python//python:proto.bzl", "py_proto_library")
 
 ################################################################################
 # Protos
@@ -21,6 +22,13 @@ proto_library(
 
 cc_proto_library(
     name = "header_proto_cc",
+    deps = [
+        ":header_proto",
+    ],
+)
+
+py_proto_library(
+    name = "header_proto_py",
     deps = [
         ":header_proto",
     ],
@@ -42,6 +50,13 @@ cc_proto_library(
     ],
 )
 
+py_proto_library(
+    name = "transform_proto_py",
+    deps = [
+        ":transform_proto",
+    ],
+)
+
 proto_library(
     name = "pose_proto",
     srcs = ["pose.proto"],
@@ -52,6 +67,13 @@ proto_library(
 
 cc_proto_library(
     name = "pose_proto_cc",
+    deps = [
+        ":pose_proto",
+    ],
+)
+
+py_proto_library(
+    name = "pose_proto_py",
     deps = [
         ":pose_proto",
     ],
@@ -73,6 +95,13 @@ cc_proto_library(
     ],
 )
 
+py_proto_library(
+    name = "odometry_proto_py",
+    deps = [
+        ":odometry_proto",
+    ],
+)
+
 proto_library(
     name = "detection_proto",
     srcs = ["detection.proto"],
@@ -89,6 +118,13 @@ cc_proto_library(
     ],
 )
 
+py_proto_library(
+    name = "detection_proto_py",
+    deps = [
+        ":detection_proto",
+    ],
+)
+
 proto_library(
     name = "navsat_proto",
     srcs = ["navsat.proto"],
@@ -99,6 +135,13 @@ proto_library(
 
 cc_proto_library(
     name = "navsat_proto_cc",
+    deps = [
+        ":navsat_proto",
+    ],
+)
+
+py_proto_library(
+    name = "navsat_proto_py",
     deps = [
         ":navsat_proto",
     ],

--- a/resim/toolchain/check_python_test.py
+++ b/resim/toolchain/check_python_test.py
@@ -7,7 +7,7 @@ class TestPythonVersion(unittest.TestCase):
         version_info = sys.version_info 
         self.assertEqual(version_info[0], 3)
         self.assertEqual(version_info[1], 10)
-        self.assertEqual(version_info[2], 2)
+        self.assertEqual(version_info[2], 12)
 
 if __name__ == '__main__':
     unittest.main()

--- a/transitive_deps.bzl
+++ b/transitive_deps.bzl
@@ -37,6 +37,7 @@ def resim_core_transitive_dependencies():
         # Available versions are listed in @rules_python//python:versions.bzl.
         # We recommend using the same version your team is already standardized on.
         python_version = "3.10",
+        ignore_root_user_error = True,
     )
 
     hedron_compile_commands_setup()
@@ -60,4 +61,5 @@ def resim_core_transitive_dependencies():
     python_register_toolchains(
         name = "rules_ros2_python",
         python_version = "3.10",
+        ignore_root_user_error = True,
     )


### PR DESCRIPTION
## Description of change
Upgrade rules_python and protobuf so we can set up protobuf generated python.

## Guide to reproduce test results.
```
bazel build //resim/msg/...
bazel test //...
```
## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
