### PR TITLE
Add foxglove visualization converters for ReSim types

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -334,3 +334,12 @@ def resim_core_dependencies():
         strip_prefix = "resim-python-client-8b9e79b3c845bda6c040b773d7443e7f3d612f88",
         url = "https://github.com/resim-ai/resim-python-client/archive/8b9e79b3c845bda6c040b773d7443e7f3d612f88.zip",
     )
+
+    # Protobuf schemas for communications with foxglove
+    http_archive(
+        name = "foxglove_schemas",
+        build_file = "@resim_open_core//resim/third_party/foxglove_schemas:schemas.BUILD",
+        sha256 = "817d60451b7f09314b9ccf6eafdb5a0c2f354dc219b8d5518d1f4fc5c6f52da8",
+        strip_prefix = "schemas-releases-typescript-v0.7.1/schemas/proto",
+        urls = ["https://github.com/foxglove/schemas/archive/refs/tags/releases/typescript/v0.7.1.zip"],
+    )

--- a/resim/third_party/foxglove_schemas/BUILD
+++ b/resim/third_party/foxglove_schemas/BUILD
@@ -1,0 +1,4 @@
+exports_files(
+    glob(["*.BUILD"]),
+    visibility = ["//visibility:public"],
+)

--- a/resim/third_party/foxglove_schemas/schemas.BUILD
+++ b/resim/third_party/foxglove_schemas/schemas.BUILD
@@ -1,0 +1,26 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+proto_library(
+    name = "protos",
+    srcs = glob(["foxglove/*.proto"]),
+    deps = [
+        "@com_google_protobuf//:duration_proto",
+        "@com_google_protobuf//:timestamp_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "protos_cc",
+    deps = [":protos"],
+)
+
+# Group everything into a separate CC library rule so we can use the "includes"
+# attribute to enable the use of angular brackets when including the generated
+# headers
+cc_library(
+    name = "foxglove_schemas",
+    includes = ["."],
+    visibility = ["//visibility:public"],
+    deps = [":protos_cc"],
+)

--- a/resim/visualization/foxglove/BUILD
+++ b/resim/visualization/foxglove/BUILD
@@ -1,0 +1,173 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+cc_library(
+    name = "color_to_foxglove",
+    srcs = ["color_to_foxglove.cc"],
+    hdrs = ["color_to_foxglove.hh"],
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        "//resim/assert",
+        "//resim/visualization:color",
+        "@foxglove_schemas",
+    ],
+)
+
+cc_test(
+    name = "color_to_foxglove_test",
+    srcs = ["color_to_foxglove_test.cc"],
+    deps = [
+        ":color_to_foxglove",
+        "@com_google_googletest//:gtest_main",
+        "@foxglove_schemas",
+    ],
+)
+
+cc_library(
+    name = "orientation_to_foxglove",
+    srcs = ["orientation_to_foxglove.cc"],
+    hdrs = ["orientation_to_foxglove.hh"],
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        "//resim/assert",
+        "//resim/transforms:so3",
+        "@foxglove_schemas",
+        "@libeigen//:eigen",
+    ],
+)
+
+cc_test(
+    name = "orientation_to_foxglove_test",
+    srcs = ["orientation_to_foxglove_test.cc"],
+    deps = [
+        ":orientation_to_foxglove",
+        "//resim/testing:random_matrix",
+        "//resim/transforms:so3",
+        "@com_google_googletest//:gtest_main",
+        "@foxglove_schemas",
+        "@libeigen//:eigen",
+    ],
+)
+
+cc_library(
+    name = "vector_to_foxglove",
+    srcs = ["vector_to_foxglove.cc"],
+    hdrs = ["vector_to_foxglove.hh"],
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        "//resim/assert",
+        "@foxglove_schemas",
+        "@libeigen//:eigen",
+    ],
+)
+
+cc_test(
+    name = "vector_to_foxglove_test",
+    srcs = ["vector_to_foxglove_test.cc"],
+    deps = [
+        ":vector_to_foxglove",
+        "//resim/testing:random_matrix",
+        "@com_google_googletest//:gtest_main",
+        "@foxglove_schemas",
+    ],
+)
+
+cc_library(
+    name = "pose_to_foxglove",
+    srcs = ["pose_to_foxglove.cc"],
+    hdrs = ["pose_to_foxglove.hh"],
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        ":orientation_to_foxglove",
+        ":vector_to_foxglove",
+        "//resim/assert",
+        "//resim/transforms:se3",
+        "@foxglove_schemas",
+    ],
+)
+
+cc_test(
+    name = "pose_to_foxglove_test",
+    srcs = ["pose_to_foxglove_test.cc"],
+    deps = [
+        ":pose_to_foxglove",
+        "//resim/transforms:liegroup_test_helpers",
+        "//resim/transforms:se3",
+        "@com_google_googletest//:gtest_main",
+        "@foxglove_schemas",
+        "@libeigen//:eigen",
+    ],
+)
+
+cc_library(
+    name = "frame_transform_to_foxglove",
+    srcs = ["frame_transform_to_foxglove.cc"],
+    hdrs = ["frame_transform_to_foxglove.hh"],
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        ":orientation_to_foxglove",
+        ":vector_to_foxglove",
+        "//resim/assert",
+        "//resim/time:timestamp",
+        "//resim/time/proto:time_to_proto",
+        "//resim/transforms:se3",
+    ],
+)
+
+cc_test(
+    name = "frame_transform_to_foxglove_test",
+    srcs = ["frame_transform_to_foxglove_test.cc"],
+    deps = [
+        ":frame_transform_to_foxglove",
+        ":orientation_to_foxglove",
+        ":vector_to_foxglove",
+        "//resim/time:timestamp",
+        "//resim/transforms:liegroup_test_helpers",
+        "//resim/transforms:se3",
+        "@com_google_googletest//:gtest_main",
+        "@foxglove_schemas",
+        "@libeigen//:eigen",
+    ],
+)
+
+cc_library(
+    name = "wireframe_to_foxglove",
+    srcs = ["wireframe_to_foxglove.cc"],
+    hdrs = ["wireframe_to_foxglove.hh"],
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        ":color_to_foxglove",
+        ":pose_to_foxglove",
+        ":vector_to_foxglove",
+        "//resim/assert",
+        "//resim/geometry:wireframe",
+        "//resim/transforms:se3",
+        "//resim/visualization:color",
+        "@foxglove_schemas",
+    ],
+)
+
+cc_test(
+    name = "wireframe_to_foxglove_test",
+    srcs = ["wireframe_to_foxglove_test.cc"],
+    deps = [
+        ":wireframe_to_foxglove",
+        "//resim/geometry:drone_wireframe",
+        "//resim/geometry:wireframe",
+        "//resim/visualization:color",
+        "@com_google_googletest//:gtest_main",
+        "@foxglove_schemas",
+        "@libeigen//:eigen",
+    ],
+)

