### PR TITLE
Add ROS2 converters for primitive types

### DIFF
--- a/resim/msg/BUILD
+++ b/resim/msg/BUILD
@@ -236,6 +236,10 @@ cc_library(
     name = "byte_swap_helpers",
     srcs = ["byte_swap_helpers.cc"],
     hdrs = ["byte_swap_helpers.hh"],
+    visibility = [
+        "//resim/msg:__subpackages__",
+        "//resim/ros2:__subpackages__",
+    ],
     deps = [
         ":primitives_proto_cc",
         "//resim/utils:inout",

--- a/resim/msg/BUILD
+++ b/resim/msg/BUILD
@@ -166,6 +166,28 @@ py_proto_library(
     ],
 )
 
+proto_library(
+    name = "primitives_proto",
+    srcs = ["primitives.proto"],
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "primitives_proto_cc",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":primitives_proto",
+    ],
+)
+
+py_proto_library(
+    name = "primitives_proto_py",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":primitives_proto",
+    ],
+)
+
 ################################################################################
 # Helpers
 ################################################################################
@@ -177,11 +199,13 @@ cc_library(
     hdrs = ["fuzz_helpers.hh"],
     visibility = ["//visibility:public"],
     deps = [
+        ":byte_swap_helpers",
         ":detection_proto_cc",
         ":header_proto_cc",
         ":navsat_proto_cc",
         ":odometry_proto_cc",
         ":pose_proto_cc",
+        ":primitives_proto_cc",
         ":transform_proto_cc",
         "//resim/geometry/proto:fuzz_helpers",
         "//resim/testing:fuzz_helpers",
@@ -204,6 +228,27 @@ cc_test(
         ":pose_proto_cc",
         ":transform_proto_cc",
         "//resim/geometry/proto:fuzz_helpers",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "byte_swap_helpers",
+    srcs = ["byte_swap_helpers.cc"],
+    hdrs = ["byte_swap_helpers.hh"],
+    deps = [
+        ":primitives_proto_cc",
+        "//resim/utils:inout",
+    ],
+)
+
+cc_test(
+    name = "byte_swap_helpers_test",
+    srcs = ["byte_swap_helpers_test.cc"],
+    deps = [
+        ":byte_swap_helpers",
+        ":primitives_proto_cc",
+        "//resim/utils:inout",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/resim/msg/byte_swap_helpers.cc
+++ b/resim/msg/byte_swap_helpers.cc
@@ -47,7 +47,7 @@ void set_data(const uint16_t data, InOut<UInt16> msg) {
 template <std::endian target_order>
 int16_t data(const Int16 &msg) {
   constexpr size_t NUM_BYTES = 2;
-  std::array<std::byte, NUM_BYTES> data_bits;
+  std::array<std::byte, NUM_BYTES> data_bits{};
   std::memcpy(data_bits.data(), msg.data().data(), NUM_BYTES);
 
   static_assert(
@@ -62,7 +62,7 @@ int16_t data(const Int16 &msg) {
 template <std::endian target_order>
 uint16_t data(const UInt16 &msg) {
   constexpr size_t NUM_BYTES = 2;
-  std::array<std::byte, NUM_BYTES> data_bits;
+  std::array<std::byte, NUM_BYTES> data_bits{};
   std::memcpy(data_bits.data(), msg.data().data(), NUM_BYTES);
 
   static_assert(

--- a/resim/msg/byte_swap_helpers.cc
+++ b/resim/msg/byte_swap_helpers.cc
@@ -6,13 +6,12 @@
 
 #include "resim/msg/byte_swap_helpers.hh"
 
-#include <bit>
 #include <cstring>
-#include <iomanip>
 #include <utility>
 
 namespace resim::msg {
 
+template <std::endian target_order>
 void set_data(int16_t data, InOut<Int16> msg) {
   constexpr size_t NUM_BYTES = 2;
   std::string serialized{NUM_BYTES, '\0'};
@@ -21,7 +20,7 @@ void set_data(int16_t data, InOut<Int16> msg) {
   static_assert(
       std::endian::native == std::endian::little or
       std::endian::native == std::endian::big);
-  if constexpr (std::endian::native == std::endian::big) {
+  if constexpr (std::endian::native != target_order) {
     std::swap(data_bits.at(0), data_bits.at(1));
   }
 
@@ -29,6 +28,7 @@ void set_data(int16_t data, InOut<Int16> msg) {
   msg->set_data(serialized);
 }
 
+template <std::endian target_order>
 void set_data(const uint16_t data, InOut<UInt16> msg) {
   constexpr size_t NUM_BYTES = 2;
   std::string serialized{NUM_BYTES, '\0'};
@@ -37,13 +37,14 @@ void set_data(const uint16_t data, InOut<UInt16> msg) {
   static_assert(
       std::endian::native == std::endian::little or
       std::endian::native == std::endian::big);
-  if constexpr (std::endian::native == std::endian::big) {
+  if constexpr (std::endian::native != target_order) {
     std::swap(data_bits.at(0), data_bits.at(1));
   }
   std::memcpy(serialized.data(), &data_bits, NUM_BYTES);
   msg->set_data(serialized);
 }
 
+template <std::endian target_order>
 int16_t data(const Int16 &msg) {
   constexpr size_t NUM_BYTES = 2;
   std::array<std::byte, NUM_BYTES> data_bits;
@@ -52,12 +53,13 @@ int16_t data(const Int16 &msg) {
   static_assert(
       std::endian::native == std::endian::little or
       std::endian::native == std::endian::big);
-  if constexpr (std::endian::native == std::endian::big) {
+  if constexpr (std::endian::native != target_order) {
     std::swap(data_bits.at(0), data_bits.at(1));
   }
   return std::bit_cast<int16_t>(data_bits);
 }
 
+template <std::endian target_order>
 uint16_t data(const UInt16 &msg) {
   constexpr size_t NUM_BYTES = 2;
   std::array<std::byte, NUM_BYTES> data_bits;
@@ -66,10 +68,26 @@ uint16_t data(const UInt16 &msg) {
   static_assert(
       std::endian::native == std::endian::little or
       std::endian::native == std::endian::big);
-  if constexpr (std::endian::native == std::endian::big) {
+  if constexpr (std::endian::native != target_order) {
     std::swap(data_bits.at(0), data_bits.at(1));
   }
   return std::bit_cast<uint16_t>(data_bits);
 }
+
+template void set_data<std::endian::little>(int16_t data, InOut<Int16> msg);
+
+template void set_data<std::endian::little>(uint16_t data, InOut<UInt16> msg);
+
+template int16_t data<std::endian::little>(const Int16 &msg);
+
+template uint16_t data<std::endian::little>(const UInt16 &msg);
+
+template void set_data<std::endian::big>(int16_t data, InOut<Int16> msg);
+
+template void set_data<std::endian::big>(uint16_t data, InOut<UInt16> msg);
+
+template int16_t data<std::endian::big>(const Int16 &msg);
+
+template uint16_t data<std::endian::big>(const UInt16 &msg);
 
 }  // namespace resim::msg

--- a/resim/msg/byte_swap_helpers.cc
+++ b/resim/msg/byte_swap_helpers.cc
@@ -1,0 +1,75 @@
+// Copyright 2024 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include "resim/msg/byte_swap_helpers.hh"
+
+#include <bit>
+#include <cstring>
+#include <iomanip>
+#include <utility>
+
+namespace resim::msg {
+
+void set_data(int16_t data, InOut<Int16> msg) {
+  constexpr size_t NUM_BYTES = 2;
+  std::string serialized{NUM_BYTES, '\0'};
+  auto data_bits = std::bit_cast<std::array<std::byte, NUM_BYTES>>(data);
+
+  static_assert(
+      std::endian::native == std::endian::little or
+      std::endian::native == std::endian::big);
+  if constexpr (std::endian::native == std::endian::big) {
+    std::swap(data_bits.at(0), data_bits.at(1));
+  }
+
+  std::memcpy(serialized.data(), &data_bits, NUM_BYTES);
+  msg->set_data(serialized);
+}
+
+void set_data(const uint16_t data, InOut<UInt16> msg) {
+  constexpr size_t NUM_BYTES = 2;
+  std::string serialized{NUM_BYTES, '\0'};
+  auto data_bits = std::bit_cast<std::array<std::byte, NUM_BYTES>>(data);
+
+  static_assert(
+      std::endian::native == std::endian::little or
+      std::endian::native == std::endian::big);
+  if constexpr (std::endian::native == std::endian::big) {
+    std::swap(data_bits.at(0), data_bits.at(1));
+  }
+  std::memcpy(serialized.data(), &data_bits, NUM_BYTES);
+  msg->set_data(serialized);
+}
+
+int16_t data(const Int16 &msg) {
+  constexpr size_t NUM_BYTES = 2;
+  std::array<std::byte, NUM_BYTES> data_bits;
+  std::memcpy(data_bits.data(), msg.data().data(), NUM_BYTES);
+
+  static_assert(
+      std::endian::native == std::endian::little or
+      std::endian::native == std::endian::big);
+  if constexpr (std::endian::native == std::endian::big) {
+    std::swap(data_bits.at(0), data_bits.at(1));
+  }
+  return std::bit_cast<int16_t>(data_bits);
+}
+
+uint16_t data(const UInt16 &msg) {
+  constexpr size_t NUM_BYTES = 2;
+  std::array<std::byte, NUM_BYTES> data_bits;
+  std::memcpy(data_bits.data(), msg.data().data(), NUM_BYTES);
+
+  static_assert(
+      std::endian::native == std::endian::little or
+      std::endian::native == std::endian::big);
+  if constexpr (std::endian::native == std::endian::big) {
+    std::swap(data_bits.at(0), data_bits.at(1));
+  }
+  return std::bit_cast<uint16_t>(data_bits);
+}
+
+}  // namespace resim::msg

--- a/resim/msg/byte_swap_helpers.hh
+++ b/resim/msg/byte_swap_helpers.hh
@@ -3,7 +3,16 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
+//
+// byte_swap_helpers.hh
+//
+// This header contains helper functions used to ensure that we can
+// always write and read certain data types to protobuf bytes in
+// little endian order, regardless of platform. This is necssary for
+// int16, for instance, because protobuf does not have a native int16
+// type.
 
+#include <bit>
 #include <cstdint>
 
 #include "resim/msg/primitives.pb.h"
@@ -11,12 +20,24 @@
 
 namespace resim::msg {
 
+// Set the data field of Int16 to match an int in little endian
+// order (or big endian order if specified).
+template <std::endian target_order = std::endian::little>
 void set_data(int16_t data, InOut<Int16> msg);
 
+// Set the data field of UInt16 to match an int in little endian
+// order (or big endian order if specified).
+template <std::endian target_order = std::endian::little>
 void set_data(uint16_t data, InOut<UInt16> msg);
 
+// Get the data field of Int16 in little endian order (or big endian
+// order if specified).
+template <std::endian target_order = std::endian::little>
 int16_t data(const Int16 &msg);
 
+// Get the data field of UInt16 in little endian order (or big endian
+// order if specified).
+template <std::endian target_order = std::endian::little>
 uint16_t data(const UInt16 &msg);
 
 }  // namespace resim::msg

--- a/resim/msg/byte_swap_helpers.hh
+++ b/resim/msg/byte_swap_helpers.hh
@@ -1,0 +1,22 @@
+// Copyright 2024 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include <cstdint>
+
+#include "resim/msg/primitives.pb.h"
+#include "resim/utils/inout.hh"
+
+namespace resim::msg {
+
+void set_data(int16_t data, InOut<Int16> msg);
+
+void set_data(uint16_t data, InOut<UInt16> msg);
+
+int16_t data(const Int16 &msg);
+
+uint16_t data(const UInt16 &msg);
+
+}  // namespace resim::msg

--- a/resim/msg/byte_swap_helpers_test.cc
+++ b/resim/msg/byte_swap_helpers_test.cc
@@ -26,9 +26,11 @@ TEST(ByteSwapHelpersTest, TestSetBytes) {
   Int16 int16_msg;
   UInt16 uint16_msg;
 
+  // ACTION
   set_data(TEST_INT, InOut{int16_msg});
   set_data(TEST_UINT, InOut{uint16_msg});
 
+  // VERIFICATION
   constexpr size_t NUM_BYTES = 2u;
   EXPECT_EQ(
       std::memcmp(int16_msg.data().data(), expected_bytes.data(), NUM_BYTES),
@@ -48,9 +50,11 @@ TEST(ByteSwapHelpersTest, TestSetBytesBigEndian) {
   Int16 int16_msg;
   UInt16 uint16_msg;
 
+  // ACTION
   set_data<std::endian::big>(TEST_INT, InOut{int16_msg});
   set_data<std::endian::big>(TEST_UINT, InOut{uint16_msg});
 
+  // VERIFICATION
   constexpr size_t NUM_BYTES = 2u;
   EXPECT_EQ(
       std::memcmp(int16_msg.data().data(), expected_bytes.data(), NUM_BYTES),
@@ -71,12 +75,15 @@ TEST(ByteSwapHelpersTest, TestGetBytes) {
   set_data(TEST_INT, InOut{int16_msg});
   set_data(TEST_UINT, InOut{uint16_msg});
 
+  // ACTION / VERIFCIATION
   EXPECT_EQ(TEST_INT, data(int16_msg));
   EXPECT_EQ(TEST_UINT, data(uint16_msg));
 
+  // SETUP
   set_data<std::endian::big>(TEST_INT, InOut{int16_msg});
   set_data<std::endian::big>(TEST_UINT, InOut{uint16_msg});
 
+  // ACTION / VERIFCIATION
   EXPECT_EQ(TEST_INT, data<std::endian::big>(int16_msg));
   EXPECT_EQ(TEST_UINT, data<std::endian::big>(uint16_msg));
 }

--- a/resim/msg/byte_swap_helpers_test.cc
+++ b/resim/msg/byte_swap_helpers_test.cc
@@ -8,6 +8,7 @@
 
 #include <gtest/gtest.h>
 
+#include <bit>
 #include <cstring>
 
 #include "resim/msg/primitives.pb.h"
@@ -37,6 +38,28 @@ TEST(ByteSwapHelpersTest, TestSetBytes) {
       0u);
 }
 
+TEST(ByteSwapHelpersTest, TestSetBytesBigEndian) {
+  // SETUP
+  // Little endian
+  std::vector<uint8_t> expected_bytes{0xb7, 0x5a};
+  constexpr int16_t TEST_INT = -18598;
+  constexpr uint16_t TEST_UINT = 46938;
+
+  Int16 int16_msg;
+  UInt16 uint16_msg;
+
+  set_data<std::endian::big>(TEST_INT, InOut{int16_msg});
+  set_data<std::endian::big>(TEST_UINT, InOut{uint16_msg});
+
+  constexpr size_t NUM_BYTES = 2u;
+  EXPECT_EQ(
+      std::memcmp(int16_msg.data().data(), expected_bytes.data(), NUM_BYTES),
+      0u);
+  EXPECT_EQ(
+      std::memcmp(uint16_msg.data().data(), expected_bytes.data(), NUM_BYTES),
+      0u);
+}
+
 TEST(ByteSwapHelpersTest, TestGetBytes) {
   // SETUP
   constexpr int16_t TEST_INT = -18598;
@@ -50,6 +73,12 @@ TEST(ByteSwapHelpersTest, TestGetBytes) {
 
   EXPECT_EQ(TEST_INT, data(int16_msg));
   EXPECT_EQ(TEST_UINT, data(uint16_msg));
+
+  set_data<std::endian::big>(TEST_INT, InOut{int16_msg});
+  set_data<std::endian::big>(TEST_UINT, InOut{uint16_msg});
+
+  EXPECT_EQ(TEST_INT, data<std::endian::big>(int16_msg));
+  EXPECT_EQ(TEST_UINT, data<std::endian::big>(uint16_msg));
 }
 
 }  // namespace resim::msg

--- a/resim/msg/byte_swap_helpers_test.cc
+++ b/resim/msg/byte_swap_helpers_test.cc
@@ -19,6 +19,7 @@ namespace resim::msg {
 TEST(ByteSwapHelpersTest, TestSetBytes) {
   // SETUP
   // Little endian
+  // NOLINTNEXTLINE(readability-magic-numbers)
   std::vector<uint8_t> expected_bytes{0x5a, 0xb7};
   constexpr int16_t TEST_INT = -18598;
   constexpr uint16_t TEST_UINT = 46938;
@@ -43,6 +44,7 @@ TEST(ByteSwapHelpersTest, TestSetBytes) {
 TEST(ByteSwapHelpersTest, TestSetBytesBigEndian) {
   // SETUP
   // Little endian
+  // NOLINTNEXTLINE(readability-magic-numbers)
   std::vector<uint8_t> expected_bytes{0xb7, 0x5a};
   constexpr int16_t TEST_INT = -18598;
   constexpr uint16_t TEST_UINT = 46938;

--- a/resim/msg/byte_swap_helpers_test.cc
+++ b/resim/msg/byte_swap_helpers_test.cc
@@ -1,0 +1,55 @@
+// Copyright 2024 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include "resim/msg/byte_swap_helpers.hh"
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+
+#include "resim/msg/primitives.pb.h"
+#include "resim/utils/inout.hh"
+
+namespace resim::msg {
+
+TEST(ByteSwapHelpersTest, TestSetBytes) {
+  // SETUP
+  // Little endian
+  std::vector<uint8_t> expected_bytes{0x5a, 0xb7};
+  constexpr int16_t TEST_INT = -18598;
+  constexpr uint16_t TEST_UINT = 46938;
+
+  Int16 int16_msg;
+  UInt16 uint16_msg;
+
+  set_data(TEST_INT, InOut{int16_msg});
+  set_data(TEST_UINT, InOut{uint16_msg});
+
+  constexpr size_t NUM_BYTES = 2u;
+  EXPECT_EQ(
+      std::memcmp(int16_msg.data().data(), expected_bytes.data(), NUM_BYTES),
+      0u);
+  EXPECT_EQ(
+      std::memcmp(uint16_msg.data().data(), expected_bytes.data(), NUM_BYTES),
+      0u);
+}
+
+TEST(ByteSwapHelpersTest, TestGetBytes) {
+  // SETUP
+  constexpr int16_t TEST_INT = -18598;
+  constexpr uint16_t TEST_UINT = 46938;
+
+  Int16 int16_msg;
+  UInt16 uint16_msg;
+
+  set_data(TEST_INT, InOut{int16_msg});
+  set_data(TEST_UINT, InOut{uint16_msg});
+
+  EXPECT_EQ(TEST_INT, data(int16_msg));
+  EXPECT_EQ(TEST_UINT, data(uint16_msg));
+}
+
+}  // namespace resim::msg

--- a/resim/msg/byte_swap_helpers_test.cc
+++ b/resim/msg/byte_swap_helpers_test.cc
@@ -31,13 +31,13 @@ TEST(ByteSwapHelpersTest, TestSetBytes) {
   set_data(TEST_UINT, InOut{uint16_msg});
 
   // VERIFICATION
-  constexpr size_t NUM_BYTES = 2u;
+  constexpr size_t NUM_BYTES = 2U;
   EXPECT_EQ(
       std::memcmp(int16_msg.data().data(), expected_bytes.data(), NUM_BYTES),
-      0u);
+      0U);
   EXPECT_EQ(
       std::memcmp(uint16_msg.data().data(), expected_bytes.data(), NUM_BYTES),
-      0u);
+      0U);
 }
 
 TEST(ByteSwapHelpersTest, TestSetBytesBigEndian) {
@@ -55,13 +55,13 @@ TEST(ByteSwapHelpersTest, TestSetBytesBigEndian) {
   set_data<std::endian::big>(TEST_UINT, InOut{uint16_msg});
 
   // VERIFICATION
-  constexpr size_t NUM_BYTES = 2u;
+  constexpr size_t NUM_BYTES = 2U;
   EXPECT_EQ(
       std::memcmp(int16_msg.data().data(), expected_bytes.data(), NUM_BYTES),
-      0u);
+      0U);
   EXPECT_EQ(
       std::memcmp(uint16_msg.data().data(), expected_bytes.data(), NUM_BYTES),
-      0u);
+      0U);
 }
 
 TEST(ByteSwapHelpersTest, TestGetBytes) {

--- a/resim/msg/fuzz_helpers.cc
+++ b/resim/msg/fuzz_helpers.cc
@@ -180,4 +180,62 @@ bool verify_equality(const NavSatFix &a, const NavSatFix &b) {
          a.position_covariance_type() == b.position_covariance_type();
 }
 
+bool verify_equality(const Bool &a, const Bool &b) {
+  return a.data() == b.data();
+}
+
+bool verify_equality(const Byte &a, const Byte &b) {
+  return a.data() == b.data();
+}
+
+bool verify_equality(const Char &a, const Char &b) {
+  return a.data() == b.data();
+}
+
+bool verify_equality(const Empty &a, const Empty &b) { return true; }
+
+bool verify_equality(const Float32 &a, const Float32 &b) {
+  return a.data() == b.data();
+}
+
+bool verify_equality(const Float64 &a, const Float64 &b) {
+  return a.data() == b.data();
+}
+
+bool verify_equality(const Int16 &a, const Int16 &b) {
+  return a.data() == b.data();
+}
+
+bool verify_equality(const Int32 &a, const Int32 &b) {
+  return a.data() == b.data();
+}
+
+bool verify_equality(const Int64 &a, const Int64 &b) {
+  return a.data() == b.data();
+}
+
+bool verify_equality(const Int8 &a, const Int8 &b) {
+  return a.data() == b.data();
+}
+
+bool verify_equality(const String &a, const String &b) {
+  return a.data() == b.data();
+}
+
+bool verify_equality(const UInt16 &a, const UInt16 &b) {
+  return a.data() == b.data();
+}
+
+bool verify_equality(const UInt32 &a, const UInt32 &b) {
+  return a.data() == b.data();
+}
+
+bool verify_equality(const UInt64 &a, const UInt64 &b) {
+  return a.data() == b.data();
+}
+
+bool verify_equality(const UInt8 &a, const UInt8 &b) {
+  return a.data() == b.data();
+}
+
 }  // namespace resim::msg

--- a/resim/msg/fuzz_helpers.hh
+++ b/resim/msg/fuzz_helpers.hh
@@ -9,14 +9,17 @@
 #include <Eigen/Dense>
 #include <array>
 #include <cstdint>
+#include <limits>
 #include <random>
 
 #include "resim/geometry/proto/fuzz_helpers.hh"
+#include "resim/msg/byte_swap_helpers.hh"
 #include "resim/msg/detection.pb.h"
 #include "resim/msg/header.pb.h"
 #include "resim/msg/navsat.pb.h"
 #include "resim/msg/odometry.pb.h"
 #include "resim/msg/pose.pb.h"
+#include "resim/msg/primitives.pb.h"
 #include "resim/msg/transform.pb.h"
 #include "resim/testing/fuzz_helpers.hh"
 #include "resim/testing/random_matrix.hh"
@@ -273,6 +276,111 @@ NavSatFix random_element(TypeTag<NavSatFix> /*unused*/, InOut<Rng> rng) {
   return result;
 }
 
+template <typename Rng>
+Bool random_element(TypeTag<Bool> /*unused*/, InOut<Rng> rng) {
+  std::uniform_int_distribution dist{0, 1};
+  Bool result;
+  result.set_data((dist(*rng) % 2) == 0);
+  return result;
+}
+
+template <typename Rng>
+Byte random_element(TypeTag<Byte> /*unused*/, InOut<Rng> rng) {
+  Byte result;
+  result.set_data(std::string{random_element<char>(rng)});
+  return result;
+}
+
+template <typename Rng>
+Char random_element(TypeTag<Char> /*unused*/, InOut<Rng> rng) {
+  Char result;
+  result.set_data(std::string{random_element<char>(rng)});
+  return result;
+}
+
+template <typename Rng>
+Empty random_element(TypeTag<Empty> /*unused*/, InOut<Rng> rng) {
+  Empty result;
+  return result;
+}
+
+template <typename Rng>
+Float32 random_element(TypeTag<Float32> /*unused*/, InOut<Rng> rng) {
+  Float32 result;
+  result.set_data(random_element<float>(rng));
+  return result;
+}
+
+template <typename Rng>
+Float64 random_element(TypeTag<Float64> /*unused*/, InOut<Rng> rng) {
+  Float64 result;
+  result.set_data(random_element<double>(rng));
+  return result;
+}
+
+template <typename Rng>
+Int16 random_element(TypeTag<Int16> /*unused*/, InOut<Rng> rng) {
+  Int16 result;
+  set_data(random_element<int16_t>(rng), InOut{result});
+  return result;
+}
+
+template <typename Rng>
+Int32 random_element(TypeTag<Int32> /*unused*/, InOut<Rng> rng) {
+  Int32 result;
+  result.set_data(random_element<int32_t>(rng));
+  return result;
+}
+
+template <typename Rng>
+Int64 random_element(TypeTag<Int64> /*unused*/, InOut<Rng> rng) {
+  Int64 result;
+  result.set_data(random_element<int64_t>(rng));
+  return result;
+}
+
+template <typename Rng>
+Int8 random_element(TypeTag<Int8> /*unused*/, InOut<Rng> rng) {
+  Int8 result;
+  result.set_data(std::string{random_element<int8_t>(rng)});
+  return result;
+}
+
+template <typename Rng>
+String random_element(TypeTag<String> /*unused*/, InOut<Rng> rng) {
+  String result;
+  result.set_data(UUID::new_uuid().to_string());
+  return result;
+}
+
+template <typename Rng>
+UInt16 random_element(TypeTag<UInt16> /*unused*/, InOut<Rng> rng) {
+  UInt16 result;
+  set_data(random_element<int16_t>(rng), InOut{result});
+  return result;
+}
+
+template <typename Rng>
+UInt32 random_element(TypeTag<UInt32> /*unused*/, InOut<Rng> rng) {
+  UInt32 result;
+  result.set_data(random_element<uint32_t>(rng));
+  return result;
+}
+
+template <typename Rng>
+UInt64 random_element(TypeTag<UInt64> /*unused*/, InOut<Rng> rng) {
+  UInt64 result;
+  result.set_data(random_element<uint64_t>(rng));
+  return result;
+}
+
+template <typename Rng>
+UInt8 random_element(TypeTag<UInt8> /*unused*/, InOut<Rng> rng) {
+  UInt8 result;
+  result.set_data(std::string{random_element<int8_t>(rng)});
+  return result;
+}
+
 bool verify_equality(const Header &a, const Header &b);
 
 bool verify_equality(const TransformStamped &a, const TransformStamped &b);
@@ -306,5 +414,35 @@ bool verify_equality(const Detection3DArray &a, const Detection3DArray &b);
 bool verify_equality(const Detection2DArray &a, const Detection2DArray &b);
 
 bool verify_equality(const NavSatFix &a, const NavSatFix &b);
+
+bool verify_equality(const Bool &a, const Bool &b);
+
+bool verify_equality(const Byte &a, const Byte &b);
+
+bool verify_equality(const Char &a, const Char &b);
+
+bool verify_equality(const Empty &a, const Empty &b);
+
+bool verify_equality(const Float32 &a, const Float32 &b);
+
+bool verify_equality(const Float64 &a, const Float64 &b);
+
+bool verify_equality(const Int16 &a, const Int16 &b);
+
+bool verify_equality(const Int32 &a, const Int32 &b);
+
+bool verify_equality(const Int64 &a, const Int64 &b);
+
+bool verify_equality(const Int8 &a, const Int8 &b);
+
+bool verify_equality(const String &a, const String &b);
+
+bool verify_equality(const UInt16 &a, const UInt16 &b);
+
+bool verify_equality(const UInt32 &a, const UInt32 &b);
+
+bool verify_equality(const UInt64 &a, const UInt64 &b);
+
+bool verify_equality(const UInt8 &a, const UInt8 &b);
 
 }  // namespace resim::msg

--- a/resim/msg/fuzz_helpers_test.cc
+++ b/resim/msg/fuzz_helpers_test.cc
@@ -491,4 +491,39 @@ TEST(FuzzHelpersTest, TestNavSatFixEqual) {
       verify_equality(nav_sat_fix_different_covariance_type, nav_sat_fix));
 }
 
+template <typename T>
+class PrimitiveFuzzHelpersTest : public ::testing::Test {};
+
+using PrimitiveTypes = ::testing::Types<
+    Bool,
+    Byte,
+    Char,
+    Float32,
+    Float64,
+    Int16,
+    Int32,
+    Int64,
+    Int8,
+    String,
+    UInt16,
+    UInt32,
+    UInt64,
+    UInt8>;
+
+TYPED_TEST_SUITE(PrimitiveFuzzHelpersTest, PrimitiveTypes);
+
+TYPED_TEST(PrimitiveFuzzHelpersTest, TestEquality) {
+  // SETUP
+  constexpr std::size_t SEED = 913U;
+  std::mt19937 rng{SEED};
+
+  const auto test_value{random_element<TypeParam>(InOut{rng})};
+  const auto different_value{random_element<TypeParam>(InOut{rng})};
+
+  // ACTION / VERIFICATION
+  EXPECT_TRUE(verify_equality(test_value, test_value));
+  EXPECT_FALSE(verify_equality(test_value, different_value));
+  EXPECT_FALSE(verify_equality(different_value, test_value));
+}
+
 }  // namespace resim::msg

--- a/resim/msg/fuzz_helpers_test.cc
+++ b/resim/msg/fuzz_helpers_test.cc
@@ -526,4 +526,18 @@ TYPED_TEST(PrimitiveFuzzHelpersTest, TestEquality) {
   EXPECT_FALSE(verify_equality(different_value, test_value));
 }
 
+TEST(FuzzHelpersTest, TestEmpty) {
+  // SETUP
+  constexpr std::size_t SEED = 913U;
+  std::mt19937 rng{SEED};
+
+  const auto test_value{random_element<Empty>(InOut{rng})};
+  const auto different_value{random_element<Empty>(InOut{rng})};
+
+  // ACTION / VERIFICATION
+  EXPECT_TRUE(verify_equality(test_value, test_value));
+  EXPECT_TRUE(verify_equality(test_value, different_value));
+  EXPECT_TRUE(verify_equality(different_value, test_value));
+}
+
 }  // namespace resim::msg

--- a/resim/msg/primitives.proto
+++ b/resim/msg/primitives.proto
@@ -1,0 +1,70 @@
+// Copyright 2024 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+syntax = "proto3";
+
+package resim.msg;
+
+// This message holds a boolean in a protobuf message so it can be
+// represented as an independent message (rather than a field in
+// another message).
+message Bool {
+    bool data = 1;
+}
+
+message Byte {
+    bytes data = 1;
+}
+
+message Char {
+    bytes data = 1;
+}
+
+message Float32 {
+    float data = 1;
+}
+
+message Float64 {
+    double data = 1;
+}
+
+message Int16 {
+    bytes data = 1;
+}
+
+message Int32 {
+    int32 data = 1;
+}
+
+message Int64 {
+    int64 data = 1;
+}
+
+message Int8 {
+    bytes data = 1;
+}
+
+message String {
+    string data = 1;
+}
+
+message UInt16 {
+    bytes data = 1;
+}
+
+message UInt32 {
+    uint32 data = 1;
+}
+
+message UInt64 {
+    uint64 data = 1;
+}
+
+message UInt8 {
+    bytes data = 1;
+}
+
+message Empty {}

--- a/resim/msg/primitives.proto
+++ b/resim/msg/primitives.proto
@@ -8,9 +8,9 @@ syntax = "proto3";
 
 package resim.msg;
 
-// This message holds a boolean in a protobuf message so it can be
-// represented as an independent message (rather than a field in
-// another message).
+// These messages hold various primitive types wrapped in messages in
+// case we want to serialize and store them.
+
 message Bool {
     bool data = 1;
 }

--- a/resim/ros2/BUILD
+++ b/resim/ros2/BUILD
@@ -12,6 +12,17 @@ load("@rules_python//python:defs.bzl", "py_test")
 load(":ros2_py_package.bzl", "ros2_py_package")
 
 cc_library(
+    name = "primitives_from_ros2",
+    srcs = ["primitives_from_ros2.cc"],
+    hdrs = ["primitives_from_ros2.hh"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//resim/msg:primitives_proto_cc",
+        "@ros2_common_interfaces//:cpp_std_msgs",
+    ],
+)
+
+cc_library(
     name = "time_from_ros2",
     srcs = ["time_from_ros2.cc"],
     hdrs = ["time_from_ros2.hh"],

--- a/resim/ros2/BUILD
+++ b/resim/ros2/BUILD
@@ -17,8 +17,23 @@ cc_library(
     hdrs = ["primitives_from_ros2.hh"],
     visibility = ["//visibility:public"],
     deps = [
+        "//resim/assert",
+        "//resim/msg:byte_swap_helpers",
         "//resim/msg:primitives_proto_cc",
         "@ros2_common_interfaces//:cpp_std_msgs",
+    ],
+)
+
+cc_test(
+    name = "primitives_from_ros2_test",
+    srcs = ["primitives_from_ros2_test.cc"],
+    deps = [
+        ":primitives_from_ros2",
+        "//resim/msg:fuzz_helpers",
+        "//resim/msg:primitives_proto_cc",
+        "//resim/testing:fuzz_helpers",
+        "//resim/utils:inout",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 

--- a/resim/ros2/primitives_from_ros2.cc
+++ b/resim/ros2/primitives_from_ros2.cc
@@ -1,0 +1,25 @@
+// Copyright 2024 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include "resim/ros2/primitives_from_ros2.hh"
+
+namespace resim::ros2 {
+
+// ROS2 converters for odometry
+
+msg::Bool convert_from_ros2(const std_msgs::msg::Bool &ros2_msg) {
+  msg::Bool result;
+  result.set_data(ros2_msg.data);
+  return result;
+}
+
+std_msgs::msg::Bool convert_to_ros2(const msg::Bool &resim_msg) {
+  std_msgs::msg::Bool result;
+  result.data = resim_msg.data();
+  return result;
+}
+
+}  // namespace resim::ros2

--- a/resim/ros2/primitives_from_ros2.cc
+++ b/resim/ros2/primitives_from_ros2.cc
@@ -6,9 +6,10 @@
 
 #include "resim/ros2/primitives_from_ros2.hh"
 
-namespace resim::ros2 {
+#include "resim/assert/assert.hh"
+#include "resim/msg/byte_swap_helpers.hh"
 
-// ROS2 converters for odometry
+namespace resim::ros2 {
 
 msg::Bool convert_from_ros2(const std_msgs::msg::Bool &ros2_msg) {
   msg::Bool result;
@@ -19,6 +20,176 @@ msg::Bool convert_from_ros2(const std_msgs::msg::Bool &ros2_msg) {
 std_msgs::msg::Bool convert_to_ros2(const msg::Bool &resim_msg) {
   std_msgs::msg::Bool result;
   result.data = resim_msg.data();
+  return result;
+}
+
+msg::Byte convert_from_ros2(const std_msgs::msg::Byte &ros2_msg) {
+  msg::Byte result;
+  result.set_data(std::string{static_cast<char>(ros2_msg.data)});
+  return result;
+}
+
+std_msgs::msg::Byte convert_to_ros2(const msg::Byte &resim_msg) {
+  std_msgs::msg::Byte result;
+  REASSERT(resim_msg.data().size() == 1U);
+  result.data = resim_msg.data().at(0);
+  return result;
+}
+
+msg::Char convert_from_ros2(const std_msgs::msg::Char &ros2_msg) {
+  msg::Char result;
+  result.set_data(std::string{static_cast<char>(ros2_msg.data)});
+  return result;
+}
+
+std_msgs::msg::Char convert_to_ros2(const msg::Char &resim_msg) {
+  std_msgs::msg::Char result;
+  REASSERT(resim_msg.data().size() == 1U);
+  result.data = resim_msg.data().at(0);
+  return result;
+}
+
+msg::Empty convert_from_ros2(const std_msgs::msg::Empty &ros2_msg) {
+  msg::Empty result;
+  return result;
+}
+
+std_msgs::msg::Empty convert_to_ros2(const msg::Empty &resim_msg) {
+  std_msgs::msg::Empty result;
+  return result;
+}
+
+msg::Float32 convert_from_ros2(const std_msgs::msg::Float32 &ros2_msg) {
+  msg::Float32 result;
+  result.set_data(ros2_msg.data);
+  return result;
+}
+
+std_msgs::msg::Float32 convert_to_ros2(const msg::Float32 &resim_msg) {
+  std_msgs::msg::Float32 result;
+  result.data = resim_msg.data();
+  return result;
+}
+
+msg::Float64 convert_from_ros2(const std_msgs::msg::Float64 &ros2_msg) {
+  msg::Float64 result;
+  result.set_data(ros2_msg.data);
+  return result;
+}
+
+std_msgs::msg::Float64 convert_to_ros2(const msg::Float64 &resim_msg) {
+  std_msgs::msg::Float64 result;
+  result.data = resim_msg.data();
+  return result;
+}
+
+msg::Int16 convert_from_ros2(const std_msgs::msg::Int16 &ros2_msg) {
+  msg::Int16 result;
+  set_data(ros2_msg.data, InOut{result});
+  return result;
+}
+
+std_msgs::msg::Int16 convert_to_ros2(const msg::Int16 &resim_msg) {
+  std_msgs::msg::Int16 result;
+  result.data = data(resim_msg);
+  return result;
+}
+
+msg::Int32 convert_from_ros2(const std_msgs::msg::Int32 &ros2_msg) {
+  msg::Int32 result;
+  result.set_data(ros2_msg.data);
+  return result;
+}
+
+std_msgs::msg::Int32 convert_to_ros2(const msg::Int32 &resim_msg) {
+  std_msgs::msg::Int32 result;
+  result.data = resim_msg.data();
+  return result;
+}
+
+msg::Int64 convert_from_ros2(const std_msgs::msg::Int64 &ros2_msg) {
+  msg::Int64 result;
+  result.set_data(ros2_msg.data);
+  return result;
+}
+
+std_msgs::msg::Int64 convert_to_ros2(const msg::Int64 &resim_msg) {
+  std_msgs::msg::Int64 result;
+  result.data = resim_msg.data();
+  return result;
+}
+
+msg::Int8 convert_from_ros2(const std_msgs::msg::Int8 &ros2_msg) {
+  msg::Int8 result;
+  result.set_data(std::string{ros2_msg.data});
+  return result;
+}
+
+std_msgs::msg::Int8 convert_to_ros2(const msg::Int8 &resim_msg) {
+  std_msgs::msg::Int8 result;
+  REASSERT(resim_msg.data().size() == 1U);
+  result.data = resim_msg.data().at(0);
+  return result;
+}
+
+msg::String convert_from_ros2(const std_msgs::msg::String &ros2_msg) {
+  msg::String result;
+  result.set_data(ros2_msg.data);
+  return result;
+}
+
+std_msgs::msg::String convert_to_ros2(const msg::String &resim_msg) {
+  std_msgs::msg::String result;
+  result.data = resim_msg.data();
+  return result;
+}
+
+msg::UInt16 convert_from_ros2(const std_msgs::msg::UInt16 &ros2_msg) {
+  msg::UInt16 result;
+  set_data(ros2_msg.data, InOut{result});
+  return result;
+}
+
+std_msgs::msg::UInt16 convert_to_ros2(const msg::UInt16 &resim_msg) {
+  std_msgs::msg::UInt16 result;
+  result.data = data(resim_msg);
+  return result;
+}
+
+msg::UInt32 convert_from_ros2(const std_msgs::msg::UInt32 &ros2_msg) {
+  msg::UInt32 result;
+  result.set_data(ros2_msg.data);
+  return result;
+}
+
+std_msgs::msg::UInt32 convert_to_ros2(const msg::UInt32 &resim_msg) {
+  std_msgs::msg::UInt32 result;
+  result.data = resim_msg.data();
+  return result;
+}
+
+msg::UInt64 convert_from_ros2(const std_msgs::msg::UInt64 &ros2_msg) {
+  msg::UInt64 result;
+  result.set_data(ros2_msg.data);
+  return result;
+}
+
+std_msgs::msg::UInt64 convert_to_ros2(const msg::UInt64 &resim_msg) {
+  std_msgs::msg::UInt64 result;
+  result.data = resim_msg.data();
+  return result;
+}
+
+msg::UInt8 convert_from_ros2(const std_msgs::msg::UInt8 &ros2_msg) {
+  msg::UInt8 result;
+  result.set_data(std::string{static_cast<char>(ros2_msg.data)});
+  return result;
+}
+
+std_msgs::msg::UInt8 convert_to_ros2(const msg::UInt8 &resim_msg) {
+  std_msgs::msg::UInt8 result;
+  REASSERT(resim_msg.data().size() == 1U);
+  result.data = resim_msg.data().at(0);
   return result;
 }
 

--- a/resim/ros2/primitives_from_ros2.hh
+++ b/resim/ros2/primitives_from_ros2.hh
@@ -7,15 +7,85 @@
 #pragma once
 
 #include <std_msgs/msg/bool.hpp>
+#include <std_msgs/msg/byte.hpp>
+#include <std_msgs/msg/char.hpp>
+#include <std_msgs/msg/empty.hpp>
+#include <std_msgs/msg/float32.hpp>
+#include <std_msgs/msg/float64.hpp>
+#include <std_msgs/msg/int16.hpp>
+#include <std_msgs/msg/int32.hpp>
+#include <std_msgs/msg/int64.hpp>
+#include <std_msgs/msg/int8.hpp>
+#include <std_msgs/msg/string.hpp>
+#include <std_msgs/msg/u_int16.hpp>
+#include <std_msgs/msg/u_int32.hpp>
+#include <std_msgs/msg/u_int64.hpp>
+#include <std_msgs/msg/u_int8.hpp>
 
 #include "resim/msg/primitives.pb.h"
 
 namespace resim::ros2 {
 
-// ROS2 converters for odometry
+// ROS2 converters for primitives
 
 msg::Bool convert_from_ros2(const std_msgs::msg::Bool &ros2_msg);
 
 std_msgs::msg::Bool convert_to_ros2(const msg::Bool &resim_msg);
+
+msg::Byte convert_from_ros2(const std_msgs::msg::Byte &ros2_msg);
+
+std_msgs::msg::Byte convert_to_ros2(const msg::Byte &resim_msg);
+
+msg::Char convert_from_ros2(const std_msgs::msg::Char &ros2_msg);
+
+std_msgs::msg::Char convert_to_ros2(const msg::Char &resim_msg);
+
+msg::Empty convert_from_ros2(const std_msgs::msg::Empty &ros2_msg);
+
+std_msgs::msg::Empty convert_to_ros2(const msg::Empty &resim_msg);
+
+msg::Float32 convert_from_ros2(const std_msgs::msg::Float32 &ros2_msg);
+
+std_msgs::msg::Float32 convert_to_ros2(const msg::Float32 &resim_msg);
+
+msg::Float64 convert_from_ros2(const std_msgs::msg::Float64 &ros2_msg);
+
+std_msgs::msg::Float64 convert_to_ros2(const msg::Float64 &resim_msg);
+
+msg::Int16 convert_from_ros2(const std_msgs::msg::Int16 &ros2_msg);
+
+std_msgs::msg::Int16 convert_to_ros2(const msg::Int16 &resim_msg);
+
+msg::Int32 convert_from_ros2(const std_msgs::msg::Int32 &ros2_msg);
+
+std_msgs::msg::Int32 convert_to_ros2(const msg::Int32 &resim_msg);
+
+msg::Int64 convert_from_ros2(const std_msgs::msg::Int64 &ros2_msg);
+
+std_msgs::msg::Int64 convert_to_ros2(const msg::Int64 &resim_msg);
+
+msg::Int8 convert_from_ros2(const std_msgs::msg::Int8 &ros2_msg);
+
+std_msgs::msg::Int8 convert_to_ros2(const msg::Int8 &resim_msg);
+
+msg::String convert_from_ros2(const std_msgs::msg::String &ros2_msg);
+
+std_msgs::msg::String convert_to_ros2(const msg::String &resim_msg);
+
+msg::UInt16 convert_from_ros2(const std_msgs::msg::UInt16 &ros2_msg);
+
+std_msgs::msg::UInt16 convert_to_ros2(const msg::UInt16 &resim_msg);
+
+msg::UInt32 convert_from_ros2(const std_msgs::msg::UInt32 &ros2_msgz);
+
+std_msgs::msg::UInt32 convert_to_ros2(const msg::UInt32 &resim_msg);
+
+msg::UInt64 convert_from_ros2(const std_msgs::msg::UInt64 &ros2_msg);
+
+std_msgs::msg::UInt64 convert_to_ros2(const msg::UInt64 &resim_msg);
+
+msg::UInt8 convert_from_ros2(const std_msgs::msg::UInt8 &ros2_msg);
+
+std_msgs::msg::UInt8 convert_to_ros2(const msg::UInt8 &resim_msg);
 
 }  // namespace resim::ros2

--- a/resim/ros2/primitives_from_ros2.hh
+++ b/resim/ros2/primitives_from_ros2.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#pragma once
+
+#include <std_msgs/msg/bool.hpp>
+
+#include "resim/msg/primitives.pb.h"
+
+namespace resim::ros2 {
+
+// ROS2 converters for odometry
+
+msg::Bool convert_from_ros2(const std_msgs::msg::Bool &ros2_msg);
+
+std_msgs::msg::Bool convert_to_ros2(const msg::Bool &resim_msg);
+
+}  // namespace resim::ros2

--- a/resim/ros2/primitives_from_ros2_test.cc
+++ b/resim/ros2/primitives_from_ros2_test.cc
@@ -1,0 +1,55 @@
+// Copyright 2024 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include "resim/ros2/primitives_from_ros2.hh"
+
+#include <gtest/gtest.h>
+
+#include <random>
+
+#include "resim/msg/fuzz_helpers.hh"
+#include "resim/msg/primitives.pb.h"
+#include "resim/testing/fuzz_helpers.hh"
+#include "resim/utils/inout.hh"
+
+namespace resim::ros2 {
+
+using Types = ::testing::Types<
+    msg::Byte,
+    msg::Char,
+    msg::Empty,
+    msg::Float32,
+    msg::Float64,
+    msg::Int16,
+    msg::Int32,
+    msg::Int64,
+    msg::Int8,
+    msg::String,
+    msg::UInt16,
+    msg::UInt32,
+    msg::UInt64,
+    msg::UInt8>;
+
+template <typename T>
+struct PrimitivesFromRos2Test : public ::testing::Test {};
+
+TYPED_TEST_SUITE(PrimitivesFromRos2Test, Types);
+
+TYPED_TEST(PrimitivesFromRos2Test, TestRoundTrip) {
+  // SETUP
+  constexpr std::size_t SEED = 913U;
+  std::mt19937 rng{SEED};
+  const TypeParam test_element{random_element<TypeParam>(InOut{rng})};
+
+  // ACTION
+  const TypeParam round_tripped{
+      convert_from_ros2(convert_to_ros2(test_element))};
+
+  // VERIFICATION
+  EXPECT_TRUE(verify_equality(test_element, round_tripped));
+}
+
+}  // namespace resim::ros2

--- a/resim/ros2/primitives_from_ros2_test.cc
+++ b/resim/ros2/primitives_from_ros2_test.cc
@@ -18,6 +18,7 @@
 namespace resim::ros2 {
 
 using Types = ::testing::Types<
+    msg::Bool,
     msg::Byte,
     msg::Char,
     msg::Empty,


### PR DESCRIPTION
## Description of change
Add primitive message types and ROS2 converters for them.

## Guide to reproduce test results.
```
bazel test //resim/msg:byte_swap_helpers_test
bazel test //resim/msg:fuzz_helpers_test
bazel test //resim/ros2:primitives_from_ros2_test
```
## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
