### PR TITLE
Add the required prefix to the requirements_lock target

### DIFF
--- a/transitive_deps.bzl
+++ b/transitive_deps.bzl
@@ -70,5 +70,5 @@ def resim_core_transitive_dependencies():
     # requirements_lock.txt.
     pip_parse(
         name = "resim_python_deps",
-        requirements_lock = "//:requirements_lock.txt",
+        requirements_lock = "@resim_open_core//:requirements_lock.txt",
     )


### PR DESCRIPTION
## Description of change
Add the needed prefix to the requireents_lock target which causes failures in dependent repos if not present. A short explanation: Without the prefix, dependent repos look for requirements_lock.txt in their own workspace which is not the desired behavior.

## Guide to reproduce test results.
 * Change one of our dependent repos to depend on this branch.
 * Verify that things now work as expected.
 
## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