--- a/resim/visualization/foxglove/color_to_foxglove.cc
+++ b/resim/visualization/foxglove/color_to_foxglove.cc
@@ -1,0 +1,16 @@
+#include "resim/visualization/foxglove/color_to_foxglove.hh"
+
+#include "resim/assert/assert.hh"
+
+namespace resim::visualization::foxglove {
+
+void pack_into_foxglove(const Color &in, ::foxglove::Color *const out) {
+  REASSERT(out != nullptr, "Can't pack invalid color!");
+  out->Clear();
+  out->set_r(in.r);
+  out->set_g(in.g);
+  out->set_b(in.b);
+  out->set_a(in.a);
+}
+
+}  // namespace resim::visualization::foxglove

--- a/resim/visualization/foxglove/color_to_foxglove.hh
+++ b/resim/visualization/foxglove/color_to_foxglove.hh
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <foxglove/Color.pb.h>
+
+#include "resim/visualization/color.hh"
+
+namespace resim::visualization::foxglove {
+
+// Pack the given color into a ::foxglove::Color message.
+void pack_into_foxglove(const Color &in, ::foxglove::Color *out);
+
+}  // namespace resim::visualization::foxglove

--- a/resim/visualization/foxglove/color_to_foxglove_test.cc
+++ b/resim/visualization/foxglove/color_to_foxglove_test.cc
@@ -1,0 +1,52 @@
+
+#include "resim/visualization/foxglove/color_to_foxglove.hh"
+
+#include <foxglove/Color.pb.h>
+#include <gtest/gtest.h>
+
+#include <random>
+
+namespace resim::visualization::foxglove {
+
+namespace {
+
+// Generate a uniformly random color
+template <typename RNG>
+Color random_color(RNG &&rng) {
+  constexpr double LB = 0.;
+  constexpr double UB = 1.;
+  std::uniform_real_distribution<double> dist{LB, UB};
+
+  Color result;
+  result.r = dist(rng);
+  result.g = dist(rng);
+  result.b = dist(rng);
+  result.a = dist(rng);
+
+  return result;
+}
+
+}  // namespace
+
+TEST(ColorToFoxgloveTest, TestPackIntoFoxglove) {
+  // SETUP
+  constexpr unsigned SEED = 3494U;
+  std::mt19937 rng{SEED};
+
+  constexpr int NUM_TESTS = 1000;
+  for (int ii = 0; ii < NUM_TESTS; ++ii) {
+    const Color test_color{random_color(rng)};
+
+    // ACTION
+    ::foxglove::Color color;
+    pack_into_foxglove(test_color, &color);
+
+    // VERIFICATION
+    EXPECT_EQ(color.r(), test_color.r);
+    EXPECT_EQ(color.g(), test_color.g);
+    EXPECT_EQ(color.b(), test_color.b);
+    EXPECT_EQ(color.a(), test_color.a);
+  }
+}
+
+}  // namespace resim::visualization::foxglove

