### PR TITLE
Fix pagination bug in fetch_job_metrics_by_batch()

### DIFF
--- a/resim/metrics/fetch_job_metrics.py
+++ b/resim/metrics/fetch_job_metrics.py
@@ -21,6 +21,7 @@ from resim.metrics.python.unpack_metrics import (
     unpack_metrics,
     UnpackedMetrics
 )
+from resim.metrics.fetch_all_pages import fetch_all_pages
 
 import resim.metrics.proto.metrics_pb2 as mp
 
@@ -50,14 +51,13 @@ def fetch_job_metrics_by_batch(*,
     client = AuthenticatedClient(
         base_url=api_url,
         token=token)
-    jobs_response = list_jobs.sync(str(project_id), str(batch_id), client=client)
-    assert jobs_response is not None
+    jobs_responses = fetch_all_pages(list_jobs.sync, str(project_id), str(batch_id), client=client)
     jobs = [
         JobInfo(
             job_id=uuid.UUID(job.job_id),
             batch_id=batch_id,
             project_id=project_id
-        ) for job in jobs_response.jobs]
+        ) for jobs_response in jobs_responses for job in jobs_response.jobs]
 
     # Fetch the metrics for these jobs:
     metrics_protos, metrics_data_protos = fetch_job_metrics(

--- a/resim/metrics/fetch_job_metrics.py
+++ b/resim/metrics/fetch_job_metrics.py
@@ -36,14 +36,16 @@ class JobInfo:
     batch_id: uuid.UUID
     project_id: uuid.UUID
 
+
 def fetch_job_metrics_by_batch(*,
-                        token: str,
-                        api_url: str,
-                        project_id: uuid.UUID,
-                        batch_id: uuid.UUID) -> Dict[uuid.UUID, UnpackedMetrics]:
+                               token: str,
+                               api_url: str,
+                               project_id: uuid.UUID,
+                               batch_id: uuid.UUID) -> Dict[uuid.UUID,
+                                                            UnpackedMetrics]:
     """
     This downloads all metrics associated with a certain batch, and stores them in a
-    dictionary mapping each job ID to the metrics and metrics data associated with 
+    dictionary mapping each job ID to the metrics and metrics data associated with
     those job IDs.
     """
 
@@ -51,7 +53,11 @@ def fetch_job_metrics_by_batch(*,
     client = AuthenticatedClient(
         base_url=api_url,
         token=token)
-    jobs_responses = fetch_all_pages(list_jobs.sync, str(project_id), str(batch_id), client=client)
+    jobs_responses = fetch_all_pages(
+        list_jobs.sync,
+        str(project_id),
+        str(batch_id),
+        client=client)
     jobs = [
         JobInfo(
             job_id=uuid.UUID(job.job_id),
@@ -73,6 +79,7 @@ def fetch_job_metrics_by_batch(*,
             metrics_data=metrics_data)
 
     return unpacked_metrics_per_job
+
 
 def fetch_job_metrics(*,
                       token: str,
@@ -226,7 +233,7 @@ def _get_metrics_urls(*,
     """
     metrics_urls_lock.acquire()
     metrics_urls[job_id] = fetch_metrics_urls.fetch_metrics_urls(
-        project_id=project_id,batch_id=batch_id, job_id=job_id, client=client)
+        project_id=project_id, batch_id=batch_id, job_id=job_id, client=client)
     metrics_urls_lock.release()
 
 

--- a/resim/metrics/fetch_job_metrics_test.py
+++ b/resim/metrics/fetch_job_metrics_test.py
@@ -45,6 +45,7 @@ class MockJob:
 @dataclass(frozen=True)
 class MockListJobsResponse200:
     jobs: list[MockJob]
+    next_page_token: str
 
 
 @dataclass
@@ -140,7 +141,8 @@ def _mock_list_job_ids_by_batch(
     return MockListJobsResponse200(
         jobs=[
             MockJob(
-                job_id=str(job_id)) for job_id in _BATCH_IDS_TO_JOB_IDS_MAP[batch_id_uuid]])
+                job_id=str(job_id)) for job_id in _BATCH_IDS_TO_JOB_IDS_MAP[batch_id_uuid]],
+         next_page_token="")
 
 # TODO(tknowles): In an ideal world, this would not be mocked out, but this will require us
 #                 to use valid messages within our Mock protobuf messages.

--- a/resim/metrics/fetch_job_metrics_test.py
+++ b/resim/metrics/fetch_job_metrics_test.py
@@ -142,7 +142,7 @@ def _mock_list_job_ids_by_batch(
         jobs=[
             MockJob(
                 job_id=str(job_id)) for job_id in _BATCH_IDS_TO_JOB_IDS_MAP[batch_id_uuid]],
-         next_page_token="")
+        next_page_token="")
 
 # TODO(tknowles): In an ideal world, this would not be mocked out, but this will require us
 #                 to use valid messages within our Mock protobuf messages.


### PR DESCRIPTION
## Description of change
Currently, only the first page of job metrics is being checked. This doesn't work for batches with more than 10 jobs. Fetch all pages.

## Guide to reproduce test results.
```bash
bazel test //resim/metrics:fetch_job_metrics_test
```
## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
