### PR TITLE
Release primitive ros2 types in python

### DIFF
--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -113,6 +113,7 @@ py_package(
         "//resim/msg:navsat_proto_py",
         "//resim/msg:odometry_proto_py",
         "//resim/msg:pose_proto_py",
+        "//resim/msg:primitives_proto_py",
         "//resim/msg:transform_proto_py",
         "//resim/transforms/proto:framed_vector_3_proto_py",
     ],


### PR DESCRIPTION
## Description of change
Make sure that ROS2 primitive message types are in our messages wheel.

## Guide to reproduce test results.
```bash
bazel build //pkg/...
```
And verify that the msg wheel has the new library in it.

## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