--- a/resim/visualization/foxglove/frame_transform_to_foxglove.cc
+++ b/resim/visualization/foxglove/frame_transform_to_foxglove.cc
@@ -1,0 +1,30 @@
+
+#include <foxglove/FrameTransform.pb.h>
+
+#include "resim/assert/assert.hh"
+#include "resim/time/proto/time_to_proto.hh"
+#include "resim/time/timestamp.hh"
+#include "resim/transforms/se3.hh"
+#include "resim/visualization/foxglove/orientation_to_foxglove.hh"
+#include "resim/visualization/foxglove/vector_to_foxglove.hh"
+
+namespace resim::visualization::foxglove {
+
+void pack_into_foxglove(
+    const transforms::SE3 &in,
+    const time::Timestamp time,
+    ::foxglove::FrameTransform *const out,
+    const std::string &parent,
+    const std::string &child) {
+  REASSERT(out != nullptr, "Can't pack invalid frame transform!");
+  REASSERT(in.is_framed(), "Can only pack framed SE3s to FrameTransforms!");
+  out->Clear();
+  time::proto::pack(time, out->mutable_timestamp());
+  out->set_parent_frame_id(
+      parent.empty() ? in.into().id().to_string() : parent);
+  out->set_child_frame_id(child.empty() ? in.from().id().to_string() : child);
+  pack_into_foxglove(in.translation(), out->mutable_translation());
+  pack_into_foxglove(in.rotation(), out->mutable_rotation());
+}
+
+}  // namespace resim::visualization::foxglove

--- a/resim/visualization/foxglove/frame_transform_to_foxglove.hh
+++ b/resim/visualization/foxglove/frame_transform_to_foxglove.hh
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <foxglove/FrameTransform.pb.h>
+
+#include "resim/time/proto/time_to_proto.hh"
+#include "resim/transforms/se3.hh"
+
+namespace resim::visualization::foxglove {
+
+// Pack a framed SE3 into a FrameTransform foxglove message for visualization
+// purposes.
+// @param[in] in - The SE3 to pack into the FrameTransform.
+// @param[in] time - The time to pack.
+// @param[out] out - The mesage to pack into.
+// @param[in] parent - The parent frame id to use. The into frame id from "in"
+//                     is used if this is left empty.
+// @param[in] child - The child frame id to use. The from frame id from "in" is
+//                    used if this is left empty.
+void pack_into_foxglove(
+    const transforms::SE3 &in,
+    time::Timestamp time,
+    ::foxglove::FrameTransform *out,
+    const std::string &parent = "",
+    const std::string &child = "");
+
+}  // namespace resim::visualization::foxglove

