### PR TITLE
Add log visualization tools

### DIFF
--- a/resim/visualization/log/BUILD
+++ b/resim/visualization/log/BUILD
@@ -1,0 +1,164 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+
+cc_library(
+    name = "visit_topic",
+    srcs = ["visit_topic.cc"],
+    hdrs = ["visit_topic.hh"],
+    deps = [
+        "//resim/assert",
+        "//resim/third_party/mcap:mcap_impl",
+        "//resim/utils:inout",
+    ],
+)
+
+cc_test(
+    name = "visit_topic_test",
+    srcs = ["visit_topic_test.cc"],
+    deps = [
+        ":test_helpers",
+        ":visit_topic",
+        "//resim/assert",
+        "//resim/experiences:experience",
+        "//resim/experiences/proto:experience_proto_cc",
+        "//resim/experiences/proto:experience_to_proto",
+        "//resim/third_party/mcap:mcap_impl",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "extract_experience",
+    srcs = ["extract_experience.cc"],
+    hdrs = ["extract_experience.hh"],
+    deps = [
+        ":visit_topic",
+        "//resim/experiences:experience",
+        "//resim/experiences/proto:experience_proto_cc",
+        "//resim/experiences/proto:experience_to_proto",
+        "//resim/third_party/mcap:mcap_impl",
+        "//resim/utils:inout",
+    ],
+)
+
+cc_test(
+    name = "extract_experience_test",
+    srcs = ["extract_experience_test.cc"],
+    deps = [
+        ":extract_experience",
+        ":test_helpers",
+        "//resim/assert",
+        "//resim/experiences:experience",
+        "//resim/experiences/proto:experience_proto_cc",
+        "//resim/experiences/proto:experience_to_proto",
+        "//resim/experiences/proto:experiences_test_helpers",
+        "//resim/third_party/mcap:mcap_impl",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "visualize_actor_states",
+    srcs = ["visualize_actor_states.cc"],
+    hdrs = ["visualize_actor_states.hh"],
+    deps = [
+        ":visit_topic",
+        "//resim/actor:actor_id",
+        "//resim/actor/state:observable_state",
+        "//resim/actor/state/proto:observable_state_proto_cc",
+        "//resim/actor/state/proto:observable_state_to_proto",
+        "//resim/assert",
+        "//resim/experiences:experience",
+        "//resim/experiences:geometry",
+        "//resim/simulator:standard_frames",
+        "//resim/third_party/mcap:mcap_impl",
+        "//resim/transforms:se3",
+        "//resim/utils:inout",
+        "//resim/utils:match",
+        "//resim/utils:mcap_logger",
+        "//resim/visualization/foxglove:frame_transform_to_foxglove",
+        "//resim/visualization/foxglove:wireframe_to_foxglove",
+        "@fmt",
+        "@foxglove_schemas",
+    ],
+)
+
+cc_test(
+    name = "visualize_actor_states_test",
+    srcs = ["visualize_actor_states_test.cc"],
+    deps = [
+        ":test_helpers",
+        ":visit_topic",
+        ":visualize_actor_states",
+        "//resim/actor/state:observable_state",
+        "//resim/actor/state:rigid_body_state",
+        "//resim/actor/state/proto:observable_state_proto_cc",
+        "//resim/actor/state/proto:observable_state_to_proto",
+        "//resim/assert",
+        "//resim/curves:two_jet",
+        "//resim/curves:two_jet_test_helpers",
+        "//resim/experiences:experience",
+        "//resim/experiences/proto:experience_proto_cc",
+        "//resim/experiences/proto:experience_to_proto",
+        "//resim/experiences/proto:experiences_test_helpers",
+        "//resim/geometry:wireframe",
+        "//resim/simulator:standard_frames",
+        "//resim/time:timestamp",
+        "//resim/time/proto:time_to_proto",
+        "//resim/transforms:frame",
+        "//resim/transforms:se3",
+        "//resim/transforms:so3",
+        "//resim/utils:mcap_logger",
+        "//resim/visualization/foxglove:frame_transform_to_foxglove",
+        "//resim/visualization/foxglove:wireframe_to_foxglove",
+        "@com_google_googletest//:gtest_main",
+        "@fmt",
+        "@foxglove_schemas",
+    ],
+)
+
+cc_binary(
+    name = "make_visualization_log",
+    srcs = ["make_visualization_log.cc"],
+    deps = [
+        ":extract_experience",
+        ":visualize_actor_states",
+        "//resim/assert",
+        "//resim/experiences:experience",
+        "//resim/third_party/mcap:mcap_impl",
+        "//resim/utils:inout",
+        "//resim/utils:mcap_logger",
+        "@cxxopts",
+    ],
+)
+
+cc_library(
+    name = "test_helpers",
+    srcs = ["test_helpers.cc"],
+    hdrs = ["test_helpers.hh"],
+    deps = [
+        "//resim/experiences:actor",
+        "//resim/experiences:experience",
+        "//resim/experiences:geometry",
+        "//resim/experiences/proto:experience_proto_cc",
+        "//resim/geometry:drone_wireframe",
+        "//resim/geometry:wireframe",
+        "//resim/third_party/mcap:mcap_impl",
+        "//resim/utils:mcap_logger",
+        "//resim/utils:uuid",
+    ],
+)
+
+cc_test(
+    name = "test_helpers_test",
+    srcs = ["test_helpers_test.cc"],
+    deps = [
+        ":test_helpers",
+        "//resim/experiences:experience",
+        "//resim/experiences/proto:experience_proto_cc",
+        "//resim/geometry:wireframe",
+        "//resim/third_party/mcap:mcap_impl",
+        "//resim/utils:mcap_logger",
+        "//resim/utils:uuid",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/resim/visualization/log/extract_experience.cc
+++ b/resim/visualization/log/extract_experience.cc
@@ -1,0 +1,32 @@
+
+#include "resim/visualization/log/extract_experience.hh"
+
+#include <optional>
+
+#include "resim/experiences/proto/experience.pb.h"
+#include "resim/experiences/proto/experience_to_proto.hh"
+#include "resim/visualization/log/visit_topic.hh"
+
+namespace resim::visualization::log {
+
+experiences::Experience extract_experience(InOut<mcap::McapReader> reader) {
+  std::optional<experiences::Experience> experience;
+
+  visit_topic(
+      "/experience",
+      reader,
+      [&experience](const mcap::MessageView &view) {
+        experiences::proto::Experience experience_msg;
+        REASSERT(experience_msg.ParseFromArray(
+            view.message.data,
+            view.message.dataSize));
+        REASSERT(
+            not experience.has_value(),
+            "More than one experience found in input log!");
+        experience = unpack(experience_msg);
+      });
+  REASSERT(experience.has_value(), "No experience found in input log!");
+  return *experience;
+}
+
+}  // namespace resim::visualization::log

--- a/resim/visualization/log/extract_experience.hh
+++ b/resim/visualization/log/extract_experience.hh
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <mcap/reader.hpp>
+
+#include "resim/experiences/experience.hh"
+#include "resim/utils/inout.hh"
+
+namespace resim::visualization::log {
+
+// This function extracts the experience config from the given log (represented
+// by a log reader). It expects one and exactly one such message to be logged
+// on the "/experience" topic and throws otherwise.
+// @param[in] reader - The reader for the log we want to get the experience
+//                     config from.
+// @returns The experience extracted from this log.
+// @throws AssertException if zero or more than one experiences are logged.
+experiences::Experience extract_experience(InOut<mcap::McapReader> reader);
+
+}  // namespace resim::visualization::log

--- a/resim/visualization/log/extract_experience_test.cc
+++ b/resim/visualization/log/extract_experience_test.cc
@@ -1,0 +1,52 @@
+
+#include "resim/visualization/log/extract_experience.hh"
+
+#include <gtest/gtest.h>
+
+#include <mcap/reader.hpp>
+#include <sstream>
+
+#include "resim/assert/assert.hh"
+#include "resim/experiences/experience.hh"
+#include "resim/experiences/proto/experience.pb.h"
+#include "resim/experiences/proto/experience_to_proto.hh"
+#include "resim/experiences/proto/experiences_test_helpers.hh"
+#include "resim/visualization/log/test_helpers.hh"
+
+namespace resim::visualization::log {
+
+TEST(ExtractExperienceTest, TestExtractExperience) {
+  // SETUP
+  experiences::Experience experience{test_experience()};
+  experiences::proto::Experience experience_msg;
+  pack(experience, &experience_msg);
+
+  std::istringstream input_log{make_input_log(experience_msg)};
+
+  mcap::McapReader reader;
+  StreamReader readable{input_log};
+  EXPECT_TRUE(reader.open(readable).ok());
+
+  // ACTION
+  experiences::Experience extracted{extract_experience(InOut{reader})};
+
+  // VERIFICATION
+  EXPECT_TRUE(experiences::test_experience_equality(extracted, experience));
+}
+
+TEST(ExtractExperienceTest, TestExtractExperienceTooFewTooMany) {
+  for (const int num_messages : {0, 2}) {
+    // SETUP
+    std::istringstream input_log{
+        make_input_log(experiences::proto::Experience(), num_messages)};
+
+    mcap::McapReader reader;
+    StreamReader readable{input_log};
+    EXPECT_TRUE(reader.open(readable).ok());
+
+    // ACTION / VERIFICATION
+    EXPECT_THROW(extract_experience(InOut{reader}), AssertException);
+  }
+}
+
+}  // namespace resim::visualization::log

--- a/resim/visualization/log/make_visualization_log.cc
+++ b/resim/visualization/log/make_visualization_log.cc
@@ -1,0 +1,75 @@
+
+#include <cstdlib>
+#include <cxxopts.hpp>
+#include <filesystem>
+#include <iostream>
+#include <mcap/reader.hpp>
+
+#include "resim/assert/assert.hh"
+#include "resim/experiences/experience.hh"
+#include "resim/utils/inout.hh"
+#include "resim/utils/mcap_logger.hh"
+#include "resim/visualization/log/extract_experience.hh"
+#include "resim/visualization/log/visualize_actor_states.hh"
+
+namespace resim::visualization::log {
+
+// This helper function actually generates the visualization log based on the
+// given sim log path.
+// @param[in] sim_log - The path of the sim log to read the sim information
+//                      from.
+// @param[in] vis_log - The path of the visualization log to write to.
+// @throws AssertException if the sim log does not exist or can't be opened by
+// the mcap reader.
+void generate_visualization_log(
+    const std::filesystem::path &sim_log,
+    const std::filesystem::path &vis_log) {
+  REASSERT(std::filesystem::exists(sim_log), "Input log does not exist!");
+
+  mcap::McapReader reader;
+  REASSERT(reader.open(sim_log.string()).ok());
+
+  McapLogger logger{vis_log};
+  logger.add_log_contents(InOut{reader});
+
+  const experiences::Experience experience{extract_experience(InOut{reader})};
+  visualize_actor_states(experience, InOut{reader}, InOut{logger});
+}
+
+void make_visualization_log(int argc, char **argv) {
+  cxxopts::Options options{
+      "Make visualization log",
+      "A simple program for making a ReSim log visualizable in Foxglove. \n"
+      "Existing topics are copied over from the input log and FrameTransforms "
+      "\n"
+      "and SceneUpdates are added to make things visible in Foxglove."};
+  // clang-format off
+  options.add_options()
+    ("l,log", "Input log location (required)", cxxopts::value<std::string>())
+    ("o,output", "Output log location (required)", cxxopts::value<std::string>())
+    ("h,help", "Print usage")
+  ;
+  // clang-format on
+  auto options_result = options.parse(argc, argv);
+
+  if (options_result.count("help") > 0U or options_result.count("log") == 0U or
+      options_result.count("output") == 0U) {
+    std::cout << options.help() << std::endl;
+    exit(0);
+  }
+
+  const std::filesystem::path sim_mcap_path{
+      options_result["log"].as<std::string>()};
+
+  const std::filesystem::path vis_mcap_path{
+      options_result["output"].as<std::string>()};
+
+  generate_visualization_log(sim_mcap_path, vis_mcap_path);
+}
+
+}  // namespace resim::visualization::log
+
+int main(int argc, char **argv) {
+  resim::visualization::log::make_visualization_log(argc, argv);
+  return EXIT_SUCCESS;
+}

--- a/resim/visualization/log/test_helpers.cc
+++ b/resim/visualization/log/test_helpers.cc
@@ -1,0 +1,124 @@
+
+#include "resim/visualization/log/test_helpers.hh"
+
+#include "resim/experiences/actor.hh"
+#include "resim/experiences/experience.hh"
+#include "resim/experiences/geometry.hh"
+#include "resim/geometry/drone_wireframe.hh"
+#include "resim/geometry/wireframe.hh"
+#include "resim/utils/mcap_logger.hh"
+#include "resim/utils/uuid.hh"
+
+namespace resim::visualization::log {
+
+namespace {
+
+geometry::Wireframe test_wireframe() {
+  constexpr double CHASSIS_RADIUS_M = 1.;
+  constexpr double ROTOR_LATERAL_OFFSET_M = 0.3;
+  constexpr double ROTOR_VERTICAL_OFFSET_M = 0.3;
+  constexpr double ROTOR_RADIUS_M = 0.5;
+  constexpr std::size_t SAMPLES_PER_ROTOR = 2;
+
+  const geometry::DroneExtents extents{
+      .chassis_radius_m = CHASSIS_RADIUS_M,
+      .rotor_lateral_offset_m = ROTOR_LATERAL_OFFSET_M,
+      .rotor_vertical_offset_m = ROTOR_VERTICAL_OFFSET_M,
+      .rotor_radius_m = ROTOR_RADIUS_M,
+      .samples_per_rotor = SAMPLES_PER_ROTOR,
+  };
+  return geometry::drone_wireframe(extents);
+}
+
+}  // namespace
+
+using experiences::Experience;
+
+Experience test_experience() {
+  Experience experience;
+
+  // Setup the header
+  experience.header.revision.major = 1;
+  experience.header.revision.minor = 2;
+  experience.header.name = "test_experience";
+  experience.header.description = "An experience for testing.";
+  experience.header.parent_experience_name = "";
+
+  // Add geometry
+  const experiences::Geometry geometry{
+      .id = UUID::new_uuid(),
+      .model = test_wireframe(),
+  };
+  experience.geometries.emplace(geometry.id, geometry);
+
+  // Add an actor
+  const experiences::GeometryReference geometry_ref{
+      .geometry_id = geometry.id,
+  };
+  const experiences::Actor actor{
+      .id = UUID::new_uuid(),
+      .name = "test_actor",
+      .actor_type = experiences::ActorType::SYSTEM_UNDER_TEST,
+      .geometries = {geometry_ref},
+  };
+  experience.dynamic_behavior.actors.emplace_back(actor);
+
+  // The storyboard and completion criteria are not needed yet for
+  // visualization.
+
+  return experience;
+}
+
+std::string make_input_log(
+    const experiences::proto::Experience& experience_msg,
+    const int num_messages) {
+  std::ostringstream sstream;
+  // Scope so that the logger flushes to the string stream when it's destroyed.
+  {
+    McapLogger logger{sstream};
+
+    logger.add_proto_channel<experiences::proto::Experience>("/experience");
+
+    constexpr time::Timestamp TIME;
+    for (int ii = 0; ii < num_messages; ++ii) {
+      logger.log_proto("/experience", TIME, experience_msg);
+    }
+  }
+  return sstream.str();
+}
+
+StreamReader::StreamReader(std::istream& stream) : stream_{stream} {
+  stream_.seekg(0, std::istream::end);
+  size_ = stream_.tellg();
+  stream_.seekg(0, std::istream::beg);
+}
+
+uint64_t StreamReader::size() const { return size_; }
+uint64_t
+StreamReader::read(std::byte** output, uint64_t offset, uint64_t size) {
+  if (offset >= size_) {
+    return 0;
+  }
+
+  if (offset != position_) {
+    stream_.seekg(static_cast<std::streamoff>(offset));
+    position_ = offset;
+  }
+
+  if (size > buffer_.size()) {
+    buffer_.resize(size);
+  }
+
+  // We need to use memcpy to avoid a pointer cast, which clang-tidy doesn't
+  // like:
+  std::string tmp(size, '\0');
+  stream_.read(tmp.data(), static_cast<std::streamoff>(size));
+  std::memcpy(buffer_.data(), tmp.data(), size);
+  *output = buffer_.data();
+
+  const uint64_t bytesRead = stream_.gcount();
+  position_ += bytesRead;
+  return bytesRead;
+}
+
+}  // namespace resim::visualization::log

--- a/resim/visualization/log/test_helpers.hh
+++ b/resim/visualization/log/test_helpers.hh
@@ -1,0 +1,43 @@
+
+#pragma once
+
+#include <mcap/reader.hpp>
+#include <string>
+
+#include "resim/experiences/experience.hh"
+#include "resim/experiences/proto/experience.pb.h"
+
+namespace resim::visualization::log {
+
+// Helper to generate a test experience config containing a valid header and a
+// single actor with a Wireframe geometry.
+experiences::Experience test_experience();
+
+// Helper to make an mcap log (written to a string) with num_messages copies of
+// experience_msg logged to the "/experience" channel.
+// @param[in] experience_msg - The message to write to the "/experience"
+//                             channel.
+// @param[in] num_messages - The number of times to write experience_msg to the
+//                           "/experience" channel.
+std::string make_input_log(
+    const experiences::proto::Experience& experience_msg,
+    int num_messages = 1);
+
+// A more generic version of mcap::FileStreamReader so we can read a log from a
+// string. This implements the basic functionality required by mcap::IReadable
+// using the stored std::istream.
+class StreamReader final : public mcap::IReadable {
+ public:
+  explicit StreamReader(std::istream& stream);
+
+  uint64_t size() const override;
+  uint64_t read(std::byte** output, uint64_t offset, uint64_t size) override;
+
+ private:
+  std::istream& stream_;
+  std::vector<std::byte> buffer_;
+  uint64_t size_{};
+  uint64_t position_{};
+};
+
+}  // namespace resim::visualization::log

--- a/resim/visualization/log/test_helpers_test.cc
+++ b/resim/visualization/log/test_helpers_test.cc
@@ -1,0 +1,57 @@
+
+#include "resim/visualization/log/test_helpers.hh"
+
+#include <gtest/gtest.h>
+
+#include <mcap/reader.hpp>
+#include <variant>
+
+#include "resim/experiences/experience.hh"
+#include "resim/experiences/proto/experience.pb.h"
+#include "resim/geometry/wireframe.hh"
+#include "resim/utils/mcap_logger.hh"
+#include "resim/utils/uuid.hh"
+
+namespace resim::visualization::log {
+
+TEST(TestHelpersTest, TestExperience) {
+  // SETUP / ACTION
+  const experiences::Experience experience{test_experience()};
+
+  // VERIFICATION
+  ASSERT_EQ(experience.dynamic_behavior.actors.size(), 1U);
+  ASSERT_EQ(experience.dynamic_behavior.actors.front().geometries.size(), 1U);
+
+  const UUID geometry_id{experience.dynamic_behavior.actors.front()
+                             .geometries.front()
+                             .geometry_id};
+  EXPECT_TRUE(experience.geometries.contains(geometry_id));
+  EXPECT_EQ(experience.geometries.at(geometry_id).id, geometry_id);
+  EXPECT_TRUE(std::holds_alternative<geometry::Wireframe>(
+      experience.geometries.at(geometry_id).model));
+}
+
+TEST(TestHelpersTest, TestStreamReader) {
+  // SETUP
+  std::ostringstream sstream;
+  std::istringstream input_log{
+      make_input_log(experiences::proto::Experience())};
+
+  // ACTION
+  StreamReader stream_reader{input_log};
+  mcap::McapReader reader;
+  ASSERT_TRUE(reader.open(stream_reader).ok());
+  ASSERT_TRUE(reader.readSummary(mcap::ReadSummaryMethod::NoFallbackScan).ok());
+  ASSERT_EQ(reader.channels().size(), 1U);
+  EXPECT_EQ(reader.channels().cbegin()->second->topic, "/experience");
+}
+
+// This is mainly here for coverage purproses. Primary test is that the reader
+// works with the mcap::McapReader above.
+TEST(TestHelpersTest, TestOffsetGreaterThanSize) {
+  std::stringstream sstream{""};
+  StreamReader stream_reader{sstream};
+  EXPECT_EQ(stream_reader.read(nullptr, 1, 0), 0);
+}
+
+}  // namespace resim::visualization::log

--- a/resim/visualization/log/visit_topic.cc
+++ b/resim/visualization/log/visit_topic.cc
@@ -1,0 +1,26 @@
+
+#include "resim/visualization/log/visit_topic.hh"
+
+#include "resim/assert/assert.hh"
+#include "resim/utils/inout.hh"
+
+namespace resim::visualization::log {
+
+void visit_topic(
+    const std::string_view topic,
+    InOut<mcap::McapReader> reader,
+    const std::function<void(const mcap::MessageView &)> &visitor) {
+  mcap::ReadMessageOptions read_options;
+  read_options.topicFilter = [&topic](const std::string_view t) {
+    return t == topic;
+  };
+  const mcap::ProblemCallback on_problem = [](const mcap::Status &s) {
+    REASSERT(false, "MCAP Read Error: " + s.message);
+  };
+  for (const mcap::MessageView &view :
+       reader->readMessages(on_problem, read_options)) {
+    visitor(view);
+  }
+}
+
+}  // namespace resim::visualization::log

--- a/resim/visualization/log/visit_topic.hh
+++ b/resim/visualization/log/visit_topic.hh
@@ -1,0 +1,23 @@
+
+#pragma once
+
+#include <functional>
+#include <mcap/reader.hpp>
+#include <string_view>
+
+#include "resim/utils/inout.hh"
+
+namespace resim::visualization::log {
+
+// A simple function which calls the given visitor on all messages (represented
+// by mcap::MessageViews) matching the specified topic in the given log reader.
+// @param[in] topic - The topic we want to read from.
+// @param[in] reader - The reader to read from. Passed as an inout because
+//                     reading is non-const.
+// @param[in] visitor - The visitor to call on each message.
+void visit_topic(
+    std::string_view topic,
+    InOut<mcap::McapReader> reader,
+    const std::function<void(const mcap::MessageView &)> &visitor);
+
+}  // namespace resim::visualization::log

--- a/resim/visualization/log/visit_topic_test.cc
+++ b/resim/visualization/log/visit_topic_test.cc
@@ -1,0 +1,60 @@
+
+#include "resim/visualization/log/visit_topic.hh"
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <mcap/reader.hpp>
+#include <sstream>
+
+#include "resim/assert/assert.hh"
+#include "resim/experiences/proto/experience_to_proto.hh"
+#include "resim/visualization/log/test_helpers.hh"
+
+namespace resim::visualization::log {
+
+TEST(VisitTopicTest, TestVisitTopic) {
+  // SETUP
+  experiences::proto::Experience experience_msg;
+  pack(test_experience(), &experience_msg);
+
+  std::istringstream input_log{make_input_log(experience_msg)};
+
+  mcap::McapReader reader;
+  StreamReader readable{input_log};
+  EXPECT_TRUE(reader.open(readable).ok());
+
+  // ACTION
+  int exp_count = 0;
+  visit_topic("/experience", InOut{reader}, [&](const mcap::MessageView& view) {
+    ++exp_count;
+
+    // VERIFICATION
+    EXPECT_EQ(
+        view.schema->name,
+        experiences::proto::Experience::GetDescriptor()->full_name());
+    EXPECT_EQ(view.channel->topic, "/experience");
+
+    const std::string expected{experience_msg.SerializeAsString()};
+    ASSERT_EQ(view.message.dataSize, expected.size());
+    EXPECT_EQ(
+        std::memcmp(view.message.data, expected.data(), expected.size()),
+        0);
+  });
+  EXPECT_EQ(exp_count, 1);
+}
+
+TEST(VisitTopicTest, TestFailOnNoOpen) {
+  // SETUP
+  mcap::McapReader reader;
+
+  // ACTION / VERIFICATION
+  EXPECT_THROW(
+      visit_topic(
+          "/some_topic",
+          InOut{reader},
+          [&](const mcap::MessageView& view) {}),
+      AssertException);
+}
+
+}  // namespace resim::visualization::log

--- a/resim/visualization/log/visualize_actor_states.cc
+++ b/resim/visualization/log/visualize_actor_states.cc
@@ -1,0 +1,176 @@
+
+#include "resim/visualization/log/visualize_actor_states.hh"
+
+#include <fmt/core.h>
+#include <foxglove/FrameTransform.pb.h>
+#include <foxglove/SceneEntityDeletion.pb.h>
+#include <foxglove/SceneUpdate.pb.h>
+
+#include <string>
+#include <vector>
+
+#include "resim/actor/actor_id.hh"
+#include "resim/actor/state/observable_state.hh"
+#include "resim/actor/state/proto/observable_state.pb.h"
+#include "resim/actor/state/proto/observable_state_to_proto.hh"
+#include "resim/assert/assert.hh"
+#include "resim/experiences/geometry.hh"
+#include "resim/simulator/standard_frames.hh"
+#include "resim/time/proto/time_to_proto.hh"
+#include "resim/transforms/se3.hh"
+#include "resim/utils/inout.hh"
+#include "resim/utils/match.hh"
+#include "resim/visualization/foxglove/frame_transform_to_foxglove.hh"
+#include "resim/visualization/foxglove/wireframe_to_foxglove.hh"
+#include "resim/visualization/log/visit_topic.hh"
+
+namespace resim::visualization::log {
+
+// Helper to get the right topic name for each actor's FrameTransform.
+std::string get_transform_name(const transforms::SE3 &ref_from_body) {
+  REASSERT(
+      ref_from_body.into() == simulator::SCENE_FRAME,
+      "Actors must be relative to scene frame!");
+  return fmt::format(
+      "/transforms/{}_from_{}",
+      simulator::SCENE_FRAME_NAME,
+      ref_from_body.from().id().to_string());
+}
+
+// Helper which logs frame transforms for all of the given actor states.
+void log_frame_transforms(
+    const std::vector<actor::state::ObservableState> &actor_states,
+    InOut<McapLogger> logger) {
+  for (const auto &actor_state : actor_states) {
+    if (not actor_state.is_spawned) {
+      continue;
+    }
+    const transforms::SE3 &scene_from_actor{actor_state.state.ref_from_body()};
+
+    ::foxglove::FrameTransform frame_transform;
+    foxglove::pack_into_foxglove(
+        scene_from_actor,
+        actor_state.time_of_validity,
+        &frame_transform,
+        std::string(simulator::SCENE_FRAME_NAME),
+        scene_from_actor.from().id().to_string());
+
+    const std::string topic_name{get_transform_name(scene_from_actor)};
+    // This is a no-op if already added:
+    logger->add_proto_channel<::foxglove::FrameTransform>(topic_name);
+    logger->log_proto(
+        topic_name,
+        actor_state.time_of_validity,
+        frame_transform);
+  }
+}
+
+// Helper which logs each actor's geometry once it spawns and a deletion for it
+// when it despawns.
+// @param[in] actor_states - The actor states. Used to find spawning and
+//                           despawning events.
+// @param[in] actor_geometries - The actor geometries, extracted from the
+//                               Experience config and provided by the caller
+//                               in a map.
+// @param[in] log_time - The time to log the geometries at.
+// @param[inout] logger - The logger to write the geometries to.
+// @param[inout] visible_actors - A set containing the ids of the
+//                                currently-visible actors. Used to track which
+//                                actors have spawned but haven't had their
+//                                geometries published yet and which have
+//                                despawned but haven't had their deletion
+//                                published yet.
+void log_geometries(
+    const std::vector<actor::state::ObservableState> &actor_states,
+    const std::unordered_map<actor::ActorId, experiences::Geometry>
+        &actor_geometries,
+    const time::Timestamp log_time,
+    InOut<McapLogger> logger,
+    InOut<std::unordered_set<actor::ActorId>> visible_actors) {
+  ::foxglove::SceneUpdate scene_update;
+  for (const auto &actor_state : actor_states) {
+    const transforms::SE3 &scene_from_actor{actor_state.state.ref_from_body()};
+
+    const actor::ActorId &id{actor_state.id};
+    const std::string frame_id{scene_from_actor.from().id().to_string()};
+
+    if (not actor_geometries.contains(id)) {
+      continue;
+    }
+
+    // Spawning
+    // TODO(michael) Potentially do this on some slow cadence also so that
+    // geometries don't disappear when playing back.
+    if (actor_state.is_spawned and not visible_actors->contains(id)) {
+      visible_actors->emplace(id);
+      const experiences::Geometry &geometry{actor_geometries.at(id)};
+
+      auto &entity = *scene_update.add_entities();
+
+      time::proto::pack(
+          actor_state.time_of_validity,
+          entity.mutable_timestamp());
+      entity.set_frame_id(frame_id);
+      entity.set_id(id.to_string());
+      constexpr bool DEFAULT_FRAME_LOCKED = true;
+      entity.set_frame_locked(DEFAULT_FRAME_LOCKED);
+
+      match(geometry.model, [&](const geometry::Wireframe &wireframe) {
+        foxglove::pack_into_foxglove(wireframe, entity.add_lines());
+      });
+      // Despawning
+    } else if (not actor_state.is_spawned and visible_actors->contains(id)) {
+      visible_actors->erase(id);
+
+      auto &deletion = *scene_update.add_deletions();
+      time::proto::pack(
+          actor_state.time_of_validity,
+          deletion.mutable_timestamp());
+      deletion.set_type(::foxglove::SceneEntityDeletion::MATCHING_ID);
+      deletion.set_id(id.to_string());
+    }
+  }
+  logger->add_proto_channel<::foxglove::SceneUpdate>("/geometries");
+  logger->log_proto("/geometries", log_time, scene_update);
+}
+
+void visualize_actor_states(
+    const experiences::Experience &experience,
+    InOut<mcap::McapReader> reader,
+    InOut<McapLogger> logger) {
+  std::unordered_set<actor::ActorId> visible_actors;
+
+  std::unordered_map<actor::ActorId, experiences::Geometry> actor_geometries;
+
+  for (const auto &actor : experience.dynamic_behavior.actors) {
+    for (const auto &geometry_ref : actor.geometries) {
+      REASSERT(
+          experience.geometries.contains(geometry_ref.geometry_id),
+          "Geometry not found for actor!");
+      REASSERT(
+          actor_geometries
+              .emplace(
+                  actor.id,
+                  experience.geometries.at(geometry_ref.geometry_id))
+              .second,
+          "Duplicate geometry for actor!");
+    }
+  }
+
+  visit_topic("/actor_states", reader, [&](const mcap::MessageView &view) {
+    actor::state::proto::ObservableStates states_msg;
+    REASSERT(
+        states_msg.ParseFromArray(view.message.data, view.message.dataSize));
+    std::vector<actor::state::ObservableState> states{unpack(states_msg)};
+
+    log_frame_transforms(states, logger);
+    log_geometries(
+        states,
+        actor_geometries,
+        time::Timestamp{time::Duration{view.message.logTime}},
+        InOut{logger},
+        InOut{visible_actors});
+  });
+}
+
+}  // namespace resim::visualization::log

--- a/resim/visualization/log/visualize_actor_states.hh
+++ b/resim/visualization/log/visualize_actor_states.hh
@@ -1,0 +1,28 @@
+
+#pragma once
+
+#include <mcap/reader.hpp>
+
+#include "resim/experiences/experience.hh"
+#include "resim/utils/inout.hh"
+#include "resim/utils/mcap_logger.hh"
+
+namespace resim::visualization::log {
+
+// This function is responsible for reading the actor states from the given
+// input log (reader) and creating appropriate ::foxglove::FrameTransform and
+// ::foxglove::SceneUpdates on the "/transforms/scene_from_<actor_frame_id>/"
+// topics for the former and the "/geometries" topic for the latter. More
+// simply, this function puts content in the mcap such that Foxglove studio
+// will display frames for each actor and actor geometries (where specified) in
+// those frames.
+// @param[in] experience - The experience to get the geometries from.
+// @param[in] reader - The log to read actors from.
+// @param[out] logger - The logger to log ::foxglove::FrameTransforms and
+//                      ::foxglove::SceneUpdates too.
+void visualize_actor_states(
+    const experiences::Experience &experience,
+    InOut<mcap::McapReader> reader,
+    InOut<McapLogger> logger);
+
+}  // namespace resim::visualization::log

--- a/resim/visualization/log/visualize_actor_states_test.cc
+++ b/resim/visualization/log/visualize_actor_states_test.cc
@@ -1,0 +1,356 @@
+
+#include "resim/visualization/log/visualize_actor_states.hh"
+
+#include <fmt/core.h>
+#include <foxglove/FrameTransform.pb.h>
+#include <foxglove/SceneUpdate.pb.h>
+#include <google/protobuf/util/message_differencer.h>
+#include <gtest/gtest.h>
+
+#include <mcap/reader.hpp>
+#include <sstream>
+#include <string>
+#include <variant>
+#include <vector>
+
+#include "resim/actor/state/observable_state.hh"
+#include "resim/actor/state/proto/observable_state.pb.h"
+#include "resim/actor/state/proto/observable_state_to_proto.hh"
+#include "resim/actor/state/rigid_body_state.hh"
+#include "resim/assert/assert.hh"
+#include "resim/curves/two_jet.hh"
+#include "resim/curves/two_jet_test_helpers.hh"
+#include "resim/experiences/experience.hh"
+#include "resim/experiences/proto/experience.pb.h"
+#include "resim/experiences/proto/experience_to_proto.hh"
+#include "resim/experiences/proto/experiences_test_helpers.hh"
+#include "resim/geometry/wireframe.hh"
+#include "resim/simulator/standard_frames.hh"
+#include "resim/time/proto/time_to_proto.hh"
+#include "resim/time/timestamp.hh"
+#include "resim/transforms/frame.hh"
+#include "resim/transforms/se3.hh"
+#include "resim/transforms/so3.hh"
+#include "resim/utils/mcap_logger.hh"
+#include "resim/visualization/foxglove/frame_transform_to_foxglove.hh"
+#include "resim/visualization/foxglove/wireframe_to_foxglove.hh"
+#include "resim/visualization/log/test_helpers.hh"
+#include "resim/visualization/log/visit_topic.hh"
+
+namespace resim::visualization::log {
+
+namespace {
+
+constexpr time::Timestamp PRE_SPAWN_TIME{time::as_duration(0.)};
+constexpr time::Timestamp SPAWN_TIME{time::as_duration(1.)};
+constexpr time::Timestamp ACTIVE_TIME{time::as_duration(2.)};
+constexpr time::Timestamp DESPAWN_TIME{time::as_duration(3.)};
+constexpr time::Timestamp AFTER_DESPAWN_TIME{time::as_duration(4.)};
+
+const experiences::Experience experience{test_experience()};
+
+std::vector<actor::state::ObservableState> make_actor_states() {
+  curves::TwoJetTestHelper<curves::TwoJetR<transforms::SE3>> two_jet_helper;
+  REASSERT(
+      experience.dynamic_behavior.actors.size() == 1U,
+      "The test experience should only have one actor!");
+  auto actor_id = experience.dynamic_behavior.actors.front().id;
+
+  const auto random_rigid_body_state = [&]() {
+    actor::state::RigidBodyState<transforms::SE3> result{
+        two_jet_helper.make_test_two_jet()};
+
+    auto ref_from_body = result.ref_from_body();
+    ref_from_body.set_frames(
+        simulator::SCENE_FRAME,
+        transforms::Frame<transforms::SE3::DIMS>(actor_id));
+    result.set_ref_from_body(ref_from_body);
+
+    return result;
+  };
+
+  return {
+      actor::state::ObservableState{
+          .id = actor_id,
+          .is_spawned = false,
+          .time_of_validity = PRE_SPAWN_TIME,
+          .state = random_rigid_body_state(),
+      },
+      actor::state::ObservableState{
+          .id = actor_id,
+          .is_spawned = true,
+          .time_of_validity = SPAWN_TIME,
+          .state = random_rigid_body_state(),
+      },
+      actor::state::ObservableState{
+          .id = actor_id,
+          .is_spawned = true,
+          .time_of_validity = ACTIVE_TIME,
+          .state = random_rigid_body_state(),
+      },
+      actor::state::ObservableState{
+          .id = actor_id,
+          .is_spawned = false,
+          .time_of_validity = DESPAWN_TIME,
+          .state = random_rigid_body_state(),
+      },
+      actor::state::ObservableState{
+          .id = actor_id,
+          .is_spawned = false,
+          .time_of_validity = AFTER_DESPAWN_TIME,
+          .state = random_rigid_body_state(),
+      },
+  };
+}
+const auto actor_states{make_actor_states()};
+
+std::string make_input_log_with_actor_states() {
+  experiences::proto::Experience experience_msg;
+  pack(experience, &experience_msg);
+
+  std::ostringstream sstream;
+  // Scope so that the logger flushes to the string stream when it's destroyed.
+  {
+    McapLogger logger{sstream};
+
+    // Add the experience
+    logger.add_proto_channel<experiences::proto::Experience>("/experience");
+    constexpr time::Timestamp TIME;
+    logger.log_proto("/experience", TIME, experience_msg);
+
+    // Add some actor states
+    logger.add_proto_channel<actor::state::proto::ObservableStates>(
+        "/actor_states");
+
+    const auto log_actor_state =
+        [&](const actor::state::ObservableState& state) {
+          std::vector<actor::state::ObservableState> states = {state};
+          actor::state::proto::ObservableStates states_msg;
+          pack(states, &states_msg);
+          logger.log_proto("/actor_states", state.time_of_validity, states_msg);
+        };
+
+    for (const auto& actor_state : actor_states) {
+      log_actor_state(actor_state);
+    }
+  }
+  return sstream.str();
+}
+
+void validate_geometry_updates(
+    const std::vector<::foxglove::SceneUpdate>& geometry_updates) {
+  ASSERT_EQ(geometry_updates.size(), actor_states.size());
+
+  // Before Spawning
+  {
+    EXPECT_EQ(geometry_updates.at(0).entities_size(), 0);
+    EXPECT_EQ(geometry_updates.at(0).deletions_size(), 0);
+  }
+  // Spawning
+  {
+    ASSERT_EQ(geometry_updates.at(1).entities_size(), 1);
+    EXPECT_EQ(geometry_updates.at(2).deletions_size(), 0);
+    const auto& entity = geometry_updates.at(1).entities(0);
+    EXPECT_EQ(time::proto::unpack(entity.timestamp()), SPAWN_TIME);
+    EXPECT_EQ(
+        entity.frame_id(),
+        actor_states.at(1).state.ref_from_body().from().id().to_string());
+    EXPECT_EQ(entity.id(), actor_states.at(1).id.to_string());
+
+    ASSERT_EQ(experience.geometries.size(), 1U);
+    const auto& geometry = experience.geometries.cbegin()->second.model;
+    ASSERT_TRUE(std::holds_alternative<geometry::Wireframe>(geometry));
+
+    ::foxglove::LinePrimitive expected_primitive;
+    foxglove::pack_into_foxglove(
+        std::get<geometry::Wireframe>(geometry),
+        &expected_primitive);
+    ASSERT_EQ(entity.lines_size(), 1U);
+    EXPECT_TRUE(::google::protobuf::util::MessageDifferencer::Equals(
+        expected_primitive,
+        entity.lines(0)));
+  }
+  // Active
+  {
+    EXPECT_EQ(geometry_updates.at(2).entities_size(), 0);
+    EXPECT_EQ(geometry_updates.at(2).deletions_size(), 0);
+  }
+  // Despawn
+  {
+    EXPECT_EQ(geometry_updates.at(3).entities_size(), 0);
+    ASSERT_EQ(geometry_updates.at(3).deletions_size(), 1);
+    const auto& deletion = geometry_updates.at(3).deletions(0);
+    EXPECT_EQ(time::proto::unpack(deletion.timestamp()), DESPAWN_TIME);
+    EXPECT_EQ(deletion.type(), ::foxglove::SceneEntityDeletion::MATCHING_ID);
+    EXPECT_EQ(deletion.id(), actor_states.at(3).id.to_string());
+  }
+  // After Despawn
+  {
+    EXPECT_EQ(geometry_updates.at(4).entities_size(), 0);
+    EXPECT_EQ(geometry_updates.at(4).deletions_size(), 0);
+  }
+}
+
+void validate_frame_transforms(
+    const std::vector<::foxglove::FrameTransform>& frame_transforms) {
+  int spawned_state_idx = 0;
+  for (const auto& state : actor_states) {
+    if (state.is_spawned) {
+      ASSERT_LT(spawned_state_idx, frame_transforms.size());
+
+      const transforms::SE3& scene_from_actor{state.state.ref_from_body()};
+
+      const ::foxglove::FrameTransform& transform =
+          frame_transforms.at(spawned_state_idx);
+      const transforms::SE3 packed_scene_from_actor{
+          transforms::SO3{Eigen::Quaterniond{
+              transform.rotation().w(),
+              transform.rotation().x(),
+              transform.rotation().y(),
+              transform.rotation().z()}},
+          {transform.translation().x(),
+           transform.translation().y(),
+           transform.translation().z()}};
+
+      EXPECT_EQ(transform.parent_frame_id(), simulator::SCENE_FRAME_NAME);
+      EXPECT_EQ(
+          transform.child_frame_id(),
+          scene_from_actor.from().id().to_string());
+
+      EXPECT_TRUE(
+          packed_scene_from_actor.is_approx_transform(scene_from_actor));
+
+      ++spawned_state_idx;
+    }
+  }
+  EXPECT_EQ(spawned_state_idx, frame_transforms.size());
+}
+
+}  // namespace
+
+TEST(VisualizeActorStatesTest, TestVisualizeActorStates) {
+  // SETUP
+  std::istringstream input_log{make_input_log_with_actor_states()};
+
+  mcap::McapReader reader;
+  StreamReader readable{input_log};
+  EXPECT_TRUE(reader.open(readable).ok());
+
+  std::ostringstream out_log_stream;
+  {
+    McapLogger logger{out_log_stream};
+
+    // ACTION
+    visualize_actor_states(experience, InOut{reader}, InOut{logger});
+  }
+
+  // VERIFICATION
+  std::stringstream output_log{out_log_stream.str()};
+  mcap::McapReader output_reader;
+  StreamReader out_readable{output_log};
+  EXPECT_TRUE(output_reader.open(out_readable).ok());
+
+  std::vector<::foxglove::SceneUpdate> geometry_updates;
+  visit_topic(
+      "/geometries",
+      InOut{output_reader},
+      [&](const mcap::MessageView& view) {
+        ASSERT_EQ(
+            view.schema->name,
+            ::foxglove::SceneUpdate::GetDescriptor()->full_name());
+        ::foxglove::SceneUpdate update;
+        ASSERT_TRUE(
+            update.ParseFromArray(view.message.data, view.message.dataSize));
+        geometry_updates.push_back(update);
+      });
+  validate_geometry_updates(geometry_updates);
+
+  std::vector<::foxglove::FrameTransform> frame_transforms;
+  auto actor_id = experience.dynamic_behavior.actors.front().id;
+  const std::string frame_transform_topic = fmt::format(
+      "/transforms/{}_from_{}",
+      simulator::SCENE_FRAME_NAME,
+      actor_id.to_string());
+
+  visit_topic(
+      frame_transform_topic,
+      InOut{output_reader},
+      [&](const mcap::MessageView& view) {
+        ASSERT_EQ(
+            view.schema->name,
+            ::foxglove::FrameTransform::GetDescriptor()->full_name());
+        ::foxglove::FrameTransform transform;
+        ASSERT_TRUE(
+            transform.ParseFromArray(view.message.data, view.message.dataSize));
+        frame_transforms.push_back(transform);
+      });
+  validate_frame_transforms(frame_transforms);
+}
+
+TEST(VisualizeActorStatesTest, TestVisualizeActorStatesNoGeometry) {
+  // SETUP
+  std::istringstream input_log{make_input_log_with_actor_states()};
+
+  mcap::McapReader reader;
+  StreamReader readable{input_log};
+  EXPECT_TRUE(reader.open(readable).ok());
+
+  auto experience_without_geometry = experience;
+  experience_without_geometry.dynamic_behavior.actors.front()
+      .geometries.clear();
+
+  std::ostringstream out_log_stream;
+  {
+    McapLogger logger{out_log_stream};
+
+    // ACTION
+    visualize_actor_states(
+        experience_without_geometry,
+        InOut{reader},
+        InOut{logger});
+  }
+
+  // VERIFICATION
+  std::stringstream output_log{out_log_stream.str()};
+  mcap::McapReader output_reader;
+  StreamReader out_readable{output_log};
+  EXPECT_TRUE(output_reader.open(out_readable).ok());
+
+  visit_topic(
+      "/geometries",
+      InOut{output_reader},
+      [&](const mcap::MessageView& view) {
+        ASSERT_EQ(
+            view.schema->name,
+            ::foxglove::SceneUpdate::GetDescriptor()->full_name());
+        ::foxglove::SceneUpdate update;
+        ASSERT_TRUE(
+            update.ParseFromArray(view.message.data, view.message.dataSize));
+
+        EXPECT_EQ(update.entities_size(), 0U);
+        EXPECT_EQ(update.deletions_size(), 0U);
+      });
+
+  std::vector<::foxglove::FrameTransform> frame_transforms;
+  auto actor_id = experience.dynamic_behavior.actors.front().id;
+  const std::string frame_transform_topic = fmt::format(
+      "/transforms/{}_from_{}",
+      simulator::SCENE_FRAME_NAME,
+      actor_id.to_string());
+
+  visit_topic(
+      frame_transform_topic,
+      InOut{output_reader},
+      [&](const mcap::MessageView& view) {
+        ASSERT_EQ(
+            view.schema->name,
+            ::foxglove::FrameTransform::GetDescriptor()->full_name());
+        ::foxglove::FrameTransform transform;
+        ASSERT_TRUE(
+            transform.ParseFromArray(view.message.data, view.message.dataSize));
+        frame_transforms.push_back(transform);
+      });
+  validate_frame_transforms(frame_transforms);
+}
+
+}  // namespace resim::visualization::log


### PR DESCRIPTION
## Description of change
Add log visualization tools to open-core.

## Guide to reproduce test results.
```bash
bazel test //resim/visualization/log/...
```
## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
