### PR TITLE
Add converter plugin helpers

### DIFF
--- a/resim/ros2/BUILD
+++ b/resim/ros2/BUILD
@@ -261,6 +261,7 @@ cc_binary(
 cc_library(
     name = "converter_plugin_helpers",
     hdrs = ["converter_plugin_helpers.hh"],
+    visibility = ["//visibility:public"],
     deps = [
         ":converter_plugin_types",
         "//resim/assert",

--- a/resim/ros2/BUILD
+++ b/resim/ros2/BUILD
@@ -244,6 +244,7 @@ cc_binary(
     linkshared = True,
     visibility = ["//resim/ros2:__subpackages__"],
     deps = [
+        ":converter_plugin_helpers",
         ":converter_plugin_types",
         ":detection_from_ros2",
         ":header_from_ros2",
@@ -253,6 +254,15 @@ cc_binary(
         ":pose_from_ros2",
         ":time_from_ros2",
         ":transform_from_ros2",
+        "//resim/assert",
+    ],
+)
+
+cc_library(
+    name = "converter_plugin_helpers",
+    hdrs = ["converter_plugin_helpers.hh"],
+    deps = [
+        ":converter_plugin_types",
         "//resim/assert",
         "//resim/utils/proto:dependency_file_descriptor_set",
         "@ros2_rclcpp//:rclcpp",

--- a/resim/ros2/converter_plugin_helpers.hh
+++ b/resim/ros2/converter_plugin_helpers.hh
@@ -1,0 +1,91 @@
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+// converter_plugin_helpers.hh
+//
+// This file contains some function templates that can be be used to create
+// converter plugins for custom message types. In particular, because such
+// converters are typically defined in other namespaces, we allow users to pass
+// in a ConverterFunctor equipped with whatever converters they would like. For
+// usage examples, see default_converter_plugin.cc
+
+#include <cstring>
+#include <rclcpp/serialization.hpp>
+#include <rclcpp/serialized_message.hpp>
+#include <string>
+
+#include "resim/assert/assert.hh"
+#include "resim/ros2/converter_plugin_types.h"
+#include "resim/utils/proto/dependency_file_descriptor_set.hh"
+
+namespace resim::ros2 {
+
+// Convert a serialized ros2 message to a serialized resim message.
+// @tparam[in] Ros2Type: The message type of the ros2_message.
+// @tparam[in] ConverterFunctor: A functor with the needed converter for this
+//             type.
+// @param[in] ros2_message: The serialized message to convert.
+// @param[out] resim_message: The converted resim message.
+template <typename Ros2Type, typename ConverterFunctor>
+void convert_message(
+    const rcutils_uint8_array_t *const ros2_message,
+    rcutils_uint8_array_t *const resim_message) {
+  REASSERT(ros2_message != nullptr);
+  REASSERT(ros2_message->buffer != nullptr);
+  REASSERT(resim_message != nullptr);
+
+  rclcpp::Serialization<Ros2Type> serialization;
+
+  Ros2Type deserialized;
+  rclcpp::SerializedMessage message{*ros2_message};
+  serialization.deserialize_message(&message, &deserialized);
+  const auto converted_message = ConverterFunctor()(deserialized);
+
+  const std::size_t converted_size = converted_message.ByteSizeLong();
+
+  rcl_serialized_message_t &result = *resim_message;
+  result.allocator = ros2_message->allocator;
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+  result.buffer = reinterpret_cast<uint8_t *>(
+      result.allocator.allocate(converted_size, result.allocator.state));
+  result.buffer_length = converted_size;
+  result.buffer_capacity = converted_size;
+  converted_message.SerializeToArray(result.buffer, converted_size);
+}
+
+// Get the schema info for the type we want to convert to.
+// @tparam[in] Ros2Type: The message type of the ros2_message.
+// @tparam[in] ConverterFunctor: A functor with the needed converter for this
+//             type.
+// @param[out] schema_info: The schema info for the type we're converting to.
+template <typename Ros2Type, typename ConverterFunctor>
+void generate_type_schema(ReSimConverterSchemaInfo *schema_info) {
+  using ReSimType = decltype(ConverterFunctor()(std::declval<Ros2Type>()));
+  REASSERT(schema_info != nullptr);
+  const auto allocator = rcl_get_default_allocator();
+
+  const auto &descriptor = *ReSimType::GetDescriptor();
+  const std::string name = descriptor.full_name();
+  const std::string data = dependency_file_descriptor_set(descriptor);
+
+  const auto copy_string_to_uint8_array =
+      [&allocator](const std::string &string, rcutils_uint8_array_t &array) {
+        array.allocator = allocator;
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        array.buffer = reinterpret_cast<uint8_t *>(
+            allocator.allocate(string.size(), allocator.state));
+        REASSERT(array.buffer != nullptr);
+        array.buffer_length = string.size();
+        array.buffer_capacity = string.size();
+        std::memcpy(array.buffer, string.data(), string.size());
+      };
+
+  copy_string_to_uint8_array(name, schema_info->name);
+  schema_info->encoding = "protobuf";
+  copy_string_to_uint8_array(data, schema_info->data);
+}
+
+}  // namespace resim::ros2


### PR DESCRIPTION
## Description of change
Factor some of the default converter plugin functions out into a header so they can be used when defining other plugins.

## Guide to reproduce test results.
```bash
bazel test //resim/ros2:default_converter_plugin_test
```
## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