--- a/resim/visualization/foxglove/frame_transform_to_foxglove_test.cc
+++ b/resim/visualization/foxglove/frame_transform_to_foxglove_test.cc
@@ -1,0 +1,104 @@
+
+#include "resim/visualization/foxglove/frame_transform_to_foxglove.hh"
+
+#include <foxglove/FrameTransform.pb.h>
+#include <gtest/gtest.h>
+
+#include <Eigen/Dense>
+#include <chrono>
+#include <ratio>
+
+#include "resim/time/proto/time_to_proto.hh"
+#include "resim/time/timestamp.hh"
+#include "resim/transforms/liegroup_test_helpers.hh"
+#include "resim/transforms/se3.hh"
+#include "resim/visualization/foxglove/orientation_to_foxglove.hh"
+#include "resim/visualization/foxglove/vector_to_foxglove.hh"
+
+namespace resim::visualization::foxglove {
+
+using Frame = transforms::Frame<transforms::SE3::DIMS>;
+
+// Helper function to compare the packed msg to the original pose.
+// NOLINTBEGIN(readability-function-cognitive-complexity)
+void expect_poses_match(
+    const transforms::SE3 &pose,
+    const ::foxglove::FrameTransform &msg) {
+  const Eigen::Quaterniond quat{pose.rotation().quaternion()};
+  EXPECT_EQ(quat.w(), msg.rotation().w());
+  EXPECT_EQ(quat.x(), msg.rotation().x());
+  EXPECT_EQ(quat.y(), msg.rotation().y());
+  EXPECT_EQ(quat.z(), msg.rotation().z());
+  EXPECT_EQ(pose.translation().x(), msg.translation().x());
+  EXPECT_EQ(pose.translation().y(), msg.translation().y());
+  EXPECT_EQ(pose.translation().z(), msg.translation().z());
+}
+// NOLINTEND(readability-function-cognitive-complexity)
+
+TEST(FrameTransformToFoxgloveTest, TestPackIntoFoxglove) {
+  // SETUP
+  std::vector<transforms::SE3> test_elements{
+      transforms::make_test_group_elements<transforms::SE3>()};
+
+  for (transforms::SE3 &element : test_elements) {
+    ::foxglove::FrameTransform frame_transform;
+    constexpr auto PARENT_NAME = "parent";
+    constexpr auto CHILD_NAME = "child";
+    constexpr time::Timestamp TIME{std::chrono::seconds(1)};
+
+    element.set_frames(Frame::new_frame(), Frame::new_frame());
+
+    // ACTION
+    pack_into_foxglove(
+        element,
+        TIME,
+        &frame_transform,
+        PARENT_NAME,
+        CHILD_NAME);
+
+    // VERIFICATION
+    const auto &time_msg = frame_transform.timestamp();
+    EXPECT_EQ(
+        time_msg.seconds() * std::nano::den + time_msg.nanos(),
+        TIME.time_since_epoch().count());
+
+    EXPECT_EQ(frame_transform.parent_frame_id(), PARENT_NAME);
+    EXPECT_EQ(frame_transform.child_frame_id(), CHILD_NAME);
+
+    expect_poses_match(element, frame_transform);
+  }
+}
+
+TEST(FrameTransformToFoxgloveTest, TestPackIntoFoxgloveNoFrameIds) {
+  // SETUP
+  std::vector<transforms::SE3> test_elements{
+      transforms::make_test_group_elements<transforms::SE3>()};
+
+  for (transforms::SE3 &element : test_elements) {
+    ::foxglove::FrameTransform frame_transform;
+    constexpr time::Timestamp TIME{std::chrono::seconds(1)};
+    element.set_frames(Frame::new_frame(), Frame::new_frame());
+
+    // ACTION
+    pack_into_foxglove(element, TIME, &frame_transform);
+
+    // VERIFICATION
+    const auto &time_msg = frame_transform.timestamp();
+    EXPECT_EQ(
+        time_msg.seconds() * std::nano::den + time_msg.nanos(),
+        TIME.time_since_epoch().count());
+
+    EXPECT_EQ(
+        frame_transform.parent_frame_id(),
+        element.into().id().to_string());
+    EXPECT_EQ(
+        frame_transform.child_frame_id(),
+        element.from().id().to_string());
+
+    expect_poses_match(element, frame_transform);
+  }
+}
+
+TEST(FrameTransformToFoxgloveTest, TestUnframedThrows) {}
+
+}  // namespace resim::visualization::foxglove

