### PR TITLE
Add diffs to rigid body dynamics

### DIFF
--- a/resim/dynamics/rigid_body/dynamics.cc
+++ b/resim/dynamics/rigid_body/dynamics.cc
@@ -64,7 +64,6 @@ Dynamics::Delta Dynamics::operator()(
   // TODO(michael) Add the Jacobian to this
 
   if (diffs.has_value()) {
-    // TODO might be a more efficient way to do this
     [&f_x = diffs->f_x,
      &f_u = diffs->f_u,
      &I = inertia_,

--- a/resim/dynamics/rigid_body/dynamics_test.cc
+++ b/resim/dynamics/rigid_body/dynamics_test.cc
@@ -198,11 +198,8 @@ TEST(RigidBodyDynamicsTest, TestJacobian) {
         dynamics(state, force, START_TIME, NullableReference{diffs})};
 
     // VERIFICATION
-    const State::Delta output_perturbed{dynamics(
-        state_perturbed,
-        force_perturbed,
-        START_TIME,
-        null_reference<Dynamics::Diffs>)};
+    const State::Delta output_perturbed{
+        dynamics(state_perturbed, force_perturbed, START_TIME, null_reference)};
 
     // Using Taylor series
     const State::Delta expected_output_perturbed{

--- a/resim/dynamics/rigid_body/dynamics_test.cc
+++ b/resim/dynamics/rigid_body/dynamics_test.cc
@@ -177,7 +177,7 @@ TEST(RigidBodyDynamicsTest, TestJacobian) {
 
   constexpr int NUM_TESTS = 100;
   constexpr size_t SEED = 87U;
-  std::mt19937 rng;
+  std::mt19937 rng{SEED};
   for (int ii = 0; ii < NUM_TESTS; ++ii) {
     const State state{State() + testing::random_vector<State::Delta>(rng)};
     using Control = TangentVector;


### PR DESCRIPTION
## Description of change
Satisfy an old TODO by adding diffs for rigid body dynamics.

## Guide to reproduce test results.
```bash
bazel test --test_output=all  //resim/dynamics/rigid_body:dynamics_test
```
## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
