### PR TITLE
Revert "Revert "Add new BLOCK failure status""

### DIFF
--- a/resim/metrics/proto/generate_test_metrics.py
+++ b/resim/metrics/proto/generate_test_metrics.py
@@ -63,13 +63,13 @@ def _add_double_summary_metric(job_metrics: mp.JobMetrics) -> None:
     double_summary_values.failure_definition.fails_above = 29.0576
 
 
-def _add_event_counts(job_metrics: mp.JobMetrics) -> None:
+def _add_event_counts(job_metrics: mp.JobMetrics, block_fail: bool) -> None:
     metric = job_metrics.job_level_metrics.metrics.add()
     metric.metric_id.id.data = _get_uuid_str()
-    metric.name = "Event counts"
+    metric.name = "Event counts " + ("blocking" if block_fail else "warning")
     metric.type = mp.DOUBLE_SUMMARY_METRIC_TYPE
     metric.description = "Counts for various events"
-    metric.status = mp.PASSED_METRIC_STATUS
+    metric.status = mp.FAIL_BLOCK_METRIC_STATUS if block_fail else mp.FAIL_WARN_METRIC_STATUS
     metric.should_display = True
     metric.blocking = False
     metric.importance = mp.MEDIUM_IMPORTANCE
@@ -79,7 +79,7 @@ def _add_event_counts(job_metrics: mp.JobMetrics) -> None:
     data = job_metrics.metrics_data.add()
     data.metrics_data_id.id.data = _get_uuid_str()
     data.data_type = mp.DOUBLE_SERIES_DATA_TYPE
-    data.name = "Event counts data"
+    data.name = "Event counts data " + ("blocking" if block_fail else "warning")
     data.unit = ""
     data.is_per_category = True
     data.category_names.append("Engage")
@@ -92,7 +92,7 @@ def _add_event_counts(job_metrics: mp.JobMetrics) -> None:
     status_data = job_metrics.metrics_data.add()
     status_data.metrics_data_id.id.data = _get_uuid_str()
     status_data.data_type = mp.METRIC_STATUS_SERIES_DATA_TYPE
-    status_data.name = "Event counts status"
+    status_data.name = "Event counts status " + ("blocking" if block_fail else "warning")
     status_data.unit = ""
     status_data.is_per_category = True
     status_data.category_names.append("Engage")
@@ -100,7 +100,7 @@ def _add_event_counts(job_metrics: mp.JobMetrics) -> None:
     status_data.series_per_category.category_to_series["Engage"].statuses.series.append(
         mp.PASSED_METRIC_STATUS)
     status_data.series_per_category.category_to_series["Disengage"].statuses.series.append(
-        mp.FAILED_METRIC_STATUS)
+        mp.FAIL_BLOCK_METRIC_STATUS if block_fail else mp.FAIL_WARN_METRIC_STATUS)
 
     double_summary_values = metric.metric_values.double_metric_values
     double_summary_values.value_data_id.CopyFrom(data.metrics_data_id)
@@ -255,8 +255,8 @@ def _add_double_over_time_metric(job_metrics: mp.JobMetrics) -> None:
         ttc_statuses = ttc_status.series.statuses
         for val in ttc_doubles.series:
             if val < fails_below:
-                ttc_statuses.series.append(mp.FAILED_METRIC_STATUS)
-                metric.status = mp.FAILED_METRIC_STATUS
+                ttc_statuses.series.append(mp.FAIL_WARN_METRIC_STATUS)
+                metric.status = mp.FAIL_WARN_METRIC_STATUS
             else:
                 ttc_statuses.series.append(mp.PASSED_METRIC_STATUS)
 
@@ -350,13 +350,13 @@ def _add_line_plot_metric(job_metrics: mp.JobMetrics) -> None:
     line_plot_values.x_axis_name = "Predicted minimum distance"
 
 
-def _add_bar_chart_metric(job_metrics: mp.JobMetrics) -> None:
+def _add_bar_chart_metric(job_metrics: mp.JobMetrics, block_fail: bool) -> None:
     metric = job_metrics.job_level_metrics.metrics.add()
     metric.metric_id.id.data = _get_uuid_str()
     metric.name = "Detection latency"
     metric.type = mp.BAR_CHART_METRIC_TYPE
     metric.description = "Average latency on computing detections from images"
-    metric.status = mp.FAILED_METRIC_STATUS
+    metric.status = mp.FAIL_BLOCK_METRIC_STATUS if block_fail else mp.FAIL_WARN_METRIC_STATUS
     metric.should_display = True
     metric.blocking = False
     metric.importance = mp.MEDIUM_IMPORTANCE