--- a/resim/visualization/foxglove/orientation_to_foxglove.cc
+++ b/resim/visualization/foxglove/orientation_to_foxglove.cc
@@ -1,0 +1,21 @@
+#include "resim/visualization/foxglove/orientation_to_foxglove.hh"
+
+#include <Eigen/Dense>
+
+#include "resim/assert/assert.hh"
+
+namespace resim::visualization::foxglove {
+
+void pack_into_foxglove(
+    const transforms::SO3 &in,
+    ::foxglove::Quaternion *const out) {
+  REASSERT(out != nullptr, "Can't pack invalid orientation!");
+  out->Clear();
+  const Eigen::Quaterniond quaternion{in.quaternion()};
+  out->set_w(quaternion.w());
+  out->set_x(quaternion.x());
+  out->set_y(quaternion.y());
+  out->set_z(quaternion.z());
+}
+
+}  // namespace resim::visualization::foxglove

--- a/resim/visualization/foxglove/orientation_to_foxglove.hh
+++ b/resim/visualization/foxglove/orientation_to_foxglove.hh
@@ -1,0 +1,13 @@
+
+#pragma once
+
+#include <foxglove/Quaternion.pb.h>
+
+#include "resim/transforms/so3.hh"
+
+namespace resim::visualization::foxglove {
+
+// Pack an SO3 into a ::foxglove::Quaternion proto message.
+void pack_into_foxglove(const transforms::SO3 &in, ::foxglove::Quaternion *out);
+
+}  // namespace resim::visualization::foxglove

--- a/resim/visualization/foxglove/orientation_to_foxglove_test.cc
+++ b/resim/visualization/foxglove/orientation_to_foxglove_test.cc
@@ -1,0 +1,39 @@
+
+#include "resim/visualization/foxglove/orientation_to_foxglove.hh"
+
+#include <foxglove/Quaternion.pb.h>
+#include <gtest/gtest.h>
+
+#include <Eigen/Dense>
+
+#include "resim/testing/random_matrix.hh"
+#include "resim/transforms/so3.hh"
+
+namespace resim::visualization::foxglove {
+
+TEST(OrientationToFoxgloveTest, TestPackIntoFoxglove) {
+  // SETUP
+  constexpr unsigned SEED = 84U;
+  std::mt19937 rng{SEED};
+
+  constexpr int NUM_TESTS = 1000;
+  for (int ii = 0; ii < NUM_TESTS; ++ii) {
+    const Eigen::Quaterniond quat{testing::random_quaternion(rng)};
+    const transforms::SO3 random_orientation{quat};
+
+    // ACTION
+    ::foxglove::Quaternion quat_msg;
+    pack_into_foxglove(random_orientation, &quat_msg);
+
+    // VERIFICATION
+    // This may differ from quat above by a minus sign since q and -q represent
+    // the same orientation.
+    const Eigen::Quaterniond expected_quat{random_orientation.quaternion()};
+    EXPECT_EQ(expected_quat.w(), quat_msg.w());
+    EXPECT_EQ(expected_quat.x(), quat_msg.x());
+    EXPECT_EQ(expected_quat.y(), quat_msg.y());
+    EXPECT_EQ(expected_quat.z(), quat_msg.z());
+  }
+}
+
+}  // namespace resim::visualization::foxglove

--- a/resim/visualization/foxglove/pose_to_foxglove.cc
+++ b/resim/visualization/foxglove/pose_to_foxglove.cc
@@ -1,0 +1,19 @@
+
+#include "resim/visualization/foxglove/pose_to_foxglove.hh"
+
+#include "resim/assert/assert.hh"
+#include "resim/visualization/foxglove/orientation_to_foxglove.hh"
+#include "resim/visualization/foxglove/vector_to_foxglove.hh"
+
+namespace resim::visualization::foxglove {
+
+void pack_into_foxglove(
+    const transforms::SE3 &in,
+    ::foxglove::Pose *const out) {
+  REASSERT(out != nullptr, "Can't pack invalid pose!");
+  out->Clear();
+  pack_into_foxglove(in.rotation(), out->mutable_orientation());
+  pack_into_foxglove(in.translation(), out->mutable_position());
+}
+
+}  // namespace resim::visualization::foxglove

--- a/resim/visualization/foxglove/pose_to_foxglove.hh
+++ b/resim/visualization/foxglove/pose_to_foxglove.hh
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <foxglove/Pose.pb.h>
+
+#include "resim/transforms/se3.hh"
+
+namespace resim::visualization::foxglove {
+
+// Pack an SE3 into a foxglove pose message
+void pack_into_foxglove(const transforms::SE3 &in, ::foxglove::Pose *out);
+
+}  // namespace resim::visualization::foxglove

