### PR TITLE
Add polygon utils and distance function

### DIFF
--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -66,6 +66,7 @@ py_package(
         "resim.utils",
     ],
     deps = [
+        "//resim/geometry/python:polygon_distance.so",
         "//resim/metrics:dice_coefficient",
         "//resim/metrics:fetch_job_metrics",
         "//resim/metrics/python:metrics",

--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -66,7 +66,7 @@ py_package(
         "resim.utils",
     ],
     deps = [
-        "//resim/geometry/python:polygon_distance.so",
+        "//resim/geometry/python:polygon_distance_python.so",
         "//resim/metrics:dice_coefficient",
         "//resim/metrics:fetch_job_metrics",
         "//resim/metrics/python:metrics",

--- a/resim/geometry/BUILD
+++ b/resim/geometry/BUILD
@@ -172,3 +172,45 @@ cc_test(
         "@libeigen//:eigen",
     ],
 )
+
+cc_library(
+    name = "polygon_utils",
+    srcs = ["polygon_utils.cc"],
+    hdrs = ["polygon_utils.hh"],
+    deps = [
+        "//resim/assert",
+        "@libeigen//:eigen",
+    ],
+)
+
+cc_test(
+    name = "polygon_utils_test",
+    srcs = ["polygon_utils_test.cc"],
+    deps = [
+        ":polygon_utils",
+        "@com_google_googletest//:gtest_main",
+        "@libeigen//:eigen",
+    ],
+)
+
+cc_library(
+    name = "polygon_distance",
+    srcs = ["polygon_distance.cc"],
+    hdrs = ["polygon_distance.hh"],
+    deps = [
+        ":gjk_algorithm",
+        ":polygon_utils",
+        "//resim/assert",
+        "@libeigen//:eigen",
+    ],
+)
+
+cc_test(
+    name = "polygon_distance_test",
+    srcs = ["polygon_distance_test.cc"],
+    deps = [
+        ":polygon_distance",
+        "@com_google_googletest//:gtest_main",
+        "@libeigen//:eigen",
+    ],
+)

--- a/resim/geometry/BUILD
+++ b/resim/geometry/BUILD
@@ -179,6 +179,8 @@ cc_library(
     hdrs = ["polygon_utils.hh"],
     deps = [
         "//resim/assert",
+        "//resim/math:clamp",
+        "//resim/testing:random_matrix",
         "@libeigen//:eigen",
     ],
 )

--- a/resim/geometry/BUILD
+++ b/resim/geometry/BUILD
@@ -197,6 +197,7 @@ cc_library(
     name = "polygon_distance",
     srcs = ["polygon_distance.cc"],
     hdrs = ["polygon_distance.hh"],
+    visibility = ["//visibility:public"],
     deps = [
         ":gjk_algorithm",
         ":polygon_utils",

--- a/resim/geometry/polygon_distance.cc
+++ b/resim/geometry/polygon_distance.cc
@@ -44,11 +44,15 @@ double polygon_distance(
     const std::vector<Eigen::Vector2d> &polygon_a,
     const std::vector<Eigen::Vector2d> &polygon_b) {
   if (polygon_a.size() > 2U) {
-    REASSERT(not self_intersecting(polygon_a), "Self intersection detected!");
+    REASSERT(
+        not is_self_intersecting(polygon_a),
+        "Self intersection detected!");
     assert_convex(polygon_a);
   }
   if (polygon_b.size() > 2U) {
-    REASSERT(not self_intersecting(polygon_b), "Self intersection detected!");
+    REASSERT(
+        not is_self_intersecting(polygon_b),
+        "Self intersection detected!");
     assert_convex(polygon_b);
   }
 

--- a/resim/geometry/polygon_distance.cc
+++ b/resim/geometry/polygon_distance.cc
@@ -1,0 +1,75 @@
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include "resim/geometry/polygon_distance.hh"
+
+#include "resim/assert/assert.hh"
+#include "resim/geometry/gjk_algorithm.hh"
+#include "resim/geometry/polygon_utils.hh"
+
+namespace resim::geometry {
+
+namespace {
+using Vec2 = Eigen::Vector2d;
+
+// TODO(michael) Handle non-convex polygons
+void assert_convex(const std::vector<Eigen::Vector2d> &polygon) {
+  double sign = 0.;
+  const size_t num_vertices = polygon.size();
+  REASSERT(num_vertices > 2U, "Polygons must have at least three vertices.");
+
+  for (size_t ii = 0; ii < num_vertices; ++ii) {
+    const Vec2 prev_edge{polygon.at(ii) - polygon.at((ii - 1U) % num_vertices)};
+    const Vec2 next_edge{polygon.at((ii + 1U) % num_vertices) - polygon.at(ii)};
+    const double cross =
+        prev_edge(0) * next_edge(1) - prev_edge(1) * next_edge(0);
+    if (cross == 0.0) {
+      continue;
+    }
+    const double cross_sign = cross > 0.0 ? 1.0 : -1.0;
+    if (sign == 0.) {
+      sign = cross_sign;
+    } else {
+      REASSERT(sign == cross_sign, "Polygon is non-convex!");
+    }
+  }
+}
+
+}  // namespace
+
+double polygon_distance(
+    const std::vector<Eigen::Vector2d> &polygon_a,
+    const std::vector<Eigen::Vector2d> &polygon_b) {
+  if (polygon_a.size() > 2U) {
+    REASSERT(not self_intersecting(polygon_a), "Self intersection detected!");
+    assert_convex(polygon_a);
+  }
+  if (polygon_b.size() > 2U) {
+    REASSERT(not self_intersecting(polygon_b), "Self intersection detected!");
+    assert_convex(polygon_b);
+  }
+
+  const auto support_a = [&polygon_a](const Vec2 &v) {
+    return *std::max_element(
+        polygon_a.cbegin(),
+        polygon_a.cend(),
+        [&v](const Vec2 &a, const Vec2 &b) { return a.dot(v) < b.dot(v); });
+  };
+  const auto support_b = [&polygon_b](const Vec2 &v) {
+    return *std::max_element(
+        polygon_b.cbegin(),
+        polygon_b.cend(),
+        [&v](const Vec2 &a, const Vec2 &b) { return a.dot(v) < b.dot(v); });
+  };
+
+  constexpr int DIM = 2;
+  const auto maybe_distance = gjk_algorithm<DIM>(support_a, support_b);
+
+  REASSERT(maybe_distance.has_value());
+  return *maybe_distance;
+}
+
+}  // namespace resim::geometry

--- a/resim/geometry/polygon_distance.hh
+++ b/resim/geometry/polygon_distance.hh
@@ -9,8 +9,19 @@
 
 namespace resim::geometry {
 
+// Compute the minimum distance between two polygons.
+//
+// If either polygon has less than 3 elements, it's treated as a line
+// segement or a point. The polygons are expressed as sequences of
+// points representing their outer boundaries. Currently, polygon_a
+// and polygon_b must be simple and convex if they have more than
+// three elements and this is enforced. Orientation is not enforced.
+// TODO(michael) support non-convex polynomials.
+// @param[in] polygon_a - The first polygon.
+// @param[in] polygon_b - The second polygon.
+// @returns min ||a - b|| for any (a, b) in polygon_a x polygon_b.
 double polygon_distance(
     const std::vector<Eigen::Vector2d> &polygon_a,
     const std::vector<Eigen::Vector2d> &polygon_b);
 
-}
+}  // namespace resim::geometry

--- a/resim/geometry/polygon_distance.hh
+++ b/resim/geometry/polygon_distance.hh
@@ -12,7 +12,7 @@ namespace resim::geometry {
 // Compute the minimum distance between two polygons.
 //
 // If either polygon has less than 3 elements, it's treated as a line
-// segement or a point. The polygons are expressed as sequences of
+// segment or a point. The polygons are expressed as sequences of
 // points representing their outer boundaries. Currently, polygon_a
 // and polygon_b must be simple and convex if they have more than
 // three elements and this is enforced. Orientation is not enforced.

--- a/resim/geometry/polygon_distance.hh
+++ b/resim/geometry/polygon_distance.hh
@@ -1,0 +1,16 @@
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include <Eigen/Dense>
+#include <vector>
+
+namespace resim::geometry {
+
+double polygon_distance(
+    const std::vector<Eigen::Vector2d> &polygon_a,
+    const std::vector<Eigen::Vector2d> &polygon_b);
+
+}

--- a/resim/geometry/polygon_distance_test.cc
+++ b/resim/geometry/polygon_distance_test.cc
@@ -110,4 +110,18 @@ TEST(PolygonDistanceTest, TestOverlappingRectangles) {
   EXPECT_EQ(0., polygon_distance(polygon_a, polygon_b));
 }
 
+TEST(PolygonDistanceTest, TestSinglePoint) {
+  // SETUP
+  const std::vector<Eigen::Vector2d> polygon_a{
+      {0.0, 1.0},
+  };
+  const std::vector<Eigen::Vector2d> polygon_b{
+      {0.0, 1.5},
+      {1.0, 2.5},
+  };
+
+  // ACTION / VERIFICATION
+  EXPECT_EQ(polygon_distance(polygon_a, polygon_b), 0.5);
+}
+
 }  // namespace resim::geometry

--- a/resim/geometry/polygon_distance_test.cc
+++ b/resim/geometry/polygon_distance_test.cc
@@ -1,0 +1,113 @@
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include "resim/geometry/polygon_distance.hh"
+
+#include <gtest/gtest.h>
+
+#include <Eigen/Dense>
+#include <vector>
+
+#include "resim/assert/assert.hh"
+
+namespace resim::geometry {
+
+TEST(PolygonDistanceTest, TestOverlappingTriangles) {
+  // SETUP
+  const std::vector<Eigen::Vector2d> triangle_a{
+      {0.0, 1.0},
+      {1.0, -0.5},
+      {-1.0, -0.5},
+  };
+  const std::vector<Eigen::Vector2d> triangle_b{
+      {0.0, -1.0},
+      {1.0, 0.5},
+      {-1.0, 0.5},
+  };
+
+  // ACTION
+  const double distance = polygon_distance(triangle_a, triangle_b);
+
+  // VERIFICATION
+  EXPECT_EQ(distance, 0.0);
+}
+
+TEST(PolygonDistanceTest, TestNonoverlappingTriangles) {
+  // SETUP
+  const std::vector<Eigen::Vector2d> triangle_a{
+      {0.0, 1.0},
+      {1.0, -0.5},
+      {-1.0, -0.5},
+  };
+  const std::vector<Eigen::Vector2d> triangle_b{
+      {0.0, 1.5},
+      {1.0, 2.5},
+      {-1.0, 2.5},
+  };
+
+  // ACTION
+  const double distance = polygon_distance(triangle_a, triangle_b);
+
+  // VERIFICATION
+  EXPECT_EQ(distance, 0.5);
+}
+
+TEST(PolygonDistanceTest, TestSelfIntersection) {
+  // SETUP
+  const std::vector<Eigen::Vector2d> polygon_a{
+      {1.0, -0.5},
+      {-1.0, -0.5},
+      {1.0, 0.5},
+      {-1.0, 0.5},
+  };
+  const std::vector<Eigen::Vector2d> triangle_b{
+      {0.0, 1.5},
+      {1.0, 2.5},
+      {-1.0, 2.5},
+  };
+
+  // ACTION / VERIFICATION
+  EXPECT_THROW(polygon_distance(polygon_a, triangle_b), AssertException);
+}
+
+TEST(PolygonDistanceTest, TestNonConvex) {
+  // SETUP
+  const std::vector<Eigen::Vector2d> polygon_a{
+      {-1.0, 1.0},
+      {-1.0, -1.0},
+      {0.5, 0.5},
+      {1.0, -1.0},
+  };
+  const std::vector<Eigen::Vector2d> triangle_b{
+      {0.0, 1.5},
+      {1.0, 2.5},
+      {-1.0, 2.5},
+  };
+
+  // ACTION / VERIFICATION
+  EXPECT_THROW(polygon_distance(polygon_a, triangle_b), AssertException);
+}
+
+TEST(PolygonDistanceTest, TestOverlappingRectangles) {
+  // SETUP
+  const std::vector<Eigen::Vector2d> polygon_a{
+      {-1.0, -100.0},
+      {-1.0, 100.0},
+      {1.0, 100.0},
+      {1.0, -100.0},
+  };
+  const std::vector<Eigen::Vector2d> polygon_b{
+      {-100.0, -1.0},
+      {-100.0, 1.0},
+      {100.0, 1.0},
+      {100.0, -1.0},
+  };
+
+  // ACTION / VERIFICATION
+  EXPECT_EQ(0., polygon_distance(polygon_a, polygon_b));
+}
+
+}  // namespace resim::geometry

--- a/resim/geometry/polygon_utils.cc
+++ b/resim/geometry/polygon_utils.cc
@@ -7,6 +7,10 @@
 #include "resim/geometry/polygon_utils.hh"
 
 #include "resim/assert/assert.hh"
+#include "resim/math/clamp.hh"
+
+// TODO
+#include <iostream>
 
 namespace resim::geometry {
 
@@ -16,31 +20,63 @@ using Vec2 = Eigen::Vector2d;
 using Mat2 = Eigen::Matrix2d;
 constexpr int DIM = 2;
 
+double cross(const Vec2 &a, const Vec2 &b) { return a(0) * b(1) - a(1) * b(0); }
+
+bool ray_segment_intersection(
+    const Eigen::Vector2d &ray_start,
+    const Eigen::Vector2d &ray_dir,
+    const Eigen::Vector2d &segment_0,
+    const Eigen::Vector2d &segment_1) {
+  REASSERT(not ray_dir.isZero());
+  REASSERT(not segment_1.isApprox(segment_0));
+  const Vec2 segment_dir{segment_1 - segment_0};
+
+  // ray_start + ray_dir * t == segment_0 + segment_dir * s
+  const Vec2 ray_perp{-ray_dir(1), ray_dir(0)};
+  if (ray_perp.dot(segment_dir) == 0.0) {
+    return false;
+  }
+
+  const double s =
+      -ray_perp.dot(segment_0 - ray_start) / ray_perp.dot(segment_dir);
+
+  if (s < 0. or s > 1.) {
+    return false;
+  }
+  return ray_dir.dot(segment_0 - ray_start + segment_dir * s) >= 0.0;
+}
+
 }  // namespace
 
-bool edge_intersection(
+bool segment_intersection(
     const Eigen::Vector2d &a0,
     const Eigen::Vector2d &a1,
     const Eigen::Vector2d &b0,
     const Eigen::Vector2d &b1) {
-  const Mat2 edgemat{(Mat2() << (a1 - a0), -(b1 - b0)).finished()};
-
-  const Eigen::JacobiSVD<Mat2> svd{
-      edgemat,
-      Eigen::ComputeFullV | Eigen::ComputeFullU};
-
-  // Parallel edges
-  if (svd.rank() != DIM) {
-    return false;
-  }
-
-  const Vec2 intersection{svd.solve(b0 - a0)};
-
-  return !(
-      (intersection.array() < 0.0).any() or (intersection.array() > 1.0).any());
+  const Vec2 a0a1{a1 - a0};
+  const Vec2 b0b1{b1 - b0};
+  return cross(a0a1, b0 - a1) * cross(a0a1, b1 - a1) < 0. and
+         cross(b0b1, a0 - b1) * cross(b0b1, a1 - b1) < 0.;
 }
 
-bool self_intersecting(const std::vector<Eigen::Vector2d> &polygon) {
+double point_line_segment_distance(
+    const Eigen::Vector2d &point,
+    const Eigen::Vector2d &segment_start,
+    const Eigen::Vector2d &segment_end) {
+  if (segment_start.isApprox(segment_end)) {
+    return (point - segment_start).norm();
+  }
+
+  // segment(t) = segment_start + (segment_end - segment_start) * t for t in [0,
+  // 1]
+  const Vec2 dir{segment_end - segment_start};
+  double t = dir.dot(point - segment_start) / dir.squaredNorm();
+  t = math::clamp(t, 0., 1.);
+
+  return (segment_start + (segment_end - segment_start) * t - point).norm();
+}
+
+bool is_self_intersecting(const std::vector<Eigen::Vector2d> &polygon) {
   const size_t num_edges = polygon.size();
   REASSERT(num_edges > 2U, "Polygons must have at least three edges");
 
@@ -51,7 +87,7 @@ bool self_intersecting(const std::vector<Eigen::Vector2d> &polygon) {
     // when ii = 0.
     for (size_t jj = (ii + 2U); jj < num_edges and (jj - ii) < num_edges - 1U;
          ++jj) {
-      if (edge_intersection(
+      if (segment_intersection(
               polygon.at(ii),
               polygon.at(ii + 1),
               polygon.at(jj),
@@ -61,6 +97,28 @@ bool self_intersecting(const std::vector<Eigen::Vector2d> &polygon) {
     }
   }
   return false;
+}
+
+bool point_in_polygon(
+    const Eigen::Vector2d &point,
+    const std::vector<Eigen::Vector2d> &polygon) {
+  const size_t num_edges = polygon.size();
+  REASSERT(num_edges > 2U, "Polygons must have at least three edges");
+  REASSERT(
+      not is_self_intersecting(polygon),
+      "Can't detect points in non-simple polygon");
+  int intersection_count = 0;
+  for (size_t edge_start = 0U; edge_start < num_edges; ++edge_start) {
+    const size_t edge_end = (edge_start + 1U) % num_edges;
+    if (ray_segment_intersection(
+            point,
+            Vec2::UnitX(),
+            polygon.at(edge_start),
+            polygon.at(edge_end))) {
+      ++intersection_count;
+    }
+  }
+  return bool(intersection_count % 2);  // Odd counts mean we're inside
 }
 
 }  // namespace resim::geometry

--- a/resim/geometry/polygon_utils.cc
+++ b/resim/geometry/polygon_utils.cc
@@ -9,19 +9,16 @@
 #include "resim/assert/assert.hh"
 #include "resim/math/clamp.hh"
 
-// TODO
-#include <iostream>
-
 namespace resim::geometry {
 
 namespace {
 
 using Vec2 = Eigen::Vector2d;
-using Mat2 = Eigen::Matrix2d;
-constexpr int DIM = 2;
 
+// Helper for 2d cross product.
 double cross(const Vec2 &a, const Vec2 &b) { return a(0) * b(1) - a(1) * b(0); }
 
+// Detect whether the given ray intersects the given line segment.
 bool ray_segment_intersection(
     const Eigen::Vector2d &ray_start,
     const Eigen::Vector2d &ray_dir,
@@ -118,7 +115,8 @@ bool point_in_polygon(
       ++intersection_count;
     }
   }
-  return bool(intersection_count % 2);  // Odd counts mean we're inside
+  return static_cast<bool>(
+      intersection_count % 2);  // Odd counts mean we're inside
 }
 
 }  // namespace resim::geometry

--- a/resim/geometry/polygon_utils.cc
+++ b/resim/geometry/polygon_utils.cc
@@ -1,0 +1,66 @@
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include "resim/geometry/polygon_utils.hh"
+
+#include "resim/assert/assert.hh"
+
+namespace resim::geometry {
+
+namespace {
+
+using Vec2 = Eigen::Vector2d;
+using Mat2 = Eigen::Matrix2d;
+constexpr int DIM = 2;
+
+}  // namespace
+
+bool edge_intersection(
+    const Eigen::Vector2d &a0,
+    const Eigen::Vector2d &a1,
+    const Eigen::Vector2d &b0,
+    const Eigen::Vector2d &b1) {
+  const Mat2 edgemat{(Mat2() << (a1 - a0), -(b1 - b0)).finished()};
+
+  const Eigen::JacobiSVD<Mat2> svd{
+      edgemat,
+      Eigen::ComputeFullV | Eigen::ComputeFullU};
+
+  // Parallel edges
+  if (svd.rank() != DIM) {
+    return false;
+  }
+
+  const Vec2 intersection{svd.solve(b0 - a0)};
+
+  return !(
+      (intersection.array() < 0.0).any() or (intersection.array() > 1.0).any());
+}
+
+bool self_intersecting(const std::vector<Eigen::Vector2d> &polygon) {
+  const size_t num_edges = polygon.size();
+  REASSERT(num_edges > 2U, "Polygons must have at least three edges");
+
+  for (size_t ii = 0U; ii < num_edges; ++ii) {
+    // The condition here is a bit complex. We want jj to be an edge
+    // we have not already checked, and we want it not to be the edge
+    // before the ii-th edge which can only happen if we loop around
+    // when ii = 0.
+    for (size_t jj = (ii + 2U); jj < num_edges and (jj - ii) < num_edges - 1U;
+         ++jj) {
+      if (edge_intersection(
+              polygon.at(ii),
+              polygon.at(ii + 1),
+              polygon.at(jj),
+              polygon.at((jj + 1) % num_edges /* Will wrap around */))) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+}  // namespace resim::geometry

--- a/resim/geometry/polygon_utils.hh
+++ b/resim/geometry/polygon_utils.hh
@@ -9,12 +9,32 @@
 
 namespace resim::geometry {
 
-bool edge_intersection(
+// Checks whether two line segments intersect.
+//
+// Intersection occurs if the intersection point of the two lines is
+// in the open interval of each segment. For example, segments with
+// coincident endpoints do not satisfy this function.
+bool segment_intersection(
     const Eigen::Vector2d &a0,
     const Eigen::Vector2d &a1,
     const Eigen::Vector2d &b0,
     const Eigen::Vector2d &b1);
 
-bool self_intersecting(const std::vector<Eigen::Vector2d> &polygon);
+// Get the shortest distance between a point and any point along a
+// given line segment.
+double point_line_segment_distance(
+    const Eigen::Vector2d &point,
+    const Eigen::Vector2d &segment_start,
+    const Eigen::Vector2d &segment_end);
+
+// Determine whether a polygon is self intersecting.
+bool is_self_intersecting(const std::vector<Eigen::Vector2d> &polygon);
+
+// Determine whether a given point is inside the given
+// polygon. Behavior is undefined for points on the edge of the
+// polygon.
+bool point_in_polygon(
+    const Eigen::Vector2d &point,
+    const std::vector<Eigen::Vector2d> &polygon);
 
 }  // namespace resim::geometry

--- a/resim/geometry/polygon_utils.hh
+++ b/resim/geometry/polygon_utils.hh
@@ -1,0 +1,20 @@
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include <Eigen/Dense>
+#include <vector>
+
+namespace resim::geometry {
+
+bool edge_intersection(
+    const Eigen::Vector2d &a0,
+    const Eigen::Vector2d &a1,
+    const Eigen::Vector2d &b0,
+    const Eigen::Vector2d &b1);
+
+bool self_intersecting(const std::vector<Eigen::Vector2d> &polygon);
+
+}  // namespace resim::geometry

--- a/resim/geometry/polygon_utils_test.cc
+++ b/resim/geometry/polygon_utils_test.cc
@@ -11,27 +11,30 @@
 
 #include <Eigen/Dense>
 #include <cmath>
+#include <random>
 #include <utility>
 #include <vector>
+
+#include "resim/testing/random_matrix.hh"
 
 namespace resim::geometry {
 using Vec2 = Eigen::Vector2d;
 
 TEST(PolygonUtilsTest, TestParallelLines) {
-  EXPECT_FALSE(edge_intersection(
+  EXPECT_FALSE(segment_intersection(
       Vec2{0.0, 0.0},
       Vec2{1.0, 1.0},
       Vec2{-1.0, 1.0},
       Vec2{0.0, 2.0}));
 
-  EXPECT_FALSE(edge_intersection(
+  EXPECT_FALSE(segment_intersection(
       Vec2{0.0, 0.0},
       Vec2{-1.0, 1.0},
       Vec2{1.0, 1.0},
       Vec2{0.0, 2.0}));
 
   // Coincident lines
-  EXPECT_FALSE(edge_intersection(
+  EXPECT_FALSE(segment_intersection(
       Vec2{0.0, 0.0},
       Vec2{1.0, 1.0},
       Vec2{0.0, 0.0},
@@ -39,17 +42,17 @@ TEST(PolygonUtilsTest, TestParallelLines) {
 }
 
 TEST(PolygonUtilsTest, TestDegenerateEdges) {
-  EXPECT_FALSE(edge_intersection(
+  EXPECT_FALSE(segment_intersection(
       Vec2{0.0, 0.0},
       Vec2{1.0, 1.0},
       Vec2{0.0, 0.0},
       Vec2{0.0, 0.0}));
-  EXPECT_FALSE(edge_intersection(
+  EXPECT_FALSE(segment_intersection(
       Vec2{0.0, 0.0},
       Vec2{1.0, 1.0},
       Vec2{-1.0, 1.0},
       Vec2{-1.0, 1.0}));
-  EXPECT_FALSE(edge_intersection(
+  EXPECT_FALSE(segment_intersection(
       Vec2{1.0, -1.0},
       Vec2{1.0, -1.0},
       Vec2{1.0, -1.0},
@@ -57,35 +60,56 @@ TEST(PolygonUtilsTest, TestDegenerateEdges) {
 }
 
 TEST(PolygonUtilsTest, TestPastEnds) {
-  EXPECT_FALSE(edge_intersection(
+  EXPECT_FALSE(segment_intersection(
       Vec2{0.0, 0.0},
       Vec2{1.0, 1.0},
       Vec2{1.1 - 0.4, 1.1 + 0.4},
       Vec2{1.1 + 0.4, 1.1 - 0.4}));
-  EXPECT_FALSE(edge_intersection(
+  EXPECT_FALSE(segment_intersection(
       Vec2{0.0, 0.0},
       Vec2{1.0, 1.0},
       Vec2{-0.1 - 0.4, -0.1 + 0.4},
       Vec2{-0.1 + 0.4, -0.1 - 0.4}));
-  EXPECT_FALSE(edge_intersection(
+  EXPECT_FALSE(segment_intersection(
       Vec2{1.1 - 0.4, 1.1 + 0.4},
       Vec2{1.1 + 0.4, 1.1 - 0.4},
       Vec2{0.0, 0.0},
       Vec2{1.0, 1.0}));
-  EXPECT_FALSE(edge_intersection(
+  EXPECT_FALSE(segment_intersection(
       Vec2{-0.1 - 0.4, -0.1 + 0.4},
       Vec2{-0.1 + 0.4, -0.1 - 0.4},
       Vec2{0.0, 0.0},
       Vec2{1.0, 1.0}));
 }
 
+TEST(PolygonUtilsTest, TestCoincidentEndpoint) {
+  EXPECT_FALSE(segment_intersection(
+      Vec2{0.0, 0.0},
+      Vec2{1.0, 1.0},
+      Vec2{1.0, 1.0},
+      Vec2{0.0, 2.0}));
+  EXPECT_FALSE(segment_intersection(
+      Vec2{0.0, 0.0},
+      Vec2{1.0, 1.0},
+      Vec2{1.0, 1.0},
+      Vec2{0.0, 0.0}));
+}
+
+TEST(PolygonUtilsTest, TestEndpointOnOtherSegment) {
+  EXPECT_FALSE(segment_intersection(
+      Vec2{0.0, 0.0},
+      Vec2{2.0, 2.0},
+      Vec2{1.0, 1.0},
+      Vec2{0.0, 2.0}));
+}
+
 TEST(PolygonUtilsTest, TestIntersection) {
-  EXPECT_TRUE(edge_intersection(
+  EXPECT_TRUE(segment_intersection(
       Vec2{-1.0, -1.0},
       Vec2{1.0, 1.0},
       Vec2{1.0, -1.0},
       Vec2{-1.0, 1.0}));
-  EXPECT_TRUE(edge_intersection(
+  EXPECT_TRUE(segment_intersection(
       Vec2{-1.0, -1.0},
       Vec2{1.0, 1.0},
       Vec2{-1.0, 1.0},
@@ -93,7 +117,7 @@ TEST(PolygonUtilsTest, TestIntersection) {
 }
 
 TEST(PolygonUtilsTest, TestSelfIntersection) {
-  EXPECT_TRUE(self_intersecting(std::vector{
+  EXPECT_TRUE(is_self_intersecting(std::vector{
       Vec2{-1.0, -1.0},
       Vec2{1.0, 1.0},
       Vec2{1.0, -1.0},
@@ -111,22 +135,187 @@ TEST(PolygonUtilsTest, TestSelfIntersection) {
           std::sin(static_cast<double>(jj) / (ii - 1) / 2.0 / M_PI));
     }
 
-    EXPECT_FALSE(self_intersecting(polygon));
+    EXPECT_FALSE(is_self_intersecting(polygon));
 
     for (int jj = 0; jj < ii; ++jj) {
       for (int kk = jj + 1; kk < ii; ++kk) {
         std::vector<Vec2> flipped_polygon{polygon};
         std::swap(flipped_polygon.at(jj), flipped_polygon.at(kk));
-        EXPECT_TRUE(self_intersecting(flipped_polygon));
+        EXPECT_TRUE(is_self_intersecting(flipped_polygon));
       }
     }
   }
 
-  EXPECT_TRUE(self_intersecting(std::vector{
+  EXPECT_TRUE(is_self_intersecting(std::vector{
       Vec2{-1.0, -1.0},
       Vec2{1.0, 1.0},
       Vec2{1.0, -1.0},
       Vec2{-1.0, 1.0}}));
+}
+
+TEST(PolygonUtilsTest, TestPointSegmentDistance) {
+  // SETUP
+  constexpr size_t SEED = 4324U;
+  std::mt19937 rng{SEED};
+  std::uniform_real_distribution<double> dist{0.0, 1.0};
+
+  constexpr double TOLERANCE = 1e-15;
+  constexpr int NUM_TESTS = 100;
+  for (int ii = 0; ii < NUM_TESTS; ++ii) {
+    const Vec2 segment_start{testing::random_vector<Vec2>(rng)};
+    const Vec2 segment_end{testing::random_vector<Vec2>(rng)};
+
+    const Vec2 dir{segment_end - segment_start};
+    const Vec2 normal{Vec2{-dir(1), dir(0)}.normalized()};
+
+    // Edge closest:
+    {
+      const Vec2 segment_coords{testing::random_vector<Vec2>(rng, dist)};
+      const Vec2 point{
+          segment_start + dir * segment_coords(0) + normal * segment_coords(1)};
+
+      // ACTION
+      const double distance =
+          point_line_segment_distance(point, segment_start, segment_end);
+
+      // VERIFICATION
+      EXPECT_LT(
+          std::fabs(distance - segment_coords(1) /* normal coord */),
+          TOLERANCE);
+    }
+    // Endpoint closest:
+    {
+      const Vec2 overshot_segment_coords{
+          testing::random_vector<Vec2>(rng, dist) + Vec2::UnitX()};
+      const Vec2 undershot_segment_coords{
+          testing::random_vector<Vec2>(rng, dist) - Vec2::UnitX()};
+
+      const Vec2 overshot_point{
+          segment_start + dir * overshot_segment_coords(0) +
+          normal * overshot_segment_coords(1)};
+      const Vec2 undershot_point{
+          segment_start + dir * undershot_segment_coords(0) +
+          normal * undershot_segment_coords(1)};
+
+      // ACTION
+      const double overshot_distance = point_line_segment_distance(
+          overshot_point,
+          segment_start,
+          segment_end);
+      const double undershot_distance = point_line_segment_distance(
+          undershot_point,
+          segment_start,
+          segment_end);
+
+      // VERIFICATION
+      EXPECT_LT(
+          std::fabs(overshot_distance - (overshot_point - segment_end).norm()),
+          TOLERANCE);
+      EXPECT_LT(
+          std::fabs(
+              undershot_distance - (undershot_point - segment_start).norm()),
+          TOLERANCE);
+    }
+  }
+}
+
+TEST(PolygonUtilsTest, TestPointSegmentDistanceOnSegment) {
+  // SETUP
+  constexpr double TOLERANCE = 1e-15;
+  constexpr size_t SEED = 4324U;
+  std::mt19937 rng{SEED};
+  const Vec2 segment_start{testing::random_vector<Vec2>(rng)};
+  const Vec2 segment_end{testing::random_vector<Vec2>(rng)};
+
+  constexpr int NUM_POINTS = 10;
+  for (int ii = 0; ii < NUM_POINTS; ++ii) {
+    const double frac = static_cast<double>(ii) / (NUM_POINTS - 1);
+    const Vec2 point{(1. - frac) * segment_start + frac * segment_end};
+
+    // ACTION / VERIFICATION
+    EXPECT_LT(
+        point_line_segment_distance(point, segment_start, segment_end),
+        TOLERANCE);
+  }
+}
+
+TEST(PolygonUtilsTest, TestPointSegmentDistanceOnDegenerate) {
+  // SETUP
+  constexpr double TOLERANCE = 1e-15;
+  constexpr size_t SEED = 4324U;
+  std::mt19937 rng{SEED};
+  const Vec2 segment_start{testing::random_vector<Vec2>(rng)};
+  const Vec2 segment_end{segment_start};
+
+  constexpr int NUM_POINTS = 10;
+  for (int ii = 0; ii < NUM_POINTS; ++ii) {
+    const Vec2 point{testing::random_vector<Vec2>(rng)};
+    // ACTION / VERIFICATION
+    EXPECT_LT(
+        point_line_segment_distance(point, segment_start, segment_end) -
+            (point - segment_start).norm(),
+        TOLERANCE);
+  }
+}
+
+TEST(PolygonUtilsTest, TestPointInPolygon) {
+  // SETUP
+  const std::vector<Vec2> polygon{
+      Vec2{-1.0, -1.0},
+      Vec2{1.0, -1.0},
+      Vec2{1.0, 1.0},
+      Vec2{-1.0, 1.0},
+  };
+
+  // ACTION / VERIFICATION
+  constexpr double EPS = 1e-12;
+  EXPECT_TRUE(point_in_polygon(Vec2{0.0, 0.0}, polygon));
+  EXPECT_TRUE(point_in_polygon(Vec2{1.0 - EPS, 0.0}, polygon));
+  EXPECT_TRUE(point_in_polygon(Vec2{-1.0 + EPS, 0.0}, polygon));
+  EXPECT_TRUE(point_in_polygon(Vec2{0.0, 1.0 - EPS}, polygon));
+  EXPECT_TRUE(point_in_polygon(Vec2{0.0, -1.0 + EPS}, polygon));
+}
+
+TEST(PoygonUtilsTest, TestPointInNonConvexPolygon) {
+  // SETUP
+  // Make a spiral
+  constexpr double OUTER_RADIUS = 20;
+  constexpr double INNER_RADIUS = 18;
+  const auto spiral = [](const double t, const double offset) -> Vec2 {
+    const double angle_rad = 2. * M_PI * t;
+    return (OUTER_RADIUS - t + offset) *
+           Vec2{std::cos(angle_rad), std::sin(angle_rad)};
+  };
+  std::vector<Vec2> spiral_poly;
+  constexpr int NUM_POINTS = 80;
+  for (int ii = 0; ii < NUM_POINTS; ++ii) {
+    const double frac = static_cast<double>(ii) / (NUM_POINTS - 1);
+    const double t = frac * (OUTER_RADIUS - INNER_RADIUS);
+    constexpr double OFFSET = 0.2;
+    spiral_poly.emplace_back(spiral(t, OFFSET));
+  }
+  for (int ii = 0; ii < NUM_POINTS; ++ii) {
+    const double frac = 1.0 - static_cast<double>(ii) / (NUM_POINTS - 1);
+    const double t = frac * (OUTER_RADIUS - INNER_RADIUS);
+    constexpr double OFFSET = -0.2;
+    spiral_poly.emplace_back(spiral(t, OFFSET));
+  }
+
+  ASSERT_TRUE(not is_self_intersecting(spiral_poly));
+
+  // for (const auto &p : spiral_poly) {
+  //   std::cout << p.transpose() << std::endl;
+  // }
+
+  // ACTION / VERIFICATION
+  for (int ii = 0; ii < NUM_POINTS - 1; ++ii) {
+    const double frac = (static_cast<double>(ii) + 0.5) / (NUM_POINTS - 1);
+    const double t = frac * (OUTER_RADIUS - INNER_RADIUS);
+    constexpr double IN_OFFSET = 0.0;
+    constexpr double OUT_OFFSET = 0.5;
+    EXPECT_TRUE(point_in_polygon(spiral(t, IN_OFFSET), spiral_poly));
+    EXPECT_FALSE(point_in_polygon(spiral(t, OUT_OFFSET), spiral_poly));
+  }
 }
 
 }  // namespace resim::geometry

--- a/resim/geometry/polygon_utils_test.cc
+++ b/resim/geometry/polygon_utils_test.cc
@@ -245,7 +245,7 @@ TEST(PolygonUtilsTest, TestPointSegmentDistanceOnDegenerate) {
   constexpr size_t SEED = 4324U;
   std::mt19937 rng{SEED};
   const Vec2 segment_start{testing::random_vector<Vec2>(rng)};
-  const Vec2 segment_end{segment_start};
+  const Vec2& segment_end{segment_start};
 
   constexpr int NUM_POINTS = 10;
   for (int ii = 0; ii < NUM_POINTS; ++ii) {

--- a/resim/geometry/polygon_utils_test.cc
+++ b/resim/geometry/polygon_utils_test.cc
@@ -1,0 +1,134 @@
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+// NOLINTBEGIN(readability-magic-numbers)
+
+#include "resim/geometry/polygon_utils.hh"
+
+#include <gtest/gtest.h>
+
+#include <Eigen/Dense>
+#include <cmath>
+#include <utility>
+#include <vector>
+
+namespace resim::geometry {
+using Vec2 = Eigen::Vector2d;
+
+TEST(PolygonUtilsTest, TestParallelLines) {
+  EXPECT_FALSE(edge_intersection(
+      Vec2{0.0, 0.0},
+      Vec2{1.0, 1.0},
+      Vec2{-1.0, 1.0},
+      Vec2{0.0, 2.0}));
+
+  EXPECT_FALSE(edge_intersection(
+      Vec2{0.0, 0.0},
+      Vec2{-1.0, 1.0},
+      Vec2{1.0, 1.0},
+      Vec2{0.0, 2.0}));
+
+  // Coincident lines
+  EXPECT_FALSE(edge_intersection(
+      Vec2{0.0, 0.0},
+      Vec2{1.0, 1.0},
+      Vec2{0.0, 0.0},
+      Vec2{1.0, 1.0}));
+}
+
+TEST(PolygonUtilsTest, TestDegenerateEdges) {
+  EXPECT_FALSE(edge_intersection(
+      Vec2{0.0, 0.0},
+      Vec2{1.0, 1.0},
+      Vec2{0.0, 0.0},
+      Vec2{0.0, 0.0}));
+  EXPECT_FALSE(edge_intersection(
+      Vec2{0.0, 0.0},
+      Vec2{1.0, 1.0},
+      Vec2{-1.0, 1.0},
+      Vec2{-1.0, 1.0}));
+  EXPECT_FALSE(edge_intersection(
+      Vec2{1.0, -1.0},
+      Vec2{1.0, -1.0},
+      Vec2{1.0, -1.0},
+      Vec2{1.0, -1.0}));
+}
+
+TEST(PolygonUtilsTest, TestPastEnds) {
+  EXPECT_FALSE(edge_intersection(
+      Vec2{0.0, 0.0},
+      Vec2{1.0, 1.0},
+      Vec2{1.1 - 0.4, 1.1 + 0.4},
+      Vec2{1.1 + 0.4, 1.1 - 0.4}));
+  EXPECT_FALSE(edge_intersection(
+      Vec2{0.0, 0.0},
+      Vec2{1.0, 1.0},
+      Vec2{-0.1 - 0.4, -0.1 + 0.4},
+      Vec2{-0.1 + 0.4, -0.1 - 0.4}));
+  EXPECT_FALSE(edge_intersection(
+      Vec2{1.1 - 0.4, 1.1 + 0.4},
+      Vec2{1.1 + 0.4, 1.1 - 0.4},
+      Vec2{0.0, 0.0},
+      Vec2{1.0, 1.0}));
+  EXPECT_FALSE(edge_intersection(
+      Vec2{-0.1 - 0.4, -0.1 + 0.4},
+      Vec2{-0.1 + 0.4, -0.1 - 0.4},
+      Vec2{0.0, 0.0},
+      Vec2{1.0, 1.0}));
+}
+
+TEST(PolygonUtilsTest, TestIntersection) {
+  EXPECT_TRUE(edge_intersection(
+      Vec2{-1.0, -1.0},
+      Vec2{1.0, 1.0},
+      Vec2{1.0, -1.0},
+      Vec2{-1.0, 1.0}));
+  EXPECT_TRUE(edge_intersection(
+      Vec2{-1.0, -1.0},
+      Vec2{1.0, 1.0},
+      Vec2{-1.0, 1.0},
+      Vec2{1.0, -1.0}));
+}
+
+TEST(PolygonUtilsTest, TestSelfIntersection) {
+  EXPECT_TRUE(self_intersecting(std::vector{
+      Vec2{-1.0, -1.0},
+      Vec2{1.0, 1.0},
+      Vec2{1.0, -1.0},
+      Vec2{-1.0, 1.0}}));
+
+  // Try some regular polygons
+  constexpr int MIN_EDGES = 5;
+  constexpr int MAX_EDGES = 12;
+  for (int ii = MIN_EDGES; ii < MAX_EDGES; ++ii) {
+    std::vector<Vec2> polygon;
+    polygon.reserve(ii);
+    for (int jj = 0; jj < ii; ++jj) {
+      polygon.emplace_back(
+          std::cos(static_cast<double>(jj) / (ii - 1) / 2.0 / M_PI),
+          std::sin(static_cast<double>(jj) / (ii - 1) / 2.0 / M_PI));
+    }
+
+    EXPECT_FALSE(self_intersecting(polygon));
+
+    for (int jj = 0; jj < ii; ++jj) {
+      for (int kk = jj + 1; kk < ii; ++kk) {
+        std::vector<Vec2> flipped_polygon{polygon};
+        std::swap(flipped_polygon.at(jj), flipped_polygon.at(kk));
+        EXPECT_TRUE(self_intersecting(flipped_polygon));
+      }
+    }
+  }
+
+  EXPECT_TRUE(self_intersecting(std::vector{
+      Vec2{-1.0, -1.0},
+      Vec2{1.0, 1.0},
+      Vec2{1.0, -1.0},
+      Vec2{-1.0, 1.0}}));
+}
+
+}  // namespace resim::geometry
+
+// NOLINTEND(readability-magic-numbers)

--- a/resim/geometry/python/BUILD
+++ b/resim/geometry/python/BUILD
@@ -9,8 +9,8 @@ load("@resim_python_deps//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_test")
 
 pybind_extension(
-    name = "polygon_distance_python",
-    srcs = ["polygon_distance_python.cc"],
+    name = "polygon_distance",
+    srcs = ["polygon_distance.cc"],
     visibility = ["//visibility:public"],
     deps = [
         "//resim/geometry:polygon_distance",
@@ -21,7 +21,7 @@ py_test(
     name = "polygon_distance_test",
     srcs = ["polygon_distance_test.py"],
     data = [
-        ":polygon_distance_python.so",
+        ":polygon_distance.so",
     ],
     deps = [
         requirement("numpy"),

--- a/resim/geometry/python/BUILD
+++ b/resim/geometry/python/BUILD
@@ -1,0 +1,29 @@
+# Copyright 2023 ReSim, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+load("@pybind11_bazel//:build_defs.bzl", "pybind_extension")
+load("@resim_python_deps//:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_test")
+
+pybind_extension(
+    name = "polygon_distance_python",
+    srcs = ["polygon_distance_python.cc"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//resim/geometry:polygon_distance",
+    ],
+)
+
+py_test(
+    name = "polygon_distance_test",
+    srcs = ["polygon_distance_test.py"],
+    data = [
+        ":polygon_distance_python.so",
+    ],
+    deps = [
+        requirement("numpy"),
+    ],
+)

--- a/resim/geometry/python/BUILD
+++ b/resim/geometry/python/BUILD
@@ -9,8 +9,8 @@ load("@resim_python_deps//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_test")
 
 pybind_extension(
-    name = "polygon_distance",
-    srcs = ["polygon_distance.cc"],
+    name = "polygon_distance_python",
+    srcs = ["polygon_distance_python.cc"],
     visibility = ["//visibility:public"],
     deps = [
         "//resim/geometry:polygon_distance",
@@ -21,7 +21,7 @@ py_test(
     name = "polygon_distance_test",
     srcs = ["polygon_distance_test.py"],
     data = [
-        ":polygon_distance.so",
+        ":polygon_distance_python.so",
     ],
     deps = [
         requirement("numpy"),

--- a/resim/geometry/python/polygon_distance.cc
+++ b/resim/geometry/python/polygon_distance.cc
@@ -4,13 +4,13 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+#include "resim/geometry/polygon_distance.hh"
+
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
 #include <Eigen/Dense>
-
-#include "resim/geometry/polygon_distance.hh"
 
 namespace resim::geometry {
 namespace py = pybind11;

--- a/resim/geometry/python/polygon_distance_python.cc
+++ b/resim/geometry/python/polygon_distance_python.cc
@@ -1,0 +1,22 @@
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include <pybind11/eigen.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <Eigen/Dense>
+
+#include "resim/geometry/polygon_distance.hh"
+
+namespace resim::geometry {
+namespace py = pybind11;
+
+PYBIND11_MODULE(polygon_distance_python, m) {
+  m.def("polygon_distance", &polygon_distance);
+}
+
+}  // namespace resim::geometry

--- a/resim/geometry/python/polygon_distance_python.cc
+++ b/resim/geometry/python/polygon_distance_python.cc
@@ -4,13 +4,13 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-#include "resim/geometry/polygon_distance.hh"
-
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
 #include <Eigen/Dense>
+
+#include "resim/geometry/polygon_distance.hh"
 
 namespace resim::geometry {
 namespace py = pybind11;

--- a/resim/geometry/python/polygon_distance_test.py
+++ b/resim/geometry/python/polygon_distance_test.py
@@ -30,10 +30,10 @@ class PolygonDistanceTest(unittest.TestCase):
                   np.array([1., 2.5]),
                   np.array([-1., 2.5])]
 
-        self.assertEqual(polydist.polygon_distance(poly_a, poly_b), 0.);
-        self.assertEqual(polydist.polygon_distance(poly_a, poly_c), 0.5);
-        self.assertEqual(polydist.polygon_distance(poly_b, poly_c), 1.0);                
-        
+        self.assertEqual(polydist.polygon_distance(poly_a, poly_b), 0.)
+        self.assertEqual(polydist.polygon_distance(poly_a, poly_c), 0.5)
+        self.assertEqual(polydist.polygon_distance(poly_b, poly_c), 1.0)
+
 
 
 if __name__ == '__main__':

--- a/resim/geometry/python/polygon_distance_test.py
+++ b/resim/geometry/python/polygon_distance_test.py
@@ -1,0 +1,40 @@
+# Copyright 2024 ReSim, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+"""
+Unit tests for Polygon Distance pybinding
+"""
+
+import unittest
+
+import numpy as np
+import resim.geometry.python.polygon_distance_python as polydist
+
+
+class PolygonDistanceTest(unittest.TestCase):
+    """Unit tests for Polygon Distance pybinding"""
+
+
+    def test_polygon_distance(self) -> None:
+        poly_a = [np.array([-1., -0.5]),
+                  np.array([1., -0.5]),
+                  np.array([0., 1.0])]
+        poly_b = [np.array([-1., 0.5]),
+                  np.array([1., 0.5]),
+                  np.array([0., -1.0])]
+        poly_c = [np.array([-1., 1.5]),
+                  np.array([1., 1.5]),
+                  np.array([1., 2.5]),
+                  np.array([-1., 2.5])]
+
+        self.assertEqual(polydist.polygon_distance(poly_a, poly_b), 0.);
+        self.assertEqual(polydist.polygon_distance(poly_a, poly_c), 0.5);
+        self.assertEqual(polydist.polygon_distance(poly_b, poly_c), 1.0);                
+        
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/resim/math/BUILD
+++ b/resim/math/BUILD
@@ -122,3 +122,9 @@ cc_test(
         "@libeigen//:eigen",
     ],
 )
+
+cc_library(
+    name = "clamp",
+    hdrs = ["clamp.hh"],
+    visibility = ["//visibility:public"],
+)

--- a/resim/math/BUILD
+++ b/resim/math/BUILD
@@ -127,4 +127,17 @@ cc_library(
     name = "clamp",
     hdrs = ["clamp.hh"],
     visibility = ["//visibility:public"],
+    deps = [
+        "//resim/assert",
+    ],
+)
+
+cc_test(
+    name = "clamp_test",
+    srcs = ["clamp_test.cc"],
+    deps = [
+        ":clamp",
+        "//resim/assert",
+        "@com_google_googletest//:gtest_main",
+    ],
 )

--- a/resim/math/clamp.hh
+++ b/resim/math/clamp.hh
@@ -4,6 +4,8 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+#include "resim/assert/assert.hh"
+
 namespace resim::math {
 
 template <typename Float>

--- a/resim/math/clamp.hh
+++ b/resim/math/clamp.hh
@@ -1,0 +1,15 @@
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+namespace resim::math {
+
+template <typename Float>
+Float clamp(Float x, Float a, Float b) {
+  REASSERT(a <= b);
+  return x > b ? b : (x < a ? a : x);
+}
+
+}  // namespace resim::math

--- a/resim/math/clamp_test.cc
+++ b/resim/math/clamp_test.cc
@@ -1,0 +1,27 @@
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+// NOLINTBEGIN(readability-magic-numbers)
+
+#include "resim/math/clamp.hh"
+
+#include <gtest/gtest.h>
+
+#include "resim/assert/assert.hh"
+
+namespace resim::math {
+
+TEST(ClampTest, TestClamp) {
+  constexpr double LB = 3.2;
+  constexpr double UB = 5.1;
+  EXPECT_EQ(4.7, clamp(4.7, LB, UB));
+  EXPECT_EQ(LB, clamp(LB - 1.0, LB, UB));
+  EXPECT_EQ(UB, clamp(UB + 1.0, LB, UB));
+  EXPECT_THROW(clamp(UB + 1.0, UB, LB), AssertException);
+}
+
+}  // namespace resim::math
+
+// NOLINTEND(readability-magic-numbers)


### PR DESCRIPTION
## Description of change
Add a function to compute the distance between convex polygons.

## Guide to reproduce test results.
```bash
bazel test //resim/geometry:polygon_distance_test
bazel test //resim/geometry:polygon_utils_test
```
## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
