### PR TITLE
Global Projects Migration

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -330,9 +330,9 @@ def resim_core_dependencies():
     maybe(
         http_archive,
         name = "resim-python-client",
-        sha256 = "b81fc964c79d670c7670e67ccba9337ff268e1c8a84f9ed0bfd0719619ee6a82",
-        strip_prefix = "resim-python-client-8b9e79b3c845bda6c040b773d7443e7f3d612f88",
-        url = "https://github.com/resim-ai/resim-python-client/archive/8b9e79b3c845bda6c040b773d7443e7f3d612f88.zip",
+        sha256 = "aca1518c2dcf29406b5ce64e18c4b2b0af27716eaa07e79d5c7d2c6cecc6fb34",
+        strip_prefix = "resim-python-client-a28eca31985d175d976b868d38c7f3adc315155b",
+        url = "https://github.com/resim-ai/resim-python-client/archive/a28eca31985d175d976b868d38c7f3adc315155b.zip",
     )
 
     # Protobuf schemas for communications with foxglove

--- a/resim/metrics/fetch_all_pages.py
+++ b/resim/metrics/fetch_all_pages.py
@@ -6,7 +6,7 @@
 
 
 """
-This module contains a simple function for fetching all pages form a given
+This module contains a simple function for fetching all pages from a given
 endpoint.
 
 In ReSim's API we have a number of endpoints with paged responses. These work

--- a/resim/metrics/fetch_job_metrics.py
+++ b/resim/metrics/fetch_job_metrics.py
@@ -55,7 +55,7 @@ def fetch_job_metrics_by_batch(*,
     jobs = [
         JobInfo(
             job_id=uuid.UUID(job.job_id),
-            batch_id=batch_id
+            batch_id=batch_id,
             project_id=project_id
         ) for job in jobs_response.jobs]
 

--- a/resim/metrics/fetch_job_metrics_test.py
+++ b/resim/metrics/fetch_job_metrics_test.py
@@ -29,25 +29,30 @@ class MockMetric:
     name: str
     data: str
 
+
 @dataclass(frozen=True)
 class MockMetricsData:
     """A mock for a resim.metric.proto.MetricsData protobuf message."""
     name: str
     data: str
 
+
 @dataclass(frozen=True)
 class MockJob:
     job_id: str
 
+
 @dataclass(frozen=True)
 class MockListJobsResponse200:
     jobs: list[MockJob]
+
 
 @dataclass
 class MockUnpackedMetrics:
     metrics: list[MockMetric]
     metrics_data: list[MockMetricsData]
     names: set[str]
+
 
 _JOB_ID_METRICS_URL_MAP = {
     uuid.UUID("1f2441f6-cee2-4078-9729-048810c1da96"):
@@ -86,19 +91,20 @@ _BATCH_IDS_TO_JOB_IDS_MAP = {
 }
 
 _METRICS_URL_TO_MESSAGE_MAP = {
-    f"https://example.com/metrics_{i}.binproto": 
-    MockMetric(name = f"metric_{i} name", data=f"metric_{i}")
+    f"https://example.com/metrics_{i}.binproto":
+    MockMetric(name=f"metric_{i} name", data=f"metric_{i}")
     for i in range(10)
 }
 
 _METRICS_DATA_URL_TO_MESSAGE_MAP = {
-    f"https://example.com/metrics_data_{i}.binproto": 
-    MockMetricsData(name = f"data_{i} name", data=f"data_{i}")
+    f"https://example.com/metrics_data_{i}.binproto":
+    MockMetricsData(name=f"data_{i} name", data=f"data_{i}")
     for i in range(10)
 }
 
+
 def _mock_fetch_metrics_urls(*,
-                             project_id: uuid.UUID,                             
+                             project_id: uuid.UUID,
                              batch_id: uuid.UUID,
                              job_id: uuid.UUID,
                              client: AuthenticatedClient) -> list[str]:
@@ -117,34 +123,41 @@ def _mock_fetch_metrics_data_urls(*,
     assert client.token == _TOKEN
     return list(_JOB_ID_METRICS_DATA_URL_MAP[job_id])
 
-def _mock_list_job_ids_by_batch(project_id: str,
-                                batch_id: str,
-                                *,
-                                client: AuthenticatedClient) -> MockListJobsResponse200:
+
+def _mock_list_job_ids_by_batch(
+        project_id: str,
+        batch_id: str,
+        *,
+        client: AuthenticatedClient) -> MockListJobsResponse200:
     batch_id_uuid = uuid.UUID(batch_id)
     project_id_uuid = uuid.UUID(project_id)
 
     assert batch_id_uuid in _BATCH_IDS
     assert project_id_uuid in _PROJECT_IDS
-    
+
     assert client.token == _TOKEN
     return MockListJobsResponse200(
-        jobs= [MockJob(job_id=str(job_id)) for job_id in _BATCH_IDS_TO_JOB_IDS_MAP[batch_id_uuid]]
-    )
+        jobs=[
+            MockJob(
+                job_id=str(job_id)) for job_id in _BATCH_IDS_TO_JOB_IDS_MAP[batch_id_uuid]])
 
 # TODO(tknowles): In an ideal world, this would not be mocked out, but this will require us
 #                 to use valid messages within our Mock protobuf messages.
+
+
 def _mock_unpack_metrics(
     *,
     metrics: list[MockMetric],
-    metrics_data: list[MockMetricsData]) -> MockUnpackedMetrics:
+        metrics_data: list[MockMetricsData]) -> MockUnpackedMetrics:
     return MockUnpackedMetrics(
         metrics=metrics[:],
         metrics_data=metrics_data[:],
         names=set(m.name for m in metrics).union(set(md.name for md in metrics_data))
     )
 
+
 T = typing.TypeVar("T")
+
 
 def _mock_get_metrics_proto(*,
                             message_type: type[T],
@@ -201,7 +214,7 @@ class FetchJobMetricsTest(unittest.TestCase):
         self.assertEqual(len(_FETCHED_JOB_IDS), len(metrics_protos))
         self.assertEqual(len(_FETCHED_JOB_IDS), len(metrics_data_protos))
         for job_id in _FETCHED_JOB_IDS:
-            metric_urls =_JOB_ID_METRICS_URL_MAP[job_id]
+            metric_urls = _JOB_ID_METRICS_URL_MAP[job_id]
             metrics_data_urls = _JOB_ID_METRICS_DATA_URL_MAP[job_id]
             self.assertIn(job_id, metrics_protos)
             self.assertIn(job_id, metrics_data_protos)
@@ -218,6 +231,7 @@ class FetchJobMetricsTest(unittest.TestCase):
                 self.assertIn(
                     _METRICS_DATA_URL_TO_MESSAGE_MAP[url],
                     metrics_data_protos[job_id])
+
 
 @patch("resim.metrics.fetch_job_metrics.fetch_metrics_urls.fetch_metrics_urls",
        new=_mock_fetch_metrics_urls)
@@ -253,8 +267,11 @@ class FetchJobMetricsByBatchTest(unittest.TestCase):
                 batch_id=batch_id,
             )
 
-            self.assertEqual(len(job_to_metrics), len(_BATCH_IDS_TO_JOB_IDS_MAP[batch_id]))
-            self.assertEqual(set(job_to_metrics.keys()), set(_BATCH_IDS_TO_JOB_IDS_MAP[batch_id]))
+            self.assertEqual(
+                len(job_to_metrics), len(
+                    _BATCH_IDS_TO_JOB_IDS_MAP[batch_id]))
+            self.assertEqual(set(job_to_metrics.keys()), set(
+                _BATCH_IDS_TO_JOB_IDS_MAP[batch_id]))
 
             for job_id, metrics in job_to_metrics.items():
                 self.assertEqual(
@@ -273,6 +290,7 @@ class FetchJobMetricsByBatchTest(unittest.TestCase):
                                for url in _JOB_ID_METRICS_DATA_URL_MAP[job_id]))
                 )
                 self.assertEqual(metrics.names, expected_names)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/resim/metrics/fetch_job_metrics_test.py
+++ b/resim/metrics/fetch_job_metrics_test.py
@@ -120,6 +120,7 @@ def _mock_fetch_metrics_data_urls(*,
                                   job_id: uuid.UUID,
                                   client: AuthenticatedClient) -> list[str]:
     assert batch_id in _BATCH_IDS
+    assert project_id in _PROJECT_IDS
     assert client.token == _TOKEN
     return list(_JOB_ID_METRICS_DATA_URL_MAP[job_id])
 
@@ -189,8 +190,6 @@ class FetchJobMetricsTest(unittest.TestCase):
         Test that we can fetch job metrics while mocking the metrics url and
         proto getters.
         """
