### PR TITLE
Add line primitive options struct

### DIFF
--- a/resim/visualization/foxglove/BUILD
+++ b/resim/visualization/foxglove/BUILD
@@ -177,3 +177,12 @@ cc_test(
         "@libeigen//:eigen",
     ],
 )
+
+cc_library(
+    name = "line_primitive_options",
+    hdrs = ["line_primitive_options.hh"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//resim/visualization:color",
+    ],
+)

--- a/resim/visualization/foxglove/line_primitive_options.hh
+++ b/resim/visualization/foxglove/line_primitive_options.hh
@@ -4,9 +4,11 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+#pragma once
+
 #include "resim/visualization/color.hh"
 
-namespace resim::visualization {
+namespace resim::visualization::foxglove {
 
 struct LinePrimitiveOptions {
   // See https://foxglove.dev/docs/studio/messages/line-primitive for
@@ -17,4 +19,4 @@ struct LinePrimitiveOptions {
   Color color{colors::JAVA};
 };
 
-}  // namespace resim::visualization
+}  // namespace resim::visualization::foxglove

--- a/resim/visualization/foxglove/line_primitive_options.hh
+++ b/resim/visualization/foxglove/line_primitive_options.hh
@@ -1,0 +1,20 @@
+// Copyright 2024 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include "resim/visualization/color.hh"
+
+namespace resim::visualization {
+
+struct LinePrimitiveOptions {
+  // See https://foxglove.dev/docs/studio/messages/line-primitive for
+  // the meaning of these options
+  static constexpr double DEFAULT_THICKNESS = 2.0;
+  double thickness = DEFAULT_THICKNESS;
+  bool scale_invariant = true;
+  Color color{colors::JAVA};
+};
+
+}  // namespace resim::visualization


### PR DESCRIPTION
## Description of change
Add the line primitive options struct from our private repository.

## Guide to reproduce test results.
```
bazel build //resim/visualization/foxglove:line_primitive_options
```

## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [ ] This change is covered by tests that are already landed, or in this PR.