--- a/resim/visualization/foxglove/pose_to_foxglove_test.cc
+++ b/resim/visualization/foxglove/pose_to_foxglove_test.cc
@@ -1,0 +1,48 @@
+
+#include "resim/visualization/foxglove/pose_to_foxglove.hh"
+
+#include <foxglove/Pose.pb.h>
+#include <gtest/gtest.h>
+
+#include <Eigen/Dense>
+#include <vector>
+
+#include "resim/transforms/liegroup_test_helpers.hh"
+#include "resim/transforms/se3.hh"
+
+namespace resim::visualization::foxglove {
+namespace {
+using transforms::SE3;
+
+// Helper function to compare the packed msg to the original pose.
+// NOLINTBEGIN(readability-function-cognitive-complexity)
+void expect_poses_match(const SE3 &pose, const ::foxglove::Pose &msg) {
+  const Eigen::Quaterniond quat{pose.rotation().quaternion()};
+  EXPECT_EQ(quat.w(), msg.orientation().w());
+  EXPECT_EQ(quat.x(), msg.orientation().x());
+  EXPECT_EQ(quat.y(), msg.orientation().y());
+  EXPECT_EQ(quat.z(), msg.orientation().z());
+  EXPECT_EQ(pose.translation().x(), msg.position().x());
+  EXPECT_EQ(pose.translation().y(), msg.position().y());
+  EXPECT_EQ(pose.translation().z(), msg.position().z());
+}
+// NOLINTEND(readability-function-cognitive-complexity)
+
+}  // namespace
+
+TEST(PoseToFoxgloveTest, TestPackIntoFoxglove) {
+  // SETUP
+  const std::vector<SE3> test_group_elements{
+      transforms::make_test_group_elements<SE3>()};
+
+  for (const SE3 &element : test_group_elements) {
+    // ACTION
+    ::foxglove::Pose msg;
+    pack_into_foxglove(element, &msg);
+
+    // VERIFICATION
+    expect_poses_match(element, msg);
+  }
+}
+
+}  // namespace resim::visualization::foxglove

--- a/resim/visualization/foxglove/vector_to_foxglove.cc
+++ b/resim/visualization/foxglove/vector_to_foxglove.cc
@@ -1,0 +1,27 @@
+#include "resim/visualization/foxglove/vector_to_foxglove.hh"
+
+#include "resim/assert/assert.hh"
+
+namespace resim::visualization::foxglove {
+
+void pack_into_foxglove(
+    const Eigen::Vector3d &in,
+    ::foxglove::Vector3 *const out) {
+  REASSERT(out != nullptr, "Can't pack invalid vector!");
+  out->Clear();
+  out->set_x(in.x());
+  out->set_y(in.y());
+  out->set_z(in.z());
+}
+
+void pack_into_foxglove(
+    const Eigen::Vector3d &in,
+    ::foxglove::Point3 *const out) {
+  REASSERT(out != nullptr, "Can't pack invalid point!");
+  out->Clear();
+  out->set_x(in.x());
+  out->set_y(in.y());
+  out->set_z(in.z());
+}
+
+}  // namespace resim::visualization::foxglove

--- a/resim/visualization/foxglove/vector_to_foxglove.hh
+++ b/resim/visualization/foxglove/vector_to_foxglove.hh
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <foxglove/Point3.pb.h>
+#include <foxglove/Vector3.pb.h>
+
+#include <Eigen/Dense>
+
+namespace resim::visualization::foxglove {
+
+// Pack a Vector3d into a ::foxglove::Vector3
+void pack_into_foxglove(const Eigen::Vector3d &in, ::foxglove::Vector3 *out);
+
+// Pack a Vector3d into a ::foxglove::Point3
+void pack_into_foxglove(const Eigen::Vector3d &in, ::foxglove::Point3 *out);
+
+}  // namespace resim::visualization::foxglove

