### PR TITLE
Add pybindings for geodetics

### DIFF
--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -101,6 +101,8 @@ py_wheel(
 py_package(
     name = "msg_package",
     packages = [
+        "resim.actor.state.proto",
+        "resim.curves.proto",
         "resim.msg",
         "resim.transforms.proto",
     ],

--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -72,6 +72,7 @@ py_package(
         "//resim/metrics/python:metrics",
         "//resim/metrics/python:metrics_writer",
         "//resim/metrics/python:unpack_metrics",
+        "//resim/transforms/python:geodetic_python.so",
         "//resim/transforms/python:quaternion.so",
         "//resim/transforms/python:se3_python.so",
         "//resim/transforms/python:so3_python.so",

--- a/resim/transforms/python/BUILD
+++ b/resim/transforms/python/BUILD
@@ -73,3 +73,25 @@ py_test(
         requirement("numpy"),
     ],
 )
+
+pybind_extension(
+    name = "geodetic_python",
+    srcs = ["geodetic_python.cc"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":so3_python.so",
+        "//resim/transforms:geodetic",
+        "@au//au",
+    ],
+)
+
+py_test(
+    name = "geodetic_python_test",
+    srcs = ["geodetic_python_test.py"],
+    data = [
+        ":geodetic_python.so",
+    ],
+    deps = [
+        requirement("numpy"),
+    ],
+)

--- a/resim/transforms/python/BUILD
+++ b/resim/transforms/python/BUILD
@@ -79,6 +79,7 @@ pybind_extension(
     srcs = ["geodetic_python.cc"],
     visibility = ["//visibility:public"],
     deps = [
+        ":se3_python.so",
         ":so3_python.so",
         "//resim/transforms:geodetic",
         "@au//au",

--- a/resim/transforms/python/geodetic_python.cc
+++ b/resim/transforms/python/geodetic_python.cc
@@ -1,0 +1,70 @@
+// Copyright 2024 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include <pybind11/eigen.h>
+#include <pybind11/pybind11.h>
+
+#include <Eigen/Dense>
+
+#include "au/au.hh"
+#include "au/units/degrees.hh"
+#include "au/units/feet.hh"
+#include "resim/transforms/geodetic.hh"
+
+namespace resim::transforms {
+namespace py = pybind11;
+
+// A simple pybinding of SE3
+// TODO(mikebauer) Add frames
+PYBIND11_MODULE(geodetic_python, m) {
+  py::class_<Geodetic>(m, "Geodetic")
+      .def(py::init<>())
+      .def(
+          "latitude_deg",
+          [](const Geodetic &g) { return g.latitude.in(au::degrees); })
+      .def(
+          "longitude_deg",
+          [](const Geodetic &g) { return g.longitude.in(au::degrees); })
+      .def(
+          "altitude_m",
+          [](const Geodetic &g) { return g.altitude.in(au::meters); })
+      .def(
+          "altitude_ft",
+          [](const Geodetic &g) { return g.altitude.in(au::feet); })
+      .def(
+          "set_latitude_deg",
+          [](Geodetic &g, const double x) { g.latitude = au::degrees(x); })
+      .def(
+          "set_longitude_deg",
+          [](Geodetic &g, const double x) { g.longitude = au::degrees(x); })
+      .def(
+          "set_altitude_m",
+          [](Geodetic &g, const double x) { g.altitude = au::meters(x); })
+      .def("set_altitude_ft", [](Geodetic &g, const double x) {
+        g.altitude = au::feet(x);
+      });
+
+  py::class_<GeodeticWithRotation>(m, "GeodeticWithRotation")
+      .def_readwrite("geodetic", &GeodeticWithRotation::geodetic)
+      .def_readwrite("rotation", &GeodeticWithRotation::rotation);
+
+  m.def(
+      "ecef_position_from_geodetic",
+      static_cast<Eigen::Vector3d (*)(const Geodetic &)>(
+          &ecef_position_from_geodetic));
+
+  m.def("geodetic_from_ecef_position", &geodetic_from_ecef_position);
+
+  m.def(
+      "ecef_from_body_from_geodetic_with_rotation",
+      &ecef_from_body_from_geodetic_with_rotation);
+
+  m.def(
+      "geodetic_with_rotation_from_ecef_from_body",
+      &geodetic_with_rotation_from_ecef_from_body);
+}
+
+}  // namespace resim::transforms

--- a/resim/transforms/python/geodetic_python.cc
+++ b/resim/transforms/python/geodetic_python.cc
@@ -13,15 +13,32 @@
 #include "au/units/degrees.hh"
 #include "au/units/feet.hh"
 #include "resim/transforms/geodetic.hh"
+#include "resim/transforms/so3.hh"
 
 namespace resim::transforms {
 namespace py = pybind11;
 
-// A simple pybinding of SE3
+// A simple pybinding of Geodetics
 // TODO(mikebauer) Add frames
 PYBIND11_MODULE(geodetic_python, m) {
+  py::module_::import("resim.transforms.python.se3_python");
+
   py::class_<Geodetic>(m, "Geodetic")
       .def(py::init<>())
+      .def(
+          py::init([](const double latitude_deg,
+                      const double longitude_deg,
+                      const double altitude_m) {
+            return Geodetic{
+                .latitude = au::degrees(latitude_deg),
+                .longitude = au::degrees(longitude_deg),
+                .altitude = au::meters(altitude_m),
+            };
+          }),
+          py::kw_only(),
+          py::arg("latitude_deg"),
+          py::arg("longitude_deg"),
+          py::arg("altitude_m"))
       .def(
           "latitude_deg",
           [](const Geodetic &g) { return g.latitude.in(au::degrees); })
@@ -48,6 +65,17 @@ PYBIND11_MODULE(geodetic_python, m) {
       });
 
   py::class_<GeodeticWithRotation>(m, "GeodeticWithRotation")
+      .def(py::init<>())
+      .def(
+          py::init([](const Geodetic &geodetic, const SO3 &rotation) {
+            return GeodeticWithRotation{
+                .geodetic = geodetic,
+                .rotation = rotation,
+            };
+          }),
+          py::kw_only(),
+          py::arg("geodetic"),
+          py::arg("rotation"))
       .def_readwrite("geodetic", &GeodeticWithRotation::geodetic)
       .def_readwrite("rotation", &GeodeticWithRotation::rotation);
 

--- a/resim/transforms/python/geodetic_python_test.py
+++ b/resim/transforms/python/geodetic_python_test.py
@@ -13,6 +13,8 @@ import unittest
 
 import numpy as np
 import resim.transforms.python.geodetic_python as geodetic
+import resim.transforms.python.so3_python as so3
+
 
 class GeodeticPythonTest(unittest.TestCase):
     """Unit tests for Geodetic pybinding"""
@@ -21,22 +23,79 @@ class GeodeticPythonTest(unittest.TestCase):
         """Seed the random number generator"""
         np.random.seed(29)
 
+    def test_roundtrip(self) -> None:
+        num_tests = 100
 
-    def test_foo(self) -> None:
+        for _ in range(num_tests):
+            g = geodetic.Geodetic(
+                latitude_deg=np.random.uniform(0., 90.),
+                longitude_deg=np.random.uniform(-180., 180.),
+                altitude_m=np.random.uniform(0., 1e4))
+
+            ecef_position = geodetic.ecef_position_from_geodetic(g)
+
+            round_tripped = geodetic.geodetic_from_ecef_position(ecef_position)
+            self.assertAlmostEqual(
+                g.latitude_deg(),
+                round_tripped.latitude_deg())
+            self.assertAlmostEqual(
+                g.longitude_deg(),
+                round_tripped.longitude_deg())
+            self.assertAlmostEqual(g.altitude_m(), round_tripped.altitude_m())
+            self.assertAlmostEqual(
+                g.altitude_ft(), round_tripped.altitude_ft())
+
+    def test_setters(self) -> None:
         g = geodetic.Geodetic()
-        g.set_latitude_deg(45.0)
-        g.set_longitude_deg(46.0)
-        g.set_altitude_ft(67.0)
 
-        ecef_position = geodetic.ecef_position_from_geodetic(g)
+        num_tests = 100
+        for _ in range(num_tests):
+            latitude_deg = np.random.uniform(0., 90.)
+            g.set_latitude_deg(latitude_deg)
+            self.assertEqual(latitude_deg, g.latitude_deg())
 
-        round_tripped = geodetic.geodetic_from_ecef_position(ecef_position)
-        print(round_tripped.latitude_deg())
-        print(round_tripped.longitude_deg())
-        print(round_tripped.altitude_ft())        
+            longitude_deg = np.random.uniform(-180., 180.)
+            g.set_longitude_deg(longitude_deg)
+            self.assertEqual(longitude_deg, g.longitude_deg())
 
-        
-        self.assertTrue(True)
+            altitude_m = np.random.uniform(0., 1e4)
+            g.set_altitude_m(altitude_m)
+            self.assertEqual(altitude_m, g.altitude_m())
+
+            altitude_ft = np.random.uniform(0., 3e4)
+            g.set_altitude_ft(altitude_ft)
+            self.assertAlmostEqual(altitude_ft, g.altitude_ft())
+
+    def test_with_rotation_roundtrip(self) -> None:
+        num_tests = 100
+
+        for _ in range(num_tests):
+            g = geodetic.GeodeticWithRotation(
+                geodetic=geodetic.Geodetic(
+                    latitude_deg=np.random.uniform(0., 90.),
+                    longitude_deg=np.random.uniform(-180., 180.),
+                    altitude_m=np.random.uniform(0., 1e4)),
+                rotation=so3.SO3.exp(np.random.uniform(-1., 1., 3))
+            )
+
+            ecef_pose = geodetic.ecef_from_body_from_geodetic_with_rotation(g)
+
+            round_tripped = geodetic.geodetic_with_rotation_from_ecef_from_body(
+                ecef_pose)
+            self.assertAlmostEqual(
+                g.geodetic.latitude_deg(),
+                round_tripped.geodetic.latitude_deg())
+            self.assertAlmostEqual(
+                g.geodetic.longitude_deg(),
+                round_tripped.geodetic.longitude_deg())
+            self.assertAlmostEqual(
+                g.geodetic.altitude_m(),
+                round_tripped.geodetic.altitude_m())
+            self.assertAlmostEqual(
+                g.geodetic.altitude_ft(),
+                round_tripped.geodetic.altitude_ft())
+            self.assertTrue(g.rotation.is_approx(round_tripped.rotation))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/resim/transforms/python/geodetic_python_test.py
+++ b/resim/transforms/python/geodetic_python_test.py
@@ -1,0 +1,42 @@
+# Copyright 2024 ReSim, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+
+"""
+Unit tests for geodetic pybinding
+"""
+
+import unittest
+
+import numpy as np
+import resim.transforms.python.geodetic_python as geodetic
+
+class GeodeticPythonTest(unittest.TestCase):
+    """Unit tests for Geodetic pybinding"""
+
+    def setUp(self) -> None:
+        """Seed the random number generator"""
+        np.random.seed(29)
+
+
+    def test_foo(self) -> None:
+        g = geodetic.Geodetic()
+        g.set_latitude_deg(45.0)
+        g.set_longitude_deg(46.0)
+        g.set_altitude_ft(67.0)
+
+        ecef_position = geodetic.ecef_position_from_geodetic(g)
+
+        round_tripped = geodetic.geodetic_from_ecef_position(ecef_position)
+        print(round_tripped.latitude_deg())
+        print(round_tripped.longitude_deg())
+        print(round_tripped.altitude_ft())        
+
+        
+        self.assertTrue(True)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Description of change
Add pybindings for geodetic libraries.

## Guide to reproduce test results.
```bash
bazel test //resim/transforms/python:geodetic_python_test
```

## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
