### PR TITLE
Prepare to release framed vector in v0.0.5

### DIFF
--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -99,7 +99,10 @@ py_wheel(
 
 py_package(
     name = "msg_package",
-    packages = ["resim.msg"],
+    packages = [
+        "resim.msg",
+        "resim.transforms.proto",
+    ],
     deps = [
         "//resim/msg:detection_proto_py",
         "//resim/msg:header_proto_py",
@@ -107,6 +110,7 @@ py_package(
         "//resim/msg:odometry_proto_py",
         "//resim/msg:pose_proto_py",
         "//resim/msg:transform_proto_py",
+        "//resim/transforms/proto:framed_vector_3_proto_py",
     ],
 )
 

--- a/resim/transforms/proto/BUILD
+++ b/resim/transforms/proto/BUILD
@@ -6,6 +6,7 @@
 
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_proto_library", "cc_test")
 load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_python//python:proto.bzl", "py_proto_library")
 
 cc_library(
     name = "liegroup_to_proto",
@@ -92,6 +93,12 @@ proto_library(
 
 cc_proto_library(
     name = "framed_vector_3_proto_cc",
+    visibility = ["//visibility:public"],
+    deps = [":framed_vector_3_proto"],
+)
+
+py_proto_library(
+    name = "framed_vector_3_proto_py",
     visibility = ["//visibility:public"],
     deps = [":framed_vector_3_proto"],
 )

--- a/version.bzl
+++ b/version.bzl
@@ -6,4 +6,4 @@
 
 """The version of open-core"""
 
-version = "0.0.3"
+version = "0.0.5"


### PR DESCRIPTION
## Description of change
Prepare to release framed vector's python proto bindings from open core as we'd like to use them elsewhere.

## Guide to reproduce test results.
```bash
bazel build //pkg:msg_wheel
pushd bazel-bin/pkg
unzip resim_msg-0.0.5-py3-none-any.whl
popd
```

Verify the newly released files are there:
```
  inflating: resim/msg/detection_pb2.py  
  inflating: resim/msg/header_pb2.py  
  inflating: resim/msg/navsat_pb2.py  
  inflating: resim/msg/odometry_pb2.py  
  inflating: resim/msg/pose_pb2.py   
  inflating: resim/msg/transform_pb2.py  
  inflating: resim/transforms/proto/frame_3_pb2.py  
  inflating: resim/transforms/proto/framed_vector_3_pb2.py  
  inflating: resim/transforms/proto/se3_pb2.py  
  inflating: resim_msg-0.0.3.dist-info/WHEEL  
  inflating: resim_msg-0.0.3.dist-info/METADATA  
  inflating: resim_msg-0.0.3.dist-info/RECORD  
```
## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [ ] This change is covered by tests that are already landed, or in this PR.