--- a/resim/visualization/foxglove/vector_to_foxglove_test.cc
+++ b/resim/visualization/foxglove/vector_to_foxglove_test.cc
@@ -1,0 +1,42 @@
+#include "resim/visualization/foxglove/vector_to_foxglove.hh"
+
+#include <foxglove/Point3.pb.h>
+#include <foxglove/Vector3.pb.h>
+#include <gtest/gtest.h>
+
+#include <Eigen/Dense>
+#include <random>
+
+#include "resim/testing/random_matrix.hh"
+
+namespace resim::visualization::foxglove {
+using Vec3 = Eigen::Vector3d;
+
+template <typename MsgType>
+class VectorToFoxgloveTest : public ::testing::Test {
+ protected:
+  static constexpr unsigned SEED = 89034U;
+  std::mt19937 rng_{SEED};
+};
+
+using MessageTypes = ::testing::Types<::foxglove::Point3, ::foxglove::Vector3>;
+TYPED_TEST_SUITE(VectorToFoxgloveTest, MessageTypes);
+
+TYPED_TEST(VectorToFoxgloveTest, TestPackIntoVector) {
+  // SETUP
+  constexpr int NUM_TESTS = 1000;
+  for (int ii = 0; ii < NUM_TESTS; ++ii) {
+    const Vec3 vec{testing::random_vector<Vec3>(TestFixture::rng_)};
+
+    // ACTION
+    TypeParam msg;
+    pack_into_foxglove(vec, &msg);
+
+    // VERIFICATION
+    EXPECT_EQ(msg.x(), vec.x());
+    EXPECT_EQ(msg.y(), vec.y());
+    EXPECT_EQ(msg.z(), vec.z());
+  }
+}
+
+}  // namespace resim::visualization::foxglove

--- a/resim/visualization/foxglove/wireframe_to_foxglove.cc
+++ b/resim/visualization/foxglove/wireframe_to_foxglove.cc
@@ -1,0 +1,33 @@
+#include "resim/visualization/foxglove/wireframe_to_foxglove.hh"
+
+#include "resim/assert/assert.hh"
+#include "resim/transforms/se3.hh"
+#include "resim/visualization/color.hh"
+#include "resim/visualization/foxglove/color_to_foxglove.hh"
+#include "resim/visualization/foxglove/pose_to_foxglove.hh"
+#include "resim/visualization/foxglove/vector_to_foxglove.hh"
+
+namespace resim::visualization::foxglove {
+namespace {
+constexpr double DEFAULT_THICKNESS = 2;
+constexpr bool DEFAULT_SCALE_INVARIANT = true;
+}  // namespace
+
+void pack_into_foxglove(
+    const geometry::Wireframe &in,
+    ::foxglove::LinePrimitive *const out) {
+  REASSERT(out != nullptr, "Can't pack into invalid line primitive!");
+  out->Clear();
+  out->set_type(::foxglove::LinePrimitive::LINE_LIST);
+  pack_into_foxglove(transforms::SE3::identity(), out->mutable_pose());
+  out->set_thickness(DEFAULT_THICKNESS);
+  out->set_scale_invariant(DEFAULT_SCALE_INVARIANT);
+  pack_into_foxglove(colors::CHARTREUSE, out->mutable_color());
+
+  for (const auto &[p1, p2] : in.edges()) {
+    pack_into_foxglove(in.points().at(p1), out->add_points());
+    pack_into_foxglove(in.points().at(p2), out->add_points());
+  }
+}
+
+}  // namespace resim::visualization::foxglove

--- a/resim/visualization/foxglove/wireframe_to_foxglove.hh
+++ b/resim/visualization/foxglove/wireframe_to_foxglove.hh
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <foxglove/LinePrimitive.pb.h>
+
+#include "resim/geometry/wireframe.hh"
+
+namespace resim::visualization::foxglove {
+
+// Pack a Wireframe into a LinePrimitive of the LINE_LIST type. Defaults to a
+// scale invariant thickness of 2 and a CHARTREUSE color.
+// TODO(michael) Make color configurable
+void pack_into_foxglove(
+    const geometry::Wireframe &in,
+    ::foxglove::LinePrimitive *out);
+
+}  // namespace resim::visualization::foxglove

