### PR TITLE
Add a state type for mpc on drone motion

### DIFF
--- a/resim/planning/drone/BUILD
+++ b/resim/planning/drone/BUILD
@@ -23,6 +23,7 @@ cc_test(
     srcs = ["state_test.cc"],
     deps = [
         ":state",
+        "//resim/math:is_approx",
         "//resim/testing:random_matrix",
         "@com_google_googletest//:gtest_main",
     ],

--- a/resim/planning/drone/BUILD
+++ b/resim/planning/drone/BUILD
@@ -1,0 +1,29 @@
+# Copyright 2024 ReSim, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+cc_library(
+    name = "state",
+    srcs = ["state.cc"],
+    hdrs = ["state.hh"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//resim/math:vector_partition",
+        "//resim/transforms:so3",
+        "@libeigen//:eigen",
+    ],
+)
+
+cc_test(
+    name = "state_test",
+    srcs = ["state_test.cc"],
+    deps = [
+        ":state",
+        "//resim/testing:random_matrix",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/resim/planning/drone/state.cc
+++ b/resim/planning/drone/state.cc
@@ -1,0 +1,32 @@
+
+
+#include "resim/planning/drone/state.hh"
+
+namespace resim::planning::drone {
+
+using math::get_block;
+
+State operator+(const State &x, const typename State::Vec &dx) {
+  return State{
+      .scene_from_body_rotation =
+          x.scene_from_body_rotation *
+          transforms::SO3::exp(get_block<StatePartition, ROTATION>(dx)),
+      .position = x.position + get_block<StatePartition, POSITION>(dx),
+      .angular_velocity =
+          x.angular_velocity + get_block<StatePartition, ANGULAR_VELOCITY>(dx),
+      .velocity = x.velocity + get_block<StatePartition, VELOCITY>(dx),
+  };
+}
+
+typename State::Vec operator-(const State &x, const State &y) {
+  State::Vec result;
+  get_block<StatePartition, ROTATION>(result) =
+      (y.scene_from_body_rotation.inverse() * x.scene_from_body_rotation).log();
+  get_block<StatePartition, POSITION>(result) = x.position - y.position;
+  get_block<StatePartition, ANGULAR_VELOCITY>(result) =
+      x.angular_velocity - y.angular_velocity;
+  get_block<StatePartition, VELOCITY>(result) = x.velocity - y.velocity;
+  return result;
+}
+
+}  // namespace resim::planning::drone

--- a/resim/planning/drone/state.cc
+++ b/resim/planning/drone/state.cc
@@ -10,22 +10,26 @@ State operator+(const State &x, const typename State::Vec &dx) {
   return State{
       .scene_from_body_rotation =
           x.scene_from_body_rotation *
-          transforms::SO3::exp(get_block<StatePartition, ROTATION>(dx)),
-      .position = x.position + get_block<StatePartition, POSITION>(dx),
+          transforms::SO3::exp(
+              get_block<State::Partition, State::ROTATION>(dx)),
+      .position = x.position + get_block<State::Partition, State::POSITION>(dx),
       .angular_velocity =
-          x.angular_velocity + get_block<StatePartition, ANGULAR_VELOCITY>(dx),
-      .velocity = x.velocity + get_block<StatePartition, VELOCITY>(dx),
+          x.angular_velocity +
+          get_block<State::Partition, State::ANGULAR_VELOCITY>(dx),
+      .velocity = x.velocity + get_block<State::Partition, State::VELOCITY>(dx),
   };
 }
 
 typename State::Vec operator-(const State &x, const State &y) {
   State::Vec result;
-  get_block<StatePartition, ROTATION>(result) =
+  get_block<State::Partition, State::ROTATION>(result) =
       (y.scene_from_body_rotation.inverse() * x.scene_from_body_rotation).log();
-  get_block<StatePartition, POSITION>(result) = x.position - y.position;
-  get_block<StatePartition, ANGULAR_VELOCITY>(result) =
+  get_block<State::Partition, State::POSITION>(result) =
+      x.position - y.position;
+  get_block<State::Partition, State::ANGULAR_VELOCITY>(result) =
       x.angular_velocity - y.angular_velocity;
-  get_block<StatePartition, VELOCITY>(result) = x.velocity - y.velocity;
+  get_block<State::Partition, State::VELOCITY>(result) =
+      x.velocity - y.velocity;
   return result;
 }
 

--- a/resim/planning/drone/state.cc
+++ b/resim/planning/drone/state.cc
@@ -1,4 +1,8 @@
-
+// Copyright 2024 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
 
 #include "resim/planning/drone/state.hh"
 

--- a/resim/planning/drone/state.hh
+++ b/resim/planning/drone/state.hh
@@ -1,0 +1,37 @@
+
+#pragma once
+
+#include <Eigen/Dense>
+
+#include "resim/math/vector_partition.hh"
+#include "resim/transforms/so3.hh"
+
+namespace resim::planning::drone {
+
+enum StateBlockIndices : std::size_t {
+  ROTATION = 0,
+  POSITION,
+  ANGULAR_VELOCITY,
+  VELOCITY,
+  NUM_BLOCKS,
+};
+
+using StatePartition = resim::math::VectorPartition<3, 3, 3, 3>;
+
+struct State {
+  static constexpr int DIM = math::OffsetAt<StatePartition, NUM_BLOCKS>::value;
+  using Vec = Eigen::Matrix<double, DIM, 1>;
+
+  // We don't use SE3 directly for this because the cost functions get
+  // un-necessarily complicated to formulate in SE3.
+  transforms::SO3 scene_from_body_rotation;
+  Eigen::Vector3d position;
+  Eigen::Vector3d angular_velocity;
+  Eigen::Vector3d velocity;
+};
+
+State operator+(const State &x, const typename State::Vec &dx);
+
+typename State::Vec operator-(const State &x, const State &y);
+
+}  // namespace resim::planning::drone

--- a/resim/planning/drone/state.hh
+++ b/resim/planning/drone/state.hh
@@ -8,18 +8,18 @@
 
 namespace resim::planning::drone {
 
-enum StateBlockIndices : std::size_t {
-  ROTATION = 0,
-  POSITION,
-  ANGULAR_VELOCITY,
-  VELOCITY,
-  NUM_BLOCKS,
-};
-
-using StatePartition = resim::math::VectorPartition<3, 3, 3, 3>;
-
 struct State {
-  static constexpr int DIM = math::OffsetAt<StatePartition, NUM_BLOCKS>::value;
+  enum BlockIndices : std::size_t {
+    ROTATION = 0,
+    POSITION,
+    ANGULAR_VELOCITY,
+    VELOCITY,
+    NUM_BLOCKS,
+  };
+
+  using Partition = resim::math::VectorPartition<3, 3, 3, 3>;
+
+  static constexpr int DIM = math::OffsetAt<Partition, NUM_BLOCKS>::value;
   using Vec = Eigen::Matrix<double, DIM, 1>;
 
   // We don't use SE3 directly for this because the cost functions get

--- a/resim/planning/drone/state.hh
+++ b/resim/planning/drone/state.hh
@@ -1,3 +1,8 @@
+// Copyright 2024 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
 
 #pragma once
 

--- a/resim/planning/drone/state_test.cc
+++ b/resim/planning/drone/state_test.cc
@@ -1,0 +1,39 @@
+
+
+#include "resim/planning/drone/state.hh"
+
+#include <gtest/gtest.h>
+
+#include "resim/math/is_approx.hh"
+#include "resim/testing/random_matrix.hh"
+
+namespace resim::planning::drone {
+
+TEST(StateTest, TestAddAndSubtract) {
+  // SETUP
+  constexpr size_t SEED = 93U;
+  std::mt19937 rng{SEED};
+  constexpr int NUM_TESTS = 100;
+  const State state;
+  for (int ii = 0; ii < NUM_TESTS; ++ii) {
+    const State::Vec delta{testing::random_vector<State::Vec>(rng)};
+
+    // ACTION
+    const State sum{state + delta};
+
+    // VERIFICATION
+    EXPECT_FALSE(
+        sum.scene_from_body_rotation.is_approx(state.scene_from_body_rotation));
+    EXPECT_FALSE(math::is_approx(sum.position, state.position));
+    EXPECT_FALSE(math::is_approx(sum.angular_velocity, state.angular_velocity));
+    EXPECT_FALSE(math::is_approx(sum.velocity, state.velocity));
+
+    // ACTION
+    const State::Vec diff{sum - state};
+
+    // VERIFICATION
+    EXPECT_TRUE(math::is_approx(diff, delta));
+  }
+}
+
+}  // namespace resim::planning::drone

--- a/resim/planning/drone/state_test.cc
+++ b/resim/planning/drone/state_test.cc
@@ -1,4 +1,8 @@
-
+// Copyright 2024 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
 
 #include "resim/planning/drone/state.hh"
 


### PR DESCRIPTION
## Description of change
Add a state type for model predictive control of drone motion including the drone's position, orientation, velocity, and angular velocity.

## Guide to reproduce test results.
```bash
bazel test //resim/planning/drone:state_test
```
## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