-        return None
-
         _FETCHED_JOB_IDS = [
             uuid.UUID("1f2441f6-cee2-4078-9729-048810c1da96"),
             uuid.UUID("f1b4fa78-7ede-46c8-bd8e-deb5681e8010"),

--- a/resim/metrics/fetch_metrics_urls.py
+++ b/resim/metrics/fetch_metrics_urls.py
@@ -20,6 +20,7 @@ from resim.metrics.fetch_all_pages import fetch_all_pages
 
 
 def fetch_metrics_urls(*,
+                       project_id: uuid.UUID,
                        batch_id: uuid.UUID,
                        job_id: uuid.UUID,
                        client: AuthenticatedClient) -> list[str]:
@@ -27,12 +28,14 @@ def fetch_metrics_urls(*,
     return [
         metric.metric_url for metrics_response in fetch_all_pages(
             list_metrics_for_job.sync,
+            str(project_id),
             str(batch_id),
             str(job_id),
             client=client) for metric in metrics_response.metrics]
 
 
 def fetch_metrics_data_urls(*,
+                            project_id: uuid.UUID,
                             batch_id: uuid.UUID,
                             job_id: uuid.UUID,
                             client: AuthenticatedClient) -> list[str]:
@@ -40,6 +43,7 @@ def fetch_metrics_data_urls(*,
     return [
         metrics_data.metrics_data_url for metrics_data_response in fetch_all_pages(
             list_metrics_data_for_job.sync,
+            str(project_id),
             str(batch_id),
             str(job_id),
             client=client) for metrics_data in metrics_data_response.metrics_data]

--- a/resim/metrics/fetch_metrics_urls_test.py
+++ b/resim/metrics/fetch_metrics_urls_test.py
@@ -60,18 +60,21 @@ class FetchMetricsUrlsTest(unittest.TestCase):
         Test that fetch_metrics_urls() works with a mocked version of
         fetch_all_pages().
         """
+        test_project_id = uuid.uuid4()
         test_batch_id = uuid.uuid4()
         test_job_id = uuid.uuid4()
         test_client = authenticated_client_mock()
 
         def mock_fetch_all_pages(
                 endpoint: typing.Callable,
+                project_id: str,
                 batch_id: str,
                 job_id: str,
                 *,
                 client: AuthenticatedClient) -> list[MockMetricsResponse]:
             """A mock for the fetch_all_pages() function that we use to return mock metrics"""
             self.assertEqual(endpoint, list_metrics_for_job.sync)
+            self.assertEqual(uuid.UUID(project_id), test_project_id)
             self.assertEqual(uuid.UUID(batch_id), test_batch_id)
             self.assertEqual(uuid.UUID(job_id), test_job_id)
             self.assertEqual(client, test_client)
@@ -85,6 +88,7 @@ class FetchMetricsUrlsTest(unittest.TestCase):
         with patch("resim.metrics.fetch_metrics_urls.fetch_all_pages",
                    new=mock_fetch_all_pages) as _:
             metrics_urls = fetch_metrics_urls.fetch_metrics_urls(
+                project_id=test_project_id,
                 batch_id=test_batch_id,
                 job_id=test_job_id,
                 client=test_client)
@@ -99,18 +103,21 @@ class FetchMetricsUrlsTest(unittest.TestCase):
         Test that fetch_metrics_data_urls() works with a mocked version of
         fetch_all_pages().
         """
+        test_project_id = uuid.uuid4()
         test_batch_id = uuid.uuid4()
         test_job_id = uuid.uuid4()
         test_client = authenticated_client_mock()
 
         def mock_fetch_all_pages(
                 endpoint: typing.Callable,
+                project_id: str,
                 batch_id: str,
                 job_id: str,
                 *,
                 client: AuthenticatedClient) -> list[MockMetricsDataResponse]:
             """A mock for the fetch_all_pages() function that we use to return mock metrics data"""
             self.assertEqual(endpoint, list_metrics_data_for_job.sync)
+            self.assertEqual(uuid.UUID(project_id), test_project_id)
             self.assertEqual(uuid.UUID(batch_id), test_batch_id)
             self.assertEqual(uuid.UUID(job_id), test_job_id)
             self.assertEqual(client, test_client)
@@ -124,6 +131,7 @@ class FetchMetricsUrlsTest(unittest.TestCase):
         with patch("resim.metrics.fetch_metrics_urls.fetch_all_pages",
                    new=mock_fetch_all_pages) as _:
             metrics_data_urls = fetch_metrics_urls.fetch_metrics_data_urls(
+                project_id=test_project_id,
                 batch_id=test_batch_id,
                 job_id=test_job_id,
                 client=test_client)


### PR DESCRIPTION
## Description of change
Upgrade batch metrics fetching code to work with project ids in the endpoint as part of the global project migration.

## Guide to reproduce test results.
```bash
bazel test //resim/metrics:fetch_job_metrics_test
bazel test //resim/metrics:fetch_metrics_urls_test
```
Run this script against the real staging api:
https://github.com/resim-ai/open-core/blob/prod/mikebauer/project-batch-metrics-test/resim/metrics/test.py
## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
