### PR TITLE
Add special type for null references

### DIFF
--- a/docs/resim/utils/output_parameters.md
+++ b/docs/resim/utils/output_parameters.md
@@ -121,7 +121,7 @@ int main(int argc, char **argv) {
   int val;
   maybe_set_to_three(resim::NullableReference{val});
   std::cout << val << std::endl;
-  maybe_set_to_three(resim::null_reference<int>);
+  maybe_set_to_three(resim::null_reference);
   return 0;
 }
 ```

--- a/resim/dynamics/forward_euler.hh
+++ b/resim/dynamics/forward_euler.hh
@@ -38,8 +38,7 @@ State ForwardEuler<State>::operator()(
     const CompleteDynamics &complete_dynamics) {
   using Jacobian = typename Base::MatXX;
   using Delta = typename Base::Delta;
-  const Delta d_state_dt{
-      complete_dynamics(state, time, null_reference<Jacobian>)};
+  const Delta d_state_dt{complete_dynamics(state, time, null_reference)};
   const double dt_s = time::as_seconds(dt);
 
   // Forward Euler :)

--- a/resim/dynamics/integrator.hh
+++ b/resim/dynamics/integrator.hh
@@ -122,12 +122,9 @@ State Integrator<State>::operator()(
 
         return dynamics(
             state,
-            controller(
-                state,
-                time,
-                null_reference<typename ControllerType::Jacobian>),
+            controller(state, time, null_reference),
             time,
-            null_reference<typename DynamicsType::Diffs>);
+            null_reference);
       });
 }
 

--- a/resim/dynamics/integrator_test.cc
+++ b/resim/dynamics/integrator_test.cc
@@ -48,7 +48,7 @@ class TestIntegrator : public Integrator<testing::OscillatorState> {
       const Delta perturbation{EPSILON * Delta::Unit(ii)};
       const State perturbed_state{state + perturbation};
       const Delta perturbed_delta{
-          complete_dynamics(perturbed_state, time, null_reference<MatXX>)};
+          complete_dynamics(perturbed_state, time, null_reference)};
       EXPECT_TRUE(
           (perturbed_delta - delta).isApprox(jacobian * perturbation, EPSILON));
     }

--- a/resim/dynamics/rigid_body/gravity_test.cc
+++ b/resim/dynamics/rigid_body/gravity_test.cc
@@ -45,8 +45,7 @@ TEST(GravityTest, TestGravity) {
         .d_reference_from_body = testing::random_vector<TangentVector>(rng),
     };
     constexpr time::Timestamp TIME;
-    const TangentVector force{
-        (*gravity_force)(state, TIME, null_reference<GravityForce::Jacobian>)};
+    const TangentVector force{(*gravity_force)(state, TIME, null_reference)};
 
     // VERIFICATION
     EXPECT_TRUE(SE3::tangent_vector_rotation_part(force).isZero());

--- a/resim/examples/output_parameters.cc
+++ b/resim/examples/output_parameters.cc
@@ -42,7 +42,7 @@ int main(int argc, char **argv) {
     int val;
     maybe_set_to_three(resim::NullableReference{val});
     std::cout << val << std::endl;
-    maybe_set_to_three(resim::null_reference<int>);
+    maybe_set_to_three(resim::null_reference);
   }
   return EXIT_SUCCESS;
 }

--- a/resim/math/newton_solver.hh
+++ b/resim/math/newton_solver.hh
@@ -26,7 +26,7 @@ namespace resim::math {
 // second argument `jacobian` is a mutable matrix which we can populate with the
 // Jacobian matrix (df_i(x)/dx_j) of the function. This is a nullable reference
 // because not all algorithms which use differentiable functions require their
-// derivatives. Such algorithms can simply pass a null_reference<...> object
+// derivatives. Such algorithms can simply pass a null_reference object
 // whenever they don't require this function to compute them.
 template <int DIM>
 using DifferentiableFunction = std::function<Eigen::Matrix<double, DIM, 1>(

--- a/resim/math/newton_solver_test.cc
+++ b/resim/math/newton_solver_test.cc
@@ -73,7 +73,7 @@ void test_nonlinear_solve(Rng &&rng) {
 
   // VERIFICATION
   ASSERT_TRUE(solution_sv.ok());
-  EXPECT_LT(fun(solution_sv.value(), null_reference<Jac>).norm(), TOLERANCE);
+  EXPECT_LT(fun(solution_sv.value(), null_reference).norm(), TOLERANCE);
 
   constexpr int TOO_FEW_ITERATIONS = 3;
   guess = 100.0 * Vec::Ones();

--- a/resim/planning/ilqr.hh
+++ b/resim/planning/ilqr.hh
@@ -210,12 +210,12 @@ double ILQR<State, Control>::forward_pass(const double linesearch_factor) {
          feedback_term_.at(ii) *
              (states_.next().at(ii) - states_.current().at(ii)));
     {
-      const auto no_diffs = null_reference<DynamicsDiffs<State, Control>>;
+      const auto no_diffs = null_reference;
       states_.mutable_next().at(ii + 1U) =
           dynamics_(states_.next().at(ii), controls_.next().at(ii), no_diffs);
     }
     {
-      const auto no_diffs = null_reference<CostDiffs<State, Control>>;
+      const auto no_diffs = null_reference;
       cost += cost_(
           states_.next().at(ii),
           NullableReference{controls_.next().at(ii)},
@@ -224,8 +224,8 @@ double ILQR<State, Control>::forward_pass(const double linesearch_factor) {
   }
 
   // Don't forget to add the cost for the final state
-  const auto no_diffs = null_reference<CostDiffs<State, Control>>;
-  const auto no_control = null_reference<const Control>;
+  const auto no_diffs = null_reference;
+  const auto no_control = null_reference;
   cost += cost_(states_.next().at(num_steps_), no_control, no_diffs);
   return cost;
 }
@@ -242,7 +242,7 @@ void ILQR<State, Control>::compute_derivatives() {
         NullableReference{controls_.current().at(ii)},
         NullableReference{cost_diffs_.at(ii)});
   }
-  const auto no_control = null_reference<const Control>;
+  const auto no_control = null_reference;
   cost_(
       states_.current().at(num_steps_),
       no_control,

--- a/resim/planning/ilqr_test.cc
+++ b/resim/planning/ilqr_test.cc
@@ -228,7 +228,7 @@ void expect_states_controls_consistent(
   ASSERT_EQ(result.states.size(), num_steps + 1U);
   for (std::size_t state_index = 0U; state_index < num_steps; ++state_index) {
     auto states = result.states;
-    const auto no_diffs = null_reference<DynamicsDiffs<State, Control>>;
+    const auto no_diffs = null_reference;
     states.at(state_index + 1U) = dynamics(
         states.at(state_index),
         result.controls.at(state_index),
@@ -261,14 +261,14 @@ void expect_controls_optimal(
       for (std::size_t state_index = 0U; state_index < num_steps;
            ++state_index) {
         {
-          const auto no_diffs = null_reference<DynamicsDiffs<State, Control>>;
+          const auto no_diffs = null_reference;
           perturbed_states.at(state_index + 1U) = dynamics(
               perturbed_states.at(state_index),
               perturbed_controls.at(state_index),
               no_diffs);
         }
         {
-          const auto no_diffs = null_reference<CostDiffs<State, Control>>;
+          const auto no_diffs = null_reference;
           cost += cost_fn(
               perturbed_states.at(state_index),
               NullableReference<const Control>{
@@ -276,8 +276,8 @@ void expect_controls_optimal(
               no_diffs);
         }
       }
-      const auto no_diffs = null_reference<CostDiffs<State, Control>>;
-      const auto no_controls = null_reference<const Control>;
+      const auto no_diffs = null_reference;
+      const auto no_controls = null_reference;
       cost += cost_fn(perturbed_states.at(num_steps), no_controls, no_diffs);
       EXPECT_GT(cost, result.cost);
     }

--- a/resim/transforms/geodetic.cc
+++ b/resim/transforms/geodetic.cc
@@ -111,7 +111,7 @@ Vec3 ecef_position_from_geodetic(const Geodetic &geodetic) {
           geodetic.longitude.in(au::radians),
           geodetic.altitude.in(au::meters),
       },
-      null_reference<Mat3>);
+      null_reference);
 }
 
 Geodetic geodetic_from_ecef_position(const Vec3 &ecef_position) {

--- a/resim/transforms/geodetic_test.cc
+++ b/resim/transforms/geodetic_test.cc
@@ -190,11 +190,10 @@ TEST(EcefTest, TestEcefFromGeodeticJacobian) {
       const double local_eps = EPSILON * std::max(1.0, std::fabs(geodetic(ii)));
       const Vec3 perturbed_geodetic{geodetic + local_eps * Vec3::Unit(ii)};
 
-      finite_differenced_jacobian.col(ii) = (ecef_position_from_geodetic(
-                                                 perturbed_geodetic,
-                                                 null_reference<Mat3>) -
-                                             ecef_position) /
-                                            local_eps;
+      finite_differenced_jacobian.col(ii) =
+          (ecef_position_from_geodetic(perturbed_geodetic, null_reference) -
+           ecef_position) /
+          local_eps;
     }
     constexpr double TOLERANCE = 1e-6;
     EXPECT_TRUE(

--- a/resim/utils/nullable_reference.hh
+++ b/resim/utils/nullable_reference.hh
@@ -19,6 +19,9 @@ class NullableReference {
   // Constructor from a reference to T
   explicit NullableReference(T &x);
 
+  // This needs to allow implicit conversion since NullReferenceType
+  // is interchangable with any null NullableReference<T>.
+  // NOLINTNEXTLINE(google-explicit-constructor)
   NullableReference(NullReferenceType /* unused */);
 
   NullableReference() = default;

--- a/resim/utils/nullable_reference.hh
+++ b/resim/utils/nullable_reference.hh
@@ -10,12 +10,16 @@
 
 namespace resim {
 
+struct NullReferenceType {};
+
 // This class represents a nullable reference to an object of type T.
 template <class T>
 class NullableReference {
  public:
   // Constructor from a reference to T
   explicit NullableReference(T &x);
+
+  NullableReference(NullReferenceType /* unused */);
 
   NullableReference() = default;
 
@@ -38,11 +42,13 @@ class NullableReference {
 };
 
 // Variable respresening a NULL NullableReference
-template <typename T>
-const NullableReference<T> null_reference{};
+const NullReferenceType null_reference;
 
 template <typename T>
 NullableReference<T>::NullableReference(T &x) : x_{&x} {}
+
+template <typename T>
+NullableReference<T>::NullableReference(NullReferenceType /* unused */) {}
 
 template <typename T>
 bool NullableReference<T>::has_value() const {

--- a/resim/utils/nullable_reference_test.cc
+++ b/resim/utils/nullable_reference_test.cc
@@ -29,7 +29,7 @@ TEST(NullableReferenceTest, TestNullableReference) {
   };
 
   // ACTION / VERFICIATION
-  EXPECT_EQ(test_function(null_reference<int>), DidSet::NO_SET_VALUE);
+  EXPECT_EQ(test_function(null_reference), DidSet::NO_SET_VALUE);
 
   int value_to_set = 0;
   EXPECT_EQ(test_function(NullableReference{value_to_set}), DidSet::SET_VALUE);
@@ -64,7 +64,7 @@ TEST(NullableReferenceDeathTest, TestBadDereference) {
   };
 
   // ACTION / VERFICIATION
-  EXPECT_THROW({ test_function(null_reference<int>); }, AssertException);
+  EXPECT_THROW({ test_function(null_reference); }, AssertException);
 }
 // NOLINTEND(readability-function-cognitive-complexity)
 


### PR DESCRIPTION
## Description of change
Add a special type for null references which is implicitly convertible to any NullableReference<T>. This is analogous to `std::nullopt_t` and works the same way.

## Guide to reproduce test results.
```bash
bazel test //resim/utils:nullable_reference_test
```
## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
