### PR TITLE
Remove mypy comments so trunk check on release passes

### DIFF
--- a/resim/metrics/python/metrics.py
+++ b/resim/metrics/python/metrics.py
@@ -21,7 +21,6 @@ from typing import Any, Callable, Dict, Generic, List, Optional, Set, TypeAlias,
 
 import numpy as np
 
-# trunk-ignore(mypy/attr-defined)
 from resim.metrics.proto import metrics_pb2
 from resim.metrics.python.metrics_utils import (
     ResimMetricsOutput,

--- a/resim/metrics/python/metrics_utils.py
+++ b/resim/metrics/python/metrics_utils.py
@@ -15,9 +15,7 @@ from typing import Optional, Set, Tuple
 from google.protobuf import timestamp_pb2
 import numpy as np
 
-# trunk-ignore(mypy/attr-defined)
 from resim.metrics.proto import metrics_pb2
-# trunk-ignore(mypy/attr-defined)
 from resim.utils.proto import uuid_pb2
 
 


### PR DESCRIPTION
## Description of change

Some comments which existed to make mypy pass now cause `trunk check` to fail on releases, as `mypy` is temporarily disabled. We therefore (again, probably temporarily) remove those comments.

## Guide to reproduce test results.

`trunk check`

## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