@@ -374,14 +374,14 @@ def _add_bar_chart_metric(job_metrics: mp.JobMetrics) -> None:
     data_series: list[dict[str, Any]] = [{
         "name": "Camera timings",
         "data": [1.5, 2.6, 1.8],
-        "statuses": [mp.PASSED_METRIC_STATUS, mp.FAILED_METRIC_STATUS,
-                     mp.PASSED_METRIC_STATUS],
+        "statuses": [mp.PASSED_METRIC_STATUS, mp.FAIL_WARN_METRIC_STATUS,
+                     mp.FAIL_BLOCK_METRIC_STATUS if block_fail else mp.FAIL_WARN_METRIC_STATUS],
     },
         {
         "name": "Pytorch timings",
         "data": [10.1, 9.2, 12.3],
-        "statuses": [mp.FAILED_METRIC_STATUS, mp.FAILED_METRIC_STATUS,
-                     mp.PASSED_METRIC_STATUS],
+        "statuses": [mp.FAIL_WARN_METRIC_STATUS, mp.FAIL_WARN_METRIC_STATUS,
+                     mp.FAIL_BLOCK_METRIC_STATUS],
     }
     ]
 
@@ -686,14 +686,17 @@ def _populate_metrics_statuses(job_metrics: mp.JobMetrics) -> None:
 
     job_metrics_status = mp.PASSED_METRIC_STATUS
     for metric in collection.metrics:
-        if metric.status == mp.FAILED_METRIC_STATUS and metric.blocking:
-            job_metrics_status = mp.FAILED_METRIC_STATUS
+        if metric.status == mp.FAIL_BLOCK_METRIC_STATUS:
+            job_metrics_status = mp.FAIL_BLOCK_METRIC_STATUS
+            break
+        if metric.status == mp.FAIL_WARN_METRIC_STATUS:
+            job_metrics_status = mp.FAIL_WARN_METRIC_STATUS
 
     job_metrics.metrics_status = job_metrics_status
     job_metrics.job_level_metrics.metrics_status = job_metrics_status
 
 
-def generate_test_metrics() -> mp.JobMetrics:
+def generate_test_metrics(block_fail: bool=False) -> mp.JobMetrics:
     """
     Generate a set of test metrics containing representative examples for each
     of our metric types.
@@ -701,11 +704,11 @@ def generate_test_metrics() -> mp.JobMetrics:
     job_metrics = mp.JobMetrics()
     job_metrics.job_id.id.data = _get_uuid_str()
 
+    _add_event_counts(job_metrics, block_fail)
+    _add_bar_chart_metric(job_metrics, block_fail)
     _add_double_summary_metric(job_metrics)
-    _add_event_counts(job_metrics)
     _add_double_over_time_metric(job_metrics)
     _add_line_plot_metric(job_metrics)
-    _add_bar_chart_metric(job_metrics)
     _add_states_over_time_metric(job_metrics)
     _add_histogram_metric(job_metrics)
     _add_scalar_metric(job_metrics)

--- a/resim/metrics/proto/metrics.proto
+++ b/resim/metrics/proto/metrics.proto
@@ -117,9 +117,10 @@ message MetricsData {
 enum MetricStatus {
     NO_METRIC_STATUS             = 0;
     PASSED_METRIC_STATUS         = 1;
-    FAILED_METRIC_STATUS         = 2;
+    FAIL_WARN_METRIC_STATUS      = 2;
     NOT_APPLICABLE_METRIC_STATUS = 3;
     RAW_METRIC_STATUS            = 4;
+    FAIL_BLOCK_METRIC_STATUS     = 5;
 }
 
 enum MetricImportance {
@@ -190,7 +191,8 @@ message Metric {
 
     MetricValues metric_values = 7;
 
-    optional bool blocking = 8;
+    optional bool blocking =
+        8;  // DEPRECATED - use FAIL_BLOCK_METRIC_STATUS instead
 
     MetricImportance importance = 9;
 

--- a/resim/metrics/proto/validate_metrics_proto_test.py
+++ b/resim/metrics/proto/validate_metrics_proto_test.py
@@ -16,17 +16,6 @@ import resim.metrics.proto.validate_metrics_proto as vmp
 import resim.metrics.proto.metrics_pb2 as mp
 import resim.metrics.proto.generate_test_metrics as gtm
 
-
-def _make_all_blocking(job_metrics: mp.JobMetrics) -> mp.JobMetrics:
-    """
-    Make every metric blocking to improve our branch coverage.
-    """
-    result = copy.deepcopy(job_metrics)
-    for metric in result.job_level_metrics.metrics:
-        metric.blocking = True
-    return result
-
-
 def _make_id_bad(job_metrics: mp.JobMetrics) -> mp.JobMetrics:
     """
     Make the job_metrics invalid by setting its job_id data to an invalid hex
@@ -55,26 +44,25 @@ class ValidateMetricsProtoTest(unittest.TestCase):
         """
         Set up our valid test metrics data.
         """
-        self._valid_metrics = gtm.generate_test_metrics()
+        self._warn_metrics = gtm.generate_test_metrics(False)
+        self._block_metrics = gtm.generate_test_metrics(True)
 
     def test_valid_job_metrics(self) -> None:
         """
         Test that our validator works on our valid test data.
         """
-        vmp.validate_job_metrics(self._valid_metrics)
-
-        all_blocking = _make_all_blocking(self._valid_metrics)
-        vmp.validate_job_metrics(all_blocking)
+        vmp.validate_job_metrics(self._warn_metrics)
+        vmp.validate_job_metrics(self._block_metrics)
 
     def test_invalid_job_metrics(self) -> None:
         """
         Test that our validator fails on invalidated test data.
         """