--- a/resim/visualization/foxglove/wireframe_to_foxglove_test.cc
+++ b/resim/visualization/foxglove/wireframe_to_foxglove_test.cc
@@ -1,0 +1,95 @@
+
+#include "resim/visualization/foxglove/wireframe_to_foxglove.hh"
+
+#include <foxglove/LinePrimitive.pb.h>
+#include <gtest/gtest.h>
+
+#include <Eigen/Dense>
+
+#include "resim/geometry/drone_wireframe.hh"
+#include "resim/geometry/wireframe.hh"
+#include "resim/visualization/color.hh"
+
+namespace resim::visualization::foxglove {
+
+namespace {
+
+constexpr double CHASSIS_RADIUS_M = 1.;
+constexpr double ROTOR_LATERAL_OFFSET_M = 0.3;
+constexpr double ROTOR_VERTICAL_OFFSET_M = 0.3;
+constexpr double ROTOR_RADIUS_M = 0.5;
+constexpr std::size_t SAMPLES_PER_ROTOR = 2;
+
+const geometry::DroneExtents test_extents{
+    .chassis_radius_m = CHASSIS_RADIUS_M,
+    .rotor_lateral_offset_m = ROTOR_LATERAL_OFFSET_M,
+    .rotor_vertical_offset_m = ROTOR_VERTICAL_OFFSET_M,
+    .rotor_radius_m = ROTOR_RADIUS_M,
+    .samples_per_rotor = SAMPLES_PER_ROTOR,
+};
+
+void expect_points_equal(
+    const Eigen::Vector3d &point,
+    const ::foxglove::Point3 &point_msg) {
+  EXPECT_DOUBLE_EQ(point.x(), point_msg.x());
+  EXPECT_DOUBLE_EQ(point.y(), point_msg.y());
+  EXPECT_DOUBLE_EQ(point.z(), point_msg.z());
+}
+
+void expect_colors_equal(
+    const Color &color,
+    const ::foxglove::Color &color_msg) {
+  EXPECT_EQ(color.r, color_msg.r());
+  EXPECT_EQ(color.g, color_msg.g());
+  EXPECT_EQ(color.b, color_msg.b());
+  EXPECT_EQ(color.a, color_msg.a());
+}
+
+void expect_pose_identity(const ::foxglove::Pose &pose) {
+  EXPECT_EQ(pose.position().x(), 0.0);
+  EXPECT_EQ(pose.position().y(), 0.0);
+  EXPECT_EQ(pose.position().z(), 0.0);
+
+  EXPECT_EQ(pose.orientation().w(), 1.0);
+  EXPECT_EQ(pose.orientation().x(), 0.0);
+  EXPECT_EQ(pose.orientation().y(), 0.0);
+  EXPECT_EQ(pose.orientation().z(), 0.0);
+}
+
+}  // namespace
+
+TEST(WireframeToFoxgloveTest, TestWireframeToFoxglove) {
+  // SETUP
+  const geometry::Wireframe wireframe{geometry::drone_wireframe(test_extents)};
+
+  // ACTION
+  ::foxglove::LinePrimitive out;
+  pack_into_foxglove(wireframe, &out);
+
+  // VERIFICATION
+  EXPECT_EQ(out.type(), ::foxglove::LinePrimitive::LINE_LIST);
+
+  // TODO(michael) Put this in a more common library
+  expect_pose_identity(out.pose());
+  constexpr double DEFAULT_THICKNESS = 2.;
+  constexpr Color DEFAULT_COLOR = colors::CHARTREUSE;
+  EXPECT_EQ(out.thickness(), DEFAULT_THICKNESS);
+  EXPECT_TRUE(out.scale_invariant());
+  expect_colors_equal(DEFAULT_COLOR, out.color());
+
+  ASSERT_EQ(out.points().size(), 2 * wireframe.edges().size());
+
+  for (int ii = 0U; ii < wireframe.edges().size(); ++ii) {
+    const Eigen::Vector3d &p1{
+        wireframe.points().at(wireframe.edges().at(ii)[0])};
+    const Eigen::Vector3d &p2{
+        wireframe.points().at(wireframe.edges().at(ii)[1])};
+    expect_points_equal(p1, out.points().at(2 * ii));
+    expect_points_equal(p2, out.points().at(2 * ii + 1));
+  }
+
+  EXPECT_EQ(out.colors().size(), 0U);
+  EXPECT_EQ(out.indices().size(), 0U);
+}
+
+}  // namespace resim::visualization::foxglove


### PR DESCRIPTION
## Description of change
Open source the visualization converters for Foxglove types.

## Guide to reproduce test results.
```bash
bazel test //resim/visualization/foxglove/...
```
## Checklist:
- [ ] I have self-reviewed this change.
- [ ] I have tested this change.
- [ ] This change is covered by tests that are already landed, or in this PR.
