### PR TITLE
Add proto bindings for experience

### DIFF
--- a/resim/experiences/proto/BUILD
+++ b/resim/experiences/proto/BUILD
@@ -6,6 +6,7 @@
 
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_proto_library", "cc_test")
 load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_python//python:proto.bzl", "py_proto_library")
 
 proto_library(
     name = "revision_proto",
@@ -117,6 +118,12 @@ proto_library(
 
 cc_proto_library(
     name = "experience_proto_cc",
+    visibility = ["//visibility:public"],
+    deps = [":experience_proto"],
+)
+
+py_proto_library(
+    name = "experience_proto_py",
     visibility = ["//visibility:public"],
     deps = [":experience_proto"],
 )


### PR DESCRIPTION
## Description of change
Add proto bindings for experiences so they can be read in metrics runners.

## Guide to reproduce test results.
```bash
bazel build //resim/experiences/proto:experience_proto_py
```
## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
