### PR TITLE
Allow ROS2 converter script to fail gracefully

### DIFF
--- a/resim/ros2/BUILD
+++ b/resim/ros2/BUILD
@@ -58,6 +58,7 @@ cc_library(
     name = "transform_from_ros2",
     srcs = ["transform_from_ros2.cc"],
     hdrs = ["transform_from_ros2.hh"],
+    visibility = ["//resim/ros2:__subpackages__"],
     deps = [
         ":header_from_ros2",
         "//resim/msg:transform_proto_cc",
@@ -141,6 +142,7 @@ cc_library(
     name = "odometry_from_ros2",
     srcs = ["odometry_from_ros2.cc"],
     hdrs = ["odometry_from_ros2.hh"],
+    visibility = ["//resim/ros2:__subpackages__"],
     deps = [
         ":header_from_ros2",
         ":pose_from_ros2",
@@ -361,7 +363,7 @@ ros2_cpp_test(
     name = "resim_log_from_ros2_test",
     testonly = True,  # Needed because ros2_cpp_test generates a non-test rule
     srcs = ["resim_log_from_ros2_test.cc"],
-    data = [":default_converter_plugin.so"],
+    data = ["//resim/ros2/testing:resim_log_from_ros2_test_converter_plugin.so"],
     set_up_ament = True,
     deps = [
         ":resim_log_from_ros2",

--- a/resim/ros2/converter_plugin.cc
+++ b/resim/ros2/converter_plugin.cc
@@ -24,8 +24,8 @@ template <typename T>
 T make_clean_serialized_message() {
   return T{
       .buffer = nullptr,
-      .buffer_length = 0u,
-      .buffer_capacity = 0u,
+      .buffer_length = 0U,
+      .buffer_capacity = 0U,
       .allocator =
           rcutils_allocator_t{
               .allocate = nullptr,
@@ -41,7 +41,12 @@ T make_clean_serialized_message() {
 template <typename T>
 class ReSimMessageRAII {
  public:
-  ReSimMessageRAII(T &message) : message_{message} {}
+  explicit ReSimMessageRAII(T &message) : message_{message} {}
+  ReSimMessageRAII(const ReSimMessageRAII &) = delete;
+  ReSimMessageRAII(ReSimMessageRAII &&) = delete;
+  ReSimMessageRAII &operator=(const ReSimMessageRAII &) = delete;
+  ReSimMessageRAII &operator=(ReSimMessageRAII &&) = delete;
+
   ~ReSimMessageRAII() {
     if (message_.buffer != nullptr) {
       message_.allocator.deallocate(message_.buffer, message_.allocator.state);

--- a/resim/ros2/converter_plugin.cc
+++ b/resim/ros2/converter_plugin.cc
@@ -7,6 +7,7 @@
 #include "resim/ros2/converter_plugin.hh"
 
 #include <dlfcn.h>
+#include <glog/logging.h>
 
 #include <span>
 #include <utility>
@@ -14,6 +15,44 @@
 #include "resim/assert/assert.hh"
 
 namespace resim::ros2 {
+
+namespace {
+
+// Simple helper to make sure we initialize the buffer with nullptr. T
+// can be rmw_serialized_message_t or rcutils_uint8_array_t.
+template <typename T>
+T make_clean_serialized_message() {
+  return T{
+      .buffer = nullptr,
+      .buffer_length = 0u,
+      .buffer_capacity = 0u,
+      .allocator =
+          rcutils_allocator_t{
+              .allocate = nullptr,
+              .deallocate = nullptr,
+              .reallocate = nullptr,
+              .zero_allocate = nullptr,
+              .state = nullptr,
+          },
+  };
+}
+
+// Simple RAII class to make sure we clean up this message if it's been alloc'd
+template <typename T>
+class ReSimMessageRAII {
+ public:
+  ReSimMessageRAII(T &message) : message_{message} {}
+  ~ReSimMessageRAII() {
+    if (message_.buffer != nullptr) {
+      message_.allocator.deallocate(message_.buffer, message_.allocator.state);
+    }
+  }
+
+ private:
+  T &message_;
+};
+
+}  // namespace
 
 ConverterPlugin::ConverterPlugin(const std::filesystem::path &plugin_path) {
   // Clear dlerror()
@@ -62,7 +101,7 @@ bool ConverterPlugin::supports_type(std::string_view ros2_message_type) const {
   return supports_type_(ros2_message_type.data());
 }
 
-std::vector<std::byte> ConverterPlugin::convert(
+std::optional<std::vector<std::byte>> ConverterPlugin::convert(
     const std::string_view ros2_message_type,
     const rclcpp::SerializedMessage &ros2_message) const {
   REASSERT(converter_ != nullptr);
@@ -70,14 +109,16 @@ std::vector<std::byte> ConverterPlugin::convert(
       supports_type(ros2_message_type),
       "Can't convert unsupported message type!");
 
-  rcl_serialized_message_t resim_message;
+  auto resim_message{make_clean_serialized_message<rcl_serialized_message_t>()};
+  ReSimMessageRAII raii{resim_message};
   const auto status = converter_(
       ros2_message_type.data(),
       &ros2_message.get_rcl_serialized_message(),
       &resim_message);
-  REASSERT(
-      status != RESIM_CONVERTER_PLUGIN_STATUS_ERROR,
-      "Error encountered on conversion!");
+  if (status == RESIM_CONVERTER_PLUGIN_STATUS_ERROR) {
+    LOG(WARNING) << "Error encountered on conversion! Skipping Message...";
+    return std::nullopt;
+  }
 
   std::vector<std::byte> result;
   result.reserve(resim_message.buffer_length);
@@ -85,9 +126,6 @@ std::vector<std::byte> ConverterPlugin::convert(
   for (const auto s : buffer) {
     result.push_back(static_cast<std::byte>(s));
   }
-  resim_message.allocator.deallocate(
-      resim_message.buffer,
-      resim_message.allocator.state);
   return result;
 }
 
@@ -97,7 +135,13 @@ ConverterPlugin::SchemaInfo ConverterPlugin::get_schema(
   REASSERT(
       supports_type(ros2_message_type),
       "Can't convert unsupported message type!");
-  ReSimConverterSchemaInfo schema_info;
+  ReSimConverterSchemaInfo schema_info{
+      .name = make_clean_serialized_message<rcutils_uint8_array_t>(),
+      .encoding = nullptr,
+      .data = make_clean_serialized_message<rcutils_uint8_array_t>(),
+  };
+  ReSimMessageRAII name_raii{schema_info.name};
+  ReSimMessageRAII data_raii{schema_info.data};
   const auto status = schema_getter_(ros2_message_type.data(), &schema_info);
   REASSERT(
       status != RESIM_CONVERTER_PLUGIN_STATUS_ERROR,
@@ -117,12 +161,6 @@ ConverterPlugin::SchemaInfo ConverterPlugin::get_schema(
   for (const auto s : buffer) {
     result.data.push_back(static_cast<std::byte>(s));
   }
-  schema_info.data.allocator.deallocate(
-      schema_info.name.buffer,
-      schema_info.name.allocator.state);
-  schema_info.data.allocator.deallocate(
-      schema_info.data.buffer,
-      schema_info.data.allocator.state);
   return result;
 }
 

--- a/resim/ros2/converter_plugin.cc
+++ b/resim/ros2/converter_plugin.cc
@@ -19,7 +19,7 @@ namespace resim::ros2 {
 namespace {
 
 // Simple helper to make sure we initialize the buffer with nullptr. T
-// can be rmw_serialized_message_t or rcutils_uint8_array_t.
+// can be rcl_serialized_message_t or rcutils_uint8_array_t.
 template <typename T>
 T make_clean_serialized_message() {
   return T{

--- a/resim/ros2/converter_plugin.hh
+++ b/resim/ros2/converter_plugin.hh
@@ -11,6 +11,7 @@
 #include <cstddef>
 #include <filesystem>
 #include <functional>
+#include <optional>
 #include <rclcpp/serialized_message.hpp>
 #include <string_view>
 #include <vector>
@@ -95,9 +96,7 @@ class ConverterPlugin {
   // @param[in] ros2_message: The message to convert.
   // @returns The converted message if successful or nullopt if this
   // converter doesn't know how to handle this type of message.
-  // @throws AssertException If the contained converter plugin returns
-  //         RESIM_CONVERTER_PLUGIN_STATUS_ERROR
-  std::vector<std::byte> convert(
+  std::optional<std::vector<std::byte>> convert(
       std::string_view ros2_message_type,
       const rclcpp::SerializedMessage &ros2_message) const;
 

--- a/resim/ros2/converter_plugin_test.cc
+++ b/resim/ros2/converter_plugin_test.cc
@@ -84,16 +84,17 @@ TEST(ConverterPluginTest, TestConvert) {
   invalid_ros2_message.get_rcl_serialized_message().buffer = nullptr;
 
   // ACTION
-  const auto converted =
+  const auto maybe_converted =
       plugin.convert("convertible_message_type", ros2_message);
+  ASSERT_TRUE(maybe_converted.has_value());
+  const auto &converted = maybe_converted.value();
 
   EXPECT_THROW(
       plugin.convert("unconvertible_message_type", ros2_message),
       AssertException);
 
-  EXPECT_THROW(
-      plugin.convert("convertible_message_type", invalid_ros2_message),
-      AssertException);
+  EXPECT_FALSE(plugin.convert("convertible_message_type", invalid_ros2_message)
+                   .has_value());
 
   // VERIFICATION
   const std::string expected_response =

--- a/resim/ros2/default_converter_plugin_test.cc
+++ b/resim/ros2/default_converter_plugin_test.cc
@@ -190,7 +190,10 @@ TYPED_TEST(DefaultConverterPluginTest, TestConvert) {
   serialization.serialize_message(&ros2_message, &serialized_message);
 
   // ACTION
-  auto converted = plugin.convert(ros2_type_name, serialized_message);
+  const auto maybe_converted =
+      plugin.convert(ros2_type_name, serialized_message);
+  ASSERT_TRUE(maybe_converted.has_value());
+  const auto &converted = maybe_converted.value();
 
   // VERIFICATION
   ReSimType deserialized;
@@ -209,9 +212,7 @@ TYPED_TEST(DefaultConverterPluginTest, TestConvertBadMessage) {
   rclcpp::SerializedMessage serialized_message;
 
   // ACTION / VERIFICATION
-  EXPECT_THROW(
-      plugin.convert(ros2_type_name, serialized_message),
-      AssertException);
+  EXPECT_EQ(plugin.convert(ros2_type_name, serialized_message), std::nullopt);
 }
 
 }  // namespace resim::ros2

--- a/resim/ros2/resim_log_from_ros2.cc
+++ b/resim/ros2/resim_log_from_ros2.cc
@@ -89,7 +89,12 @@ void resim_log_from_ros2(
 
     const rclcpp::SerializedMessage extracted_serialized_message(
         *bag_message->serialized_data);
-    auto converted = plugin.convert(type, extracted_serialized_message);
+    const auto maybe_converted =
+        plugin.convert(type, extracted_serialized_message);
+    if (not maybe_converted.has_value()) {
+      continue;
+    }
+    const auto &converted = maybe_converted.value();
     mcap::Message message;
     message.channelId = topic_to_channels_map.at(topic_name);
     message.logTime = bag_message->time_stamp;

--- a/resim/ros2/resim_log_from_ros2_test.cc
+++ b/resim/ros2/resim_log_from_ros2_test.cc
@@ -23,7 +23,8 @@ TEST(ResimLogFromRos2Test, TestConversion) {
   const std::filesystem::path input_path{test_directory.test_file_path()};
   const std::filesystem::path output_path{
       test_directory.test_file_path("mcap")};
-  constexpr auto PLUGIN_PATH = "resim/ros2/default_converter_plugin.so";
+  constexpr auto PLUGIN_PATH =
+      "resim/ros2/testing/resim_log_from_ros2_test_converter_plugin.so";
 
   populate_log(input_path);
 

--- a/resim/ros2/resim_log_from_ros2_test_helpers.cc
+++ b/resim/ros2/resim_log_from_ros2_test_helpers.cc
@@ -15,6 +15,7 @@
 #include <rclcpp/serialized_message.hpp>
 #include <rosbag2_cpp/writer.hpp>
 #include <std_msgs/msg/byte.hpp>
+#include <std_msgs/msg/u_int8_multi_array.hpp>
 #include <string>
 #include <tuple>
 
@@ -112,6 +113,9 @@ void populate_log(const std::filesystem::path &log_path) {
   // Write a message type we don't support converting
   std_msgs::msg::Byte byte;
   writer.write(byte, "/should_not_be_converted", rclcpp::Time());
+
+  std_msgs::msg::UInt8MultiArray arr;
+  writer.write(arr, "/should_fail_when_converted", rclcpp::Time());
 }
 
 // Helper function to confirm that the ReSim log at the given path contains the

--- a/resim/ros2/testing/BUILD
+++ b/resim/ros2/testing/BUILD
@@ -18,3 +18,17 @@ cc_binary(
         "@ros2_rclcpp//:rclcpp",
     ],
 )
+
+cc_binary(
+    name = "resim_log_from_ros2_test_converter_plugin.so",
+    srcs = ["resim_log_from_ros2_test_converter_plugin.cc"],
+    linkshared = True,
+    visibility = ["//visibility:public"],
+    deps = [
+        "//resim/assert",
+        "//resim/ros2:converter_plugin_helpers",
+        "//resim/ros2:converter_plugin_types",
+        "//resim/ros2:odometry_from_ros2",
+        "//resim/ros2:transform_from_ros2",
+    ],
+)

--- a/resim/ros2/testing/resim_log_from_ros2_test_converter_plugin.cc
+++ b/resim/ros2/testing/resim_log_from_ros2_test_converter_plugin.cc
@@ -1,0 +1,101 @@
+// Copyright 2024 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <unordered_map>
+
+#include "resim/ros2/converter_plugin_helpers.hh"
+#include "resim/ros2/converter_plugin_types.h"
+#include "resim/ros2/odometry_from_ros2.hh"
+#include "resim/ros2/transform_from_ros2.hh"
+
+namespace resim::ros2 {
+
+namespace {
+
+class ConverterFunctor {
+ public:
+  template <typename Ros2Type>
+  auto operator()(const Ros2Type &ros2_msg) {
+    return convert_from_ros2(ros2_msg);
+  }
+};
+
+template <typename Ros2Type>
+auto convert_message(
+    const rcutils_uint8_array_t *const ros2_message,
+    rcutils_uint8_array_t *const resim_message) {
+  return resim::ros2::convert_message<Ros2Type, ConverterFunctor>(
+      ros2_message,
+      resim_message);
+}
+
+template <typename Ros2Type>
+auto generate_type_schema(ReSimConverterSchemaInfo *schema_info) {
+  return resim::ros2::generate_type_schema<Ros2Type, ConverterFunctor>(
+      schema_info);
+}
+
+// A helper struct for holding a Converter and SchemaGetter together in our map
+// of ROS2 types to converters (see below)
+struct ConverterFunctions {
+  using Converter = std::function<
+      void(const rcutils_uint8_array_t *, rcutils_uint8_array_t *)>;
+  using SchemaGetter = std::function<void(ReSimConverterSchemaInfo *)>;
+
+  Converter converter;
+  SchemaGetter schema_getter;
+};
+
+// This map holds onto all of the functions we need to get the schema and
+// convert for each given ROS2 message.
+const std::unordered_map<std::string, ConverterFunctions> converters_map = {
+    {"nav_msgs/msg/Odometry",
+     {convert_message<nav_msgs::msg::Odometry>,
+      generate_type_schema<nav_msgs::msg::Odometry>}},
+    {"tf2_msgs/msg/TFMessage",
+     {convert_message<tf2_msgs::msg::TFMessage>,
+      generate_type_schema<tf2_msgs::msg::TFMessage>}},
+};
+
+}  // namespace
+
+// Implement the actual functions for this plugin:
+
+extern "C" bool resim_convert_supports_ros2_type(
+    const char *ros2_message_type) {
+  if (std::string(ros2_message_type) == "std_msgs/msg/UInt8MultiArray") {
+    return true;
+  }
+  return converters_map.contains(ros2_message_type);
+}
+
+extern "C" ReSimConverterPluginStatus resim_convert_ros2_to_resim(
+    const char *const ros2_message_type,
+    const rcutils_uint8_array_t *const ros2_message,
+    rcutils_uint8_array_t *const resim_message) {
+  try {
+    converters_map.at(ros2_message_type).converter(ros2_message, resim_message);
+  } catch (...) {
+    return RESIM_CONVERTER_PLUGIN_STATUS_ERROR;
+  }
+  return RESIM_CONVERTER_PLUGIN_STATUS_OK;
+}
+
+extern "C" ReSimConverterPluginStatus resim_convert_get_resim_schema(
+    const char *const ros2_message_type,
+    ReSimConverterSchemaInfo *schema_info) {
+  if (std::string(ros2_message_type) == "std_msgs/msg/UInt8MultiArray") {
+    converters_map.cbegin()->second.schema_getter(schema_info);
+    return RESIM_CONVERTER_PLUGIN_STATUS_OK;
+  }
+  converters_map.at(ros2_message_type).schema_getter(schema_info);
+  return RESIM_CONVERTER_PLUGIN_STATUS_OK;
+}
+
+}  // namespace resim::ros2

--- a/resim/ros2/testing/resim_log_from_ros2_test_converter_plugin.cc
+++ b/resim/ros2/testing/resim_log_from_ros2_test_converter_plugin.cc
@@ -4,6 +4,11 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+// This file defines a simple test converter plugin which correctly
+// converts Odometry and TFMessages, and claims to convert
+// std_msgs/msg/UInt8MultiArray, but actually fails when one tries
+// this.
+
 #include <cstdint>
 #include <functional>
 #include <string>
@@ -66,7 +71,6 @@ const std::unordered_map<std::string, ConverterFunctions> converters_map = {
 }  // namespace
 
 // Implement the actual functions for this plugin:
-
 extern "C" bool resim_convert_supports_ros2_type(
     const char *ros2_message_type) {
   if (std::string(ros2_message_type) == "std_msgs/msg/UInt8MultiArray") {


### PR DESCRIPTION
## Description of change
In some cases, we encounter old/invalid messages in a rosbag that we don't care about. We don't want these to crash the converter script so we now warn instead of crashing.

## Guide to reproduce test results.
```
bazel test //resim/ros2/...
```
## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
