### PR TITLE
Add vector fuzz helpers

### DIFF
--- a/resim/testing/BUILD
+++ b/resim/testing/BUILD
@@ -92,3 +92,12 @@ cc_library(
         "@com_google_protobuf//:protobuf",
     ],
 )
+
+cc_test(
+    name = "fuzz_helpers_test",
+    srcs = ["fuzz_helpers_test.cc"],
+    deps = [
+        ":fuzz_helpers",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/resim/testing/fuzz_helpers.hh
+++ b/resim/testing/fuzz_helpers.hh
@@ -122,4 +122,32 @@ bool verify_equality(
     const google::protobuf::Timestamp &a,
     const google::protobuf::Timestamp &b);
 
+template <typename T, typename Rng>
+std::vector<T> random_element(
+    TypeTag<std::vector<T>> /*unused*/,
+    InOut<Rng> rng) {
+  constexpr size_t MIN_SIZE = 3;
+  constexpr size_t MAX_SIZE = 7;
+  std::uniform_int_distribution<size_t> size_dist{MIN_SIZE, MAX_SIZE};
+  const size_t size = size_dist(*rng);
+  std::vector<T> result;
+  result.reserve(size);
+  for (size_t ii = 0; ii < size; ++ii) {
+    result.emplace_back(random_element(TypeTag<T>(), rng));
+  }
+  return result;
+}
+
+template <typename T>
+bool verify_equality(const std::vector<T> &a, const std::vector<T> &b) {
+  // Requires C++14 to not be undefined behavior
+  return std::mismatch(
+             a.cbegin(),
+             a.cend(),
+             b.cbegin(),
+             b.cend(),
+             [](const T &a, const T &b) { return verify_equality(a, b); }) ==
+         std::pair(a.cend(), b.cend());
+}
+
 }  // namespace resim

--- a/resim/testing/fuzz_helpers.hh
+++ b/resim/testing/fuzz_helpers.hh
@@ -124,7 +124,9 @@ bool verify_equality(
 
 // Generate a random vector of T between size 3 and 7 assuming that
 // random_element(TypeTag<T>, InOut<Rng>) has been defined either in the resim
-// namespace or the same namespace as T.
+// namespace or the same namespace as T. The size bounds were selected as
+// between 3 and 7 so we could have a range of sizes represented without slowing
+// tests down with very large vectors of elements to generate and check.
 template <typename T, typename Rng>
 std::vector<T> random_element(
     TypeTag<std::vector<T>> /*unused*/,

--- a/resim/testing/fuzz_helpers.hh
+++ b/resim/testing/fuzz_helpers.hh
@@ -8,9 +8,10 @@
 
 #include <google/protobuf/timestamp.pb.h>
 
+#include <algorithm>
 #include <concepts>
-#include <iostream>
 #include <random>
+#include <type_traits>
 
 #include "resim/utils/inout.hh"
 
@@ -122,6 +123,9 @@ bool verify_equality(
     const google::protobuf::Timestamp &a,
     const google::protobuf::Timestamp &b);
 
+// Generate a random vector of T between size 3 and 7 assuming that
+// random_element(TypeTag<T>, InOut<Rng>) has been defined either in
+// the resim namespace or the same namespace as T.
 template <typename T, typename Rng>
 std::vector<T> random_element(
     TypeTag<std::vector<T>> /*unused*/,
@@ -138,6 +142,9 @@ std::vector<T> random_element(
   return result;
 }
 
+// Verify that two vectors of type T are equal assuming that
+// verify_equality(const T &a, const T &b) is defined either in the
+// resim namespace or the same namespace as T.
 template <typename T>
 bool verify_equality(const std::vector<T> &a, const std::vector<T> &b) {
   // Requires C++14 to not be undefined behavior

--- a/resim/testing/fuzz_helpers.hh
+++ b/resim/testing/fuzz_helpers.hh
@@ -11,7 +11,6 @@
 #include <algorithm>
 #include <concepts>
 #include <random>
-#include <type_traits>
 
 #include "resim/utils/inout.hh"
 
@@ -124,8 +123,8 @@ bool verify_equality(
     const google::protobuf::Timestamp &b);
 
 // Generate a random vector of T between size 3 and 7 assuming that
-// random_element(TypeTag<T>, InOut<Rng>) has been defined either in
-// the resim namespace or the same namespace as T.
+// random_element(TypeTag<T>, InOut<Rng>) has been defined either in the resim
+// namespace or the same namespace as T.
 template <typename T, typename Rng>
 std::vector<T> random_element(
     TypeTag<std::vector<T>> /*unused*/,
@@ -143,11 +142,12 @@ std::vector<T> random_element(
 }
 
 // Verify that two vectors of type T are equal assuming that
-// verify_equality(const T &a, const T &b) is defined either in the
-// resim namespace or the same namespace as T.
+// verify_equality(const T &a, const T &b) is defined either in the resim
+// namespace or the same namespace as T.
 template <typename T>
 bool verify_equality(const std::vector<T> &a, const std::vector<T> &b) {
-  // Requires C++14 to not be undefined behavior
+  // Requires C++14 to not be undefined behavior. Thanksfully, the CTAD on the
+  // righthand-side of the equality requires C++17.
   return std::mismatch(
              a.cbegin(),
              a.cend(),

--- a/resim/testing/fuzz_helpers_test.cc
+++ b/resim/testing/fuzz_helpers_test.cc
@@ -1,3 +1,8 @@
+// Copyright 2024 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
 
 #include "resim/testing/fuzz_helpers.hh"
 
@@ -59,4 +64,5 @@ TYPED_TEST(ContainerFuzzHelpersTest, TestRandomVector) {
   EXPECT_FALSE(verify_equality(test_vec, test_vec_different_size));
   EXPECT_FALSE(verify_equality(test_vec, test_vec_different_value));
 }
-};  // namespace resim::testing
+
+}  // namespace resim::testing

--- a/resim/testing/fuzz_helpers_test.cc
+++ b/resim/testing/fuzz_helpers_test.cc
@@ -34,26 +34,44 @@ bool verify_equality(const TestStruct &a, const TestStruct &b) {
 }  // namespace some_namespace
 
 template <typename T>
-struct ContainerFuzzHelpersTest : public ::testing::Test {};
+struct ContainerFuzzHelpersTest : public ::testing::Test {
+  static constexpr size_t SEED = 82U;
+  std::mt19937 rng{SEED};
+};
 
 using PayloadTypes = ::testing::Types<double, some_namespace::TestStruct>;
 
 TYPED_TEST_SUITE(ContainerFuzzHelpersTest, PayloadTypes);
 
-TYPED_TEST(ContainerFuzzHelpersTest, TestRandomVector) {
-  // SETUP
-  std::mt19937 rng;
+// Tests that we generate distinct random vectors with random_element.
+TYPED_TEST(ContainerFuzzHelpersTest, TestVectorRandom) {
+  // SETUP / ACTION
+  // Generate a vector of vectors which should each be
+  // distinct if we're generating new wones each time.
+  const std::vector<std::vector<TypeParam>> random_vectors{
+      random_element<std::vector<std::vector<TypeParam>>>(InOut{this->rng})};
 
+  // VERIFICATION
+  for (auto it_1 = random_vectors.cbegin(); it_1 != random_vectors.cend();
+       ++it_1) {
+    for (auto it_2 = std::next(it_1); it_2 != random_vectors.cend(); ++it_2) {
+      EXPECT_FALSE(verify_equality(*it_1, *it_2));
+    }
+  }
+}
+
+TYPED_TEST(ContainerFuzzHelpersTest, TestVectorEquality) {
+  // SETUP
   const auto test_vec =
-      random_element(TypeTag<std::vector<TypeParam>>(), InOut{rng});
+      random_element(TypeTag<std::vector<TypeParam>>(), InOut{this->rng});
 
   auto test_vec_different_size{test_vec};
   test_vec_different_size.emplace_back(
-      resim::random_element<TypeParam>(InOut{rng}));
+      resim::random_element<TypeParam>(InOut{this->rng}));
 
   auto test_vec_different_value{test_vec};
   test_vec_different_value.front() =
-      resim::random_element<TypeParam>(InOut{rng});
+      resim::random_element<TypeParam>(InOut{this->rng});
 
   // ACTION / VERIFICATION
   EXPECT_TRUE(verify_equality(test_vec, test_vec));

--- a/resim/testing/fuzz_helpers_test.cc
+++ b/resim/testing/fuzz_helpers_test.cc
@@ -28,21 +28,27 @@ bool verify_equality(const TestStruct &a, const TestStruct &b) {
 
 }  // namespace some_namespace
 
-TEST(FuzzHelpersTest, TestRandomVector) {
+template <typename T>
+struct ContainerFuzzHelpersTest : public ::testing::Test {};
+
+using PayloadTypes = ::testing::Types<double, some_namespace::TestStruct>;
+
+TYPED_TEST_SUITE(ContainerFuzzHelpersTest, PayloadTypes);
+
+TYPED_TEST(ContainerFuzzHelpersTest, TestRandomVector) {
   // SETUP
   std::mt19937 rng;
 
-  const auto test_vec = random_element(
-      TypeTag<std::vector<some_namespace::TestStruct>>(),
-      InOut{rng});
+  const auto test_vec =
+      random_element(TypeTag<std::vector<TypeParam>>(), InOut{rng});
 
   auto test_vec_different_size{test_vec};
   test_vec_different_size.emplace_back(
-      resim::random_element<some_namespace::TestStruct>(InOut{rng}));
+      resim::random_element<TypeParam>(InOut{rng}));
 
   auto test_vec_different_value{test_vec};
   test_vec_different_value.front() =
-      resim::random_element<some_namespace::TestStruct>(InOut{rng});
+      resim::random_element<TypeParam>(InOut{rng});
 
   // ACTION / VERIFICATION
   EXPECT_TRUE(verify_equality(test_vec, test_vec));

--- a/resim/testing/fuzz_helpers_test.cc
+++ b/resim/testing/fuzz_helpers_test.cc
@@ -1,0 +1,56 @@
+
+#include "resim/testing/fuzz_helpers.hh"
+
+#include <gtest/gtest.h>
+
+#include <random>
+
+#include "resim/utils/inout.hh"
+
+namespace resim::testing {
+
+namespace some_namespace {
+
+struct TestStruct {
+  int val = 0;
+};
+
+template <typename Rng>
+TestStruct random_element(TypeTag<TestStruct> /*unused*/, InOut<Rng> rng) {
+  return TestStruct{
+      .val = random_element<int>(rng),
+  };
+}
+
+bool verify_equality(const TestStruct &a, const TestStruct &b) {
+  return a.val == b.val;
+}
+
+}  // namespace some_namespace
+
+TEST(FuzzHelpersTest, TestRandomVector) {
+  // SETUP
+  std::mt19937 rng;
+
+  const auto test_vec = random_element(
+      TypeTag<std::vector<some_namespace::TestStruct>>(),
+      InOut{rng});
+
+  auto test_vec_different_size{test_vec};
+  test_vec_different_size.emplace_back(
+      resim::random_element<some_namespace::TestStruct>(InOut{rng}));
+
+  auto test_vec_different_value{test_vec};
+  test_vec_different_value.front() =
+      resim::random_element<some_namespace::TestStruct>(InOut{rng});
+
+  // ACTION / VERIFICATION
+  EXPECT_TRUE(verify_equality(test_vec, test_vec));
+
+  EXPECT_FALSE(verify_equality(test_vec_different_size, test_vec));
+  EXPECT_FALSE(verify_equality(test_vec_different_value, test_vec));
+
+  EXPECT_FALSE(verify_equality(test_vec, test_vec_different_size));
+  EXPECT_FALSE(verify_equality(test_vec, test_vec_different_value));
+}
+};  // namespace resim::testing


### PR DESCRIPTION
## Description of change
Add fuzz helpers for vectors of type T, assuming that T itself has fuzz helpers.

## Guide to reproduce test results.
```bash
bazel test //resim/testing:fuzz_helpers_test
```

## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