-        bad_id = _make_id_bad(self._valid_metrics)
+        bad_id = _make_id_bad(self._warn_metrics)
         with self.assertRaises(vmp.InvalidMetricsException):
             vmp.validate_job_metrics(bad_id)
 
-        data_empty = _make_data_empty(self._valid_metrics)
+        data_empty = _make_data_empty(self._warn_metrics)
         with self.assertRaises(vmp.InvalidMetricsException):
             vmp.validate_job_metrics(data_empty)
 

--- a/resim/metrics/python/metrics_utils.py
+++ b/resim/metrics/python/metrics_utils.py
@@ -22,9 +22,10 @@ from resim.utils.proto import uuid_pb2
 class MetricStatus(Enum):
     NO_METRIC_STATUS = 0
     PASSED_METRIC_STATUS = 1
-    FAILED_METRIC_STATUS = 2
+    FAIL_WARN_METRIC_STATUS = 2
     NOT_APPLICABLE_METRIC_STATUS = 3
     RAW_METRIC_STATUS = 4
+    FAIL_BLOCK_METRIC_STATUS = 5
 
 
 class MetricImportance(Enum):

--- a/resim/metrics/python/metrics_utils_test.py
+++ b/resim/metrics/python/metrics_utils_test.py
@@ -102,7 +102,7 @@ class MetricsUtilsTest(unittest.TestCase):
             "uuid": np.array([uuid.uuid4() for _ in range(3)]),
             "string": np.array([str(i) for i in range(3)]),
             "status": np.array([mu.MetricStatus.PASSED_METRIC_STATUS,
-                                mu.MetricStatus.FAILED_METRIC_STATUS,
+                                mu.MetricStatus.FAIL_WARN_METRIC_STATUS,
                                 mu.MetricStatus.PASSED_METRIC_STATUS]),
             "class": np.array([mp.JobMetrics()]),
         }

--- a/resim/metrics/python/metrics_writer.py
+++ b/resim/metrics/python/metrics_writer.py
@@ -113,12 +113,19 @@ class ResimMetricsWriter:
         packed_job_id = pack_uuid_to_proto(self.job_id)
         output.metrics_msg.job_id.id.CopyFrom(packed_job_id)
 
-        failed = any(metric.status == MetricStatus.Value("FAILED_METRIC_STATUS")
+        fail_block = any(metric.status == MetricStatus.Value("FAIL_BLOCK_METRIC_STATUS")
                       for metric in output.metrics_msg.job_level_metrics.metrics)
-        metrics_status = (
-            MetricStatus.Value("FAILED_METRIC_STATUS")
-            if failed
-            else MetricStatus.Value("PASSED_METRIC_STATUS"))
+
+        fail_warn = any(metric.status == MetricStatus.Value("FAIL_WARN_METRIC_STATUS")
+                      for metric in output.metrics_msg.job_level_metrics.metrics)
+
+        if fail_block:
+            metrics_status = MetricStatus.Value("FAIL_BLOCK_METRIC_STATUS")
+        elif fail_warn:
+            metrics_status = MetricStatus.Value("FAIL_WARN_METRIC_STATUS")
+        else:
+            metrics_status = MetricStatus.Value("PASSED_METRIC_STATUS")
+
         output.metrics_msg.metrics_status = metrics_status
         output.metrics_msg.job_level_metrics.metrics_status = metrics_status
         return output

--- a/resim/metrics/python/metrics_writer_test.py
+++ b/resim/metrics/python/metrics_writer_test.py
@@ -42,7 +42,7 @@ EXAMPLE_FAILURE_STATES = ['UNKNOWN']
 EXAMPLE_LEGEND_SERIES_NAMES = ['Labels', 'Detections']
 EXAMPLE_STATUSES = [
     MetricStatus.PASSED_METRIC_STATUS,
-    MetricStatus.FAILED_METRIC_STATUS]
+    MetricStatus.FAIL_WARN_METRIC_STATUS]
 
 EXAMPLE_IDS = np.array([EXAMPLE_ID_SET[i] for i in range(
     NUM_ACTORS) for _ in range(EXAMPLE_COUNTS[i])])
@@ -426,7 +426,7 @@ class TestMetricsWriter(unittest.TestCase):
             'Labels', 'Detections']
         METRIC_BLOCKING = True
         METRIC_SHOULD_DISPLAY = True
-        METRIC_STATUS = MetricStatus.NOT_APPLICABLE_METRIC_STATUS
+        METRIC_STATUS = MetricStatus.FAIL_BLOCK_METRIC_STATUS
 
         timestamp_data = (SeriesMetricsData('Timestamps')
                           .with_series(EXAMPLE_TIMESTAMPS)


### PR DESCRIPTION
Reverts resim-ai/open-core#91

## Description of change

Adds a new failure status, representing BLOCKING failure, making the current default status a WARNING fail. 

## Guide to reproduce test results.

`bazel test //resim/metrics/...`

## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
