### PR TITLE
Allow the polygon distance function to fail gracefully

### DIFF
--- a/resim/geometry/BUILD
+++ b/resim/geometry/BUILD
@@ -204,6 +204,7 @@ cc_library(
         ":gjk_algorithm",
         ":polygon_utils",
         "//resim/assert",
+        "@com_github_google_glog//:glog",
         "@libeigen//:eigen",
     ],
 )

--- a/resim/geometry/polygon_distance.cc
+++ b/resim/geometry/polygon_distance.cc
@@ -6,6 +6,8 @@
 
 #include "resim/geometry/polygon_distance.hh"
 
+#include <glog/logging.h>
+
 #include "resim/assert/assert.hh"
 #include "resim/geometry/gjk_algorithm.hh"
 #include "resim/geometry/polygon_utils.hh"
@@ -33,7 +35,11 @@ void assert_convex(const std::vector<Eigen::Vector2d> &polygon) {
     if (sign == 0.) {
       sign = cross_sign;
     } else {
-      REASSERT(sign == cross_sign, "Polygon is non-convex!");
+      if (sign != cross_sign) {
+        LOG(WARNING)
+            << "Polygon is non-convex! Distance result will be underestimated!";
+        return;
+      }
     }
   }
 }

--- a/resim/geometry/polygon_distance_test.cc
+++ b/resim/geometry/polygon_distance_test.cc
@@ -78,17 +78,17 @@ TEST(PolygonDistanceTest, TestNonConvex) {
   const std::vector<Eigen::Vector2d> polygon_a{
       {-1.0, 1.0},
       {-1.0, -1.0},
-      {0.5, 0.5},
       {1.0, -1.0},
+      {-0.5, -0.5},
   };
   const std::vector<Eigen::Vector2d> triangle_b{
-      {0.0, 1.5},
+      {-0.25, -0.25},
       {1.0, 2.5},
-      {-1.0, 2.5},
+      {2.5, 1.0},
   };
 
   // ACTION / VERIFICATION
-  EXPECT_THROW(polygon_distance(polygon_a, triangle_b), AssertException);
+  EXPECT_EQ(polygon_distance(polygon_a, triangle_b), 0.0);
 }
 
 TEST(PolygonDistanceTest, TestOverlappingRectangles) {


### PR DESCRIPTION
## Description of change
We don't want to be as stringent here. Better to just warn the user about the shortcoming.

## Guide to reproduce test results.
```bash
bazel test //resim/geometry:polygon_distance_test
```
## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
