### PR TITLE
Add id field to 3D detections

### DIFF
--- a/resim/msg/detection.proto
+++ b/resim/msg/detection.proto
@@ -19,6 +19,5 @@ message Detection3D {
     //
     resim.geometry.proto.OrientedBoxSE3 bbox = 3;
 
-    // TODO(mikebauer) Add source_cloud field when we need it to match ROS
-    // vision_msgs::msg::Detection3D message.
+    string id = 4;
 }

--- a/resim/msg/detection_from_ros2.cc
+++ b/resim/msg/detection_from_ros2.cc
@@ -15,6 +15,7 @@ Detection3D convert_from_ros2(const vision_msgs::msg::Detection3D &ros2_msg) {
   Detection3D result;
   result.mutable_header()->CopyFrom(convert_from_ros2(ros2_msg.header));
   result.mutable_bbox()->CopyFrom(convert_from_ros2(ros2_msg.bbox));
+  result.set_id(ros2_msg.id);
   return result;
 }
 
@@ -22,6 +23,7 @@ vision_msgs::msg::Detection3D convert_to_ros2(const Detection3D &resim_msg) {
   vision_msgs::msg::Detection3D result;
   result.header = convert_to_ros2(resim_msg.header());
   result.bbox = convert_to_ros2(resim_msg.bbox());
+  result.id = resim_msg.id();
   return result;
 }
 

--- a/resim/msg/fuzz_helpers.cc
+++ b/resim/msg/fuzz_helpers.cc
@@ -98,7 +98,7 @@ bool verify_equality(const Odometry &a, const Odometry &b) {
 
 bool verify_equality(const Detection3D &a, const Detection3D &b) {
   return verify_equality(a.header(), b.header()) and
-         verify_equality(a.bbox(), b.bbox());
+         verify_equality(a.bbox(), b.bbox()) and a.id() == b.id();
 }
 
 bool verify_equality(const NavSatFix &a, const NavSatFix &b) {

--- a/resim/msg/fuzz_helpers.hh
+++ b/resim/msg/fuzz_helpers.hh
@@ -142,6 +142,7 @@ Detection3D random_element(TypeTag<Detection3D> /*unused*/, InOut<Rng> rng) {
       transforms::Frame<DIMS>::null_frame().id().to_string());
 
   result.mutable_bbox()->CopyFrom(bbox);
+  result.set_id(UUID::new_uuid().to_string());
   return result;
 }
 

--- a/resim/msg/fuzz_helpers_test.cc
+++ b/resim/msg/fuzz_helpers_test.cc
@@ -236,11 +236,16 @@ TEST(FuzzHelpersTest, TestDetectionEqual) {
   detection_different_bbox.mutable_bbox()->CopyFrom(
       random_element<geometry::proto::OrientedBoxSE3>(InOut{rng}));
 
+  Detection3D detection_different_id{detection};
+  detection_different_id.set_id(detection.id() + "_different");
+
   // ACTION / VERIFICATION
   EXPECT_TRUE(verify_equality(detection, detection));
   EXPECT_FALSE(verify_equality(detection, detection_different_header));
   EXPECT_FALSE(verify_equality(detection, detection_different_bbox));
   EXPECT_FALSE(verify_equality(detection_different_bbox, detection));
+  EXPECT_FALSE(verify_equality(detection, detection_different_id));
+  EXPECT_FALSE(verify_equality(detection_different_id, detection));
 }
 
 TEST(FuzzHelpersTest, TestNavSatFixEqual) {


### PR DESCRIPTION
## Description of change
Add an ID field to 3D detections to more closely match [vision_msgs::msg::Detection3D](https://github.com/ros-perception/vision_msgs/blob/ros2/vision_msgs/msg/Detection3D.msg).

## Guide to reproduce test results.
```bash
bazel test //resim/msg/...
```
## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
