### PR TITLE
Include observable state proto message type in resim-msg wheel

### DIFF
--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -104,6 +104,7 @@ py_package(
         "resim.transforms.proto",
     ],
     deps = [
+        "//resim/actor/state/proto:observable_state_proto_py",
         "//resim/msg:detection_proto_py",
         "//resim/msg:header_proto_py",
         "//resim/msg:navsat_proto_py",

--- a/resim/actor/state/proto/BUILD
+++ b/resim/actor/state/proto/BUILD
@@ -6,6 +6,7 @@
 
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_proto_library", "cc_test")
 load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_python//python:proto.bzl", "py_proto_library")
 
 proto_library(
     name = "trajectory_proto",
@@ -68,6 +69,12 @@ proto_library(
 
 cc_proto_library(
     name = "observable_state_proto_cc",
+    visibility = ["//visibility:public"],
+    deps = [":observable_state_proto"],
+)
+
+py_proto_library(
+    name = "observable_state_proto_py",
     visibility = ["//visibility:public"],
     deps = [":observable_state_proto"],
 )


### PR DESCRIPTION
## Description of change
Include the observable state proto message type in the msg wheel since it's used for actor states.

## Guide to reproduce test results.

```bash
bazel build //pkg:msg_wheel
```
## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [ ] This change is covered by tests that are already landed, or in this PR.
