### PR TITLE
Image and Plotly Metrics

### DIFF
--- a/resim/metrics/proto/BUILD
+++ b/resim/metrics/proto/BUILD
@@ -60,6 +60,7 @@ proto_library(
     visibility = ["//visibility:public"],
     deps = [
         "//resim/utils/proto:uuid_proto",
+        "@com_google_protobuf//:struct_proto",
         "@com_google_protobuf//:timestamp_proto",
     ],
 )

--- a/resim/metrics/proto/generate_test_metrics.py
+++ b/resim/metrics/proto/generate_test_metrics.py
@@ -19,6 +19,7 @@ in tests only, and not in production code.
 import uuid
 from typing import Any
 
+from google.protobuf.struct_pb2 import Struct
 import resim.metrics.proto.metrics_pb2 as mp
 
 
@@ -679,7 +680,40 @@ def _add_scalar_metric(job_metrics: mp.JobMetrics) -> None:
     metric.order = 12.0
     metric.job_id.CopyFrom(job_metrics.job_id)
     metric.metric_values.scalar_metric_values.value = 6.28318530718
+ 
+def _add_plotly_metric(job_metrics: mp.JobMetrics) -> None:
+    metric = job_metrics.job_level_metrics.metrics.add()
+    metric.metric_id.id.data = _get_uuid_str()
+    metric.name = "A plotly chart"
+    metric.type = mp.PLOTLY_METRIC_TYPE
+    metric.description = "The most plotly of plotly charts"
+    metric.status = mp.NOT_APPLICABLE_METRIC_STATUS
+    metric.should_display = True
+    metric.blocking = False
+    metric.importance = mp.ZERO_IMPORTANCE
+    metric.order = 12.0
+    metric.job_id.CopyFrom(job_metrics.job_id)
+    metric.metric_values.plotly_metric_values.json.CopyFrom(Struct())
 
+def _add_image_metric(job_metrics: mp.JobMetrics) -> None:
+    metric = job_metrics.job_level_metrics.metrics.add()
+    metric.metric_id.id.data = _get_uuid_str()
+    metric.name = "A photo of a tree"
+    metric.type = mp.IMAGE_METRIC_TYPE
+    metric.description = ("Actual photo of a real-world tree")
+    metric.status = mp.PASSED_METRIC_STATUS
+    metric.should_display = True
+    metric.blocking = False
+    metric.importance = mp.LOW_IMPORTANCE
+    metric.order = 1.2
+    metric.job_id.CopyFrom(job_metrics.job_id)
+    metrics_data = job_metrics.metrics_data.add()
+    metrics_data.metrics_data_id.id.data = _get_uuid_str()
+    metrics_data.data_type = mp.EXTERNAL_FILE_DATA_TYPE
+    metrics_data.name = "The image name"
+    metrics_data.external_file.path ="my_tree.gif"
+    image_metric_values = metric.metric_values.image_metric_values
+    image_metric_values.image_data_id.CopyFrom(metrics_data.metrics_data_id)
 
 def _populate_metrics_statuses(job_metrics: mp.JobMetrics) -> None:
     collection = job_metrics.job_level_metrics
@@ -714,7 +748,8 @@ def generate_test_metrics(block_fail: bool=False) -> mp.JobMetrics:
     _add_scalar_metric(job_metrics)
     _add_subsystem_states(job_metrics)
     _add_string_and_uuid_summary_metrics(job_metrics)
-
+    _add_plotly_metric(job_metrics)
+    _add_image_metric(job_metrics)
     _populate_metrics_statuses(job_metrics)
 
     return job_metrics

--- a/resim/metrics/proto/generate_test_metrics.py
+++ b/resim/metrics/proto/generate_test_metrics.py
@@ -686,7 +686,7 @@ def _add_plotly_metric(job_metrics: mp.JobMetrics) -> None:
     metric.metric_id.id.data = _get_uuid_str()
     metric.name = "A plotly chart"
     metric.type = mp.PLOTLY_METRIC_TYPE
-    metric.description = "The most plotly of plotly charts"
+    metric.description = "The plotliest of plotly charts"
     metric.status = mp.NOT_APPLICABLE_METRIC_STATUS
     metric.should_display = True
     metric.blocking = False

--- a/resim/metrics/proto/generate_test_metrics.py
+++ b/resim/metrics/proto/generate_test_metrics.py
@@ -680,7 +680,7 @@ def _add_scalar_metric(job_metrics: mp.JobMetrics) -> None:
     metric.order = 12.0
     metric.job_id.CopyFrom(job_metrics.job_id)
     metric.metric_values.scalar_metric_values.value = 6.28318530718
- 
+
 def _add_plotly_metric(job_metrics: mp.JobMetrics) -> None:
     metric = job_metrics.job_level_metrics.metrics.add()
     metric.metric_id.id.data = _get_uuid_str()
@@ -700,7 +700,7 @@ def _add_image_metric(job_metrics: mp.JobMetrics) -> None:
     metric.metric_id.id.data = _get_uuid_str()
     metric.name = "A photo of a tree"
     metric.type = mp.IMAGE_METRIC_TYPE
-    metric.description = ("Actual photo of a real-world tree")
+    metric.description = "Actual photo of a real-world tree"
     metric.status = mp.PASSED_METRIC_STATUS
     metric.should_display = True
     metric.blocking = False

--- a/resim/metrics/proto/metrics.proto
+++ b/resim/metrics/proto/metrics.proto
@@ -6,6 +6,7 @@
 
 syntax = "proto3";
 
+import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 import "resim/utils/proto/uuid.proto";
 
@@ -31,6 +32,10 @@ enum MetricsDataType {
     INDEXED_UUID_SERIES_DATA_TYPE          = 8;
     INDEXED_STRING_SERIES_DATA_TYPE        = 9;
     INDEXED_METRIC_STATUS_SERIES_DATA_TYPE = 10;
+
+    // External Files are a special type of metrics
+    // data, which are most often not reused.
+    EXTERNAL_FILE_DATA_TYPE = 11;
 }
 
 message MetricsDataId {
@@ -87,6 +92,12 @@ message SeriesPerCategory {
     map<string, Series> category_to_series = 1;
 }
 
+// This Metrics Data enables the passing through of an external file to a ReSim
+// metrics card. The path is expected to be relative to the metrics.binproto
+message ExternalFile {
+    string path = 1;
+}
+
 message MetricsData {
     // Generic metrics data fields
     MetricsDataId   metrics_data_id = 1;
@@ -107,6 +118,7 @@ message MetricsData {
     oneof data {
         Series            series              = 10;
         SeriesPerCategory series_per_category = 11;
+        ExternalFile      external_file       = 12;
     }
 }
 
@@ -141,6 +153,8 @@ enum MetricType {
     STATES_OVER_TIME_METRIC_TYPE = 5;
     HISTOGRAM_METRIC_TYPE        = 6;
     SCALAR_METRIC_TYPE           = 7;
+    PLOTLY_METRIC_TYPE           = 8;
+    IMAGE_METRIC_TYPE            = 9;
 }
 
 message MetricId {
@@ -221,6 +235,8 @@ message MetricValues {
         StatesOverTimeMetricValues states_over_time_metric_values = 5;
         HistogramMetricValues      histogram_metric_values        = 6;
         ScalarMetricValues         scalar_metric_values           = 7;
+        PlotlyMetricValues         plotly_metric_values           = 8;
+        ImageMetricValues          image_metric_values            = 9;
     }
 }
 
@@ -330,4 +346,12 @@ message ScalarMetricValues {
 
     optional string unit =
         3;  // Unit is stored in metric here, as no data series are used.
+}
+
+message PlotlyMetricValues {
+    google.protobuf.Struct json = 1;
+}
+
+message ImageMetricValues {
+    MetricsDataId image_data_id = 1;
 }

--- a/resim/metrics/proto/validate_metrics_proto.py
+++ b/resim/metrics/proto/validate_metrics_proto.py
@@ -441,7 +441,7 @@ def _validate_image_metric_values(
     print("yay debug!")
     print(value_data.data_type)
     _metrics_assert(value_data.data_type == mp.EXTERNAL_FILE_DATA_TYPE)
-    
+
 def _validate_metric_values(
         metric_values: mp.MetricValues,
         metrics_data_map: dict[str, mp.MetricsData]) -> None:

--- a/resim/metrics/proto/validate_metrics_proto.py
+++ b/resim/metrics/proto/validate_metrics_proto.py
@@ -476,7 +476,7 @@ def _validate_metric_values(
     elif metric_values.HasField("plotly_metric_values"):
         _validate_plotly_metric_values(
             metric_values.plotly_metric_values)
-    else: # mp.ImageMetricType
+    else: # metric_values.HasField("image_metric_values")
         _validate_image_metric_values(
             metric_values.image_metric_values, metrics_data_map)
 

--- a/resim/metrics/proto/validate_metrics_proto.py
+++ b/resim/metrics/proto/validate_metrics_proto.py
@@ -408,11 +408,40 @@ def _validate_scalar_metric_values(
     Check that a ScalarMetricValues is valid.
 
     Args:
-        histogram_metric_values: The metric values to check.
+        scalar_metric_values: The metric values to check.
     """
     _metrics_assert(scalar_metric_values.HasField('value'))
 
+def _validate_plotly_metric_values(
+        plotly_metric_values: mp.PlotlyMetricValues) -> None:
+    """
+    Check that a PlotlyMetricValues is valid.
 
+    Args:
+        plotly_metric_values: The metric values to check.
+    """
+    _metrics_assert(plotly_metric_values.HasField('json'))
+
+def _validate_image_metric_values(
+        image_metric_values: mp.ImageMetricValues,
+        metrics_data_map: dict[str, mp.MetricsData]) -> None:
+    """
+    Check that an ImageMetricValues is valid.
+
+    Args:
+        image_metric_values: The metric values to check.
+        metrics_data_map: A map to find the metrics data in.
+    """
+    _metrics_assert(image_metric_values.HasField('image_data_id'))
+    image_data_id = image_metric_values.image_data_id
+    _validate_metrics_data_id(image_data_id)
+    id_str = image_data_id.id.data
+    _metrics_assert(id_str in metrics_data_map)
+    value_data = metrics_data_map[id_str]
+    print("yay debug!")
+    print(value_data.data_type)
+    _metrics_assert(value_data.data_type == mp.EXTERNAL_FILE_DATA_TYPE)
+    
 def _validate_metric_values(
         metric_values: mp.MetricValues,
         metrics_data_map: dict[str, mp.MetricsData]) -> None:
@@ -443,9 +472,15 @@ def _validate_metric_values(
     elif metric_values.HasField("histogram_metric_values"):
         _validate_histogram_metric_values(
             metric_values.histogram_metric_values, metrics_data_map)
-    else:  # metric_values.HasField("scalar_metric_values")
+    elif metric_values.HasField("scalar_metric_values"):
         _validate_scalar_metric_values(
             metric_values.scalar_metric_values)
+    elif metric_values.HasField("plotly_metric_values"):
+        _validate_plotly_metric_values(
+            metric_values.plotly_metric_values)
+    else: # mp.ImageMetricType
+        _validate_image_metric_values(
+            metric_values.image_metric_values, metrics_data_map)
 
 
 def _validate_metric(metric: mp.Metric,
@@ -486,8 +521,12 @@ def _validate_metric(metric: mp.Metric,
     elif metric.type == mp.HISTOGRAM_METRIC_TYPE:
         _metrics_assert(metric.metric_values.HasField(
             'histogram_metric_values'))
-    else:  # metric.type == mp.SCALAR_METRIC_TYPE:
+    elif metric.type == mp.SCALAR_METRIC_TYPE:
         _metrics_assert(metric.metric_values.HasField('scalar_metric_values'))
+    elif metric.type == mp.PLOTLY_METRIC_TYPE:
+        _metrics_assert(metric.metric_values.HasField('plotly_metric_values'))
+    else:  # mp.IMAGE_METRIC_TYPE
+        _metrics_assert(metric.metric_values.HasField('image_metric_values'))
 
 
 def _validate_job_level_metrics(
@@ -543,7 +582,10 @@ def _validate_metrics_data(
     _validate_metrics_data_id(metrics_data.metrics_data_id)
     _validate_metrics_data_type(metrics_data.data_type)
 
-    if metrics_data.is_per_category:
+    if metrics_data.data_type == mp.EXTERNAL_FILE_DATA_TYPE:
+        _metrics_assert(metrics_data.HasField('external_file'))
+        _metrics_assert(len(metrics_data.external_file.path) > 0)
+    elif metrics_data.is_per_category:
         _metrics_assert(metrics_data.HasField('series_per_category'))
         for _, series in metrics_data.series_per_category.category_to_series.items():
             _metrics_assert(_series_length(series) > 0)

--- a/resim/metrics/proto/validate_metrics_proto.py
+++ b/resim/metrics/proto/validate_metrics_proto.py
@@ -438,8 +438,6 @@ def _validate_image_metric_values(
     id_str = image_data_id.id.data
     _metrics_assert(id_str in metrics_data_map)
     value_data = metrics_data_map[id_str]
-    print("yay debug!")
-    print(value_data.data_type)
     _metrics_assert(value_data.data_type == mp.EXTERNAL_FILE_DATA_TYPE)
 
 def _validate_metric_values(

--- a/resim/metrics/python/BUILD
+++ b/resim/metrics/python/BUILD
@@ -50,6 +50,7 @@ py_test(
         ":metrics_writer",
         "//resim/metrics/proto:metrics_proto_py",
         "//resim/utils/proto:uuid_proto_py",
+        "@com_google_protobuf//:protobuf_python",
     ],
 )
 
@@ -94,5 +95,6 @@ py_test(
         "//resim/metrics/proto:generate_test_metrics",
         "//resim/metrics/proto:metrics_proto_py",
         "//resim/metrics/proto:validate_metrics_proto",
+        "@com_google_protobuf//:protobuf_python",
     ],
 )

--- a/resim/metrics/python/BUILD
+++ b/resim/metrics/python/BUILD
@@ -24,6 +24,7 @@ py_test(
         ":metrics",
         ":metrics_utils",
         "//resim/metrics/proto:metrics_proto_py",
+        "@com_google_protobuf//:protobuf_python",
     ],
 )
 

--- a/resim/metrics/python/metrics.py
+++ b/resim/metrics/python/metrics.py
@@ -1593,14 +1593,13 @@ class ExternalFileMetricsData(BaseMetricsData['ExternalFileMetricsData']):
         msg = metrics_pb2.MetricsData()
         msg.metrics_data_id.id.CopyFrom(pack_uuid_to_proto(self.id))
         msg.name = self.name
-
+        msg.data_type = metrics_pb2.EXTERNAL_FILE_DATA_TYPE
         msg.is_per_category = False
 
         assert len(self.filename) > 0, "Cannot pack an empty string."
 
         external_file = metrics_pb2.ExternalFile()
         external_file.path = self.filename
-        #this copy from wont world, i don't think
         msg.external_file.CopyFrom(external_file)
 
         return msg

--- a/resim/metrics/python/metrics.py
+++ b/resim/metrics/python/metrics.py
@@ -1171,7 +1171,7 @@ class PlotlyMetric(Metric['PlotlyMetric']):
 
         if self.plotly_data is not None:
             metric_values.json = self.plotly_data
-            
+
         return msg
 
     def recursively_pack_into(
@@ -1256,7 +1256,7 @@ class BaseMetricsData(ABC, Generic[MetricsDataT]):
     id: uuid.UUID
     name: str
     unit: Optional[str]
-    
+
     @abstractmethod
     def __init__(self: MetricsDataT,
                  name: str,
@@ -1265,7 +1265,7 @@ class BaseMetricsData(ABC, Generic[MetricsDataT]):
         self.id = uuid.uuid4()
         self.name = name
         self.unit = unit
-        
+
     def __eq__(self, __value: object) -> bool:
         if not isinstance(__value, type(self)):
             return False
@@ -1274,11 +1274,11 @@ class BaseMetricsData(ABC, Generic[MetricsDataT]):
                 __value.id is not None), "Cannot compare values without valid ids"
 
         return self.id == __value.id
-    
+
     def with_unit(self: MetricsDataT, unit: str) -> MetricsDataT:
         self.unit = unit
         return self
-    
+
     @abstractmethod
     def pack(self: MetricsDataT) -> metrics_pb2.MetricsData:
         raise NotImplementedError()
@@ -1293,11 +1293,11 @@ class BaseMetricsData(ABC, Generic[MetricsDataT]):
         output = self.pack()
 
         metrics_output.metrics_msg.metrics_data.extend([output])
-    
+
 @metric_dataclass
 class MetricsData(BaseMetricsData, Generic[MetricsDataT]):
     index_data: Optional[MetricsDataT]
-    
+
     def __init__(self: MetricsDataT,
                  name: str,
                  unit: Optional[str] = None,
@@ -1580,14 +1580,13 @@ class GroupedMetricsData(MetricsData['GroupedMetricsData']):
 
 @metric_dataclass
 class ExternalFileMetricsData(BaseMetricsData['ExternalFileMetricsData']):
-    filename: str 
+    filename: str
 
     def __init__(self: ExternalFileMetricsData,
                  name: str,
                  filename: Optional[str] = None,
-                 unit: Optional[str] = None,
-                 index_data: Optional[ExternalFileMetricsData] = None):
-        super().__init__(name=name, unit=unit, index_data=index_data)
+                 unit: Optional[str] = None):
+        super().__init__(name=name, unit=unit)
         self.filename = filename
 
     def with_filename(self: ExternalFileMetricsData,
@@ -1606,7 +1605,7 @@ class ExternalFileMetricsData(BaseMetricsData['ExternalFileMetricsData']):
 
         assert len(self.filename) > 0, "Cannot pack an empty string."
 
-        external_file = metrics_pb2.ExternalFile() 
+        external_file = metrics_pb2.ExternalFile()
         external_file.path = self.filename
         msg.external_file.CopyFrom(external_file)
 

--- a/resim/metrics/python/metrics.py
+++ b/resim/metrics/python/metrics.py
@@ -1186,7 +1186,7 @@ class PlotlyMetric(Metric['PlotlyMetric']):
 
 @metric_dataclass
 class ImageMetric(Metric['ImageMetric']):
-    image_data: Optional[MetricsData]
+    image_data: Optional[ExternalFileMetricsData]
 
     def __init__(self: ImageMetric,
                  name: str,
@@ -1197,7 +1197,7 @@ class ImageMetric(Metric['ImageMetric']):
                  should_display: Optional[bool] = None,
                  parent_job_id: Optional[uuid.UUID] = None,
                  order: Optional[float] = None,
-                 image_data: Optional[MetricsData] = None,
+                 image_data: Optional[ExternalFileMetricsData] = None,
                  ):
         super().__init__(
             name=name,
@@ -1212,8 +1212,8 @@ class ImageMetric(Metric['ImageMetric']):
         self.image_data = image_data
 
     def with_image_data(self: ImageMetric,
-                        image_data: MetricsData) -> ImageMetric:
-        self.image_data.CopyFrom(image_data)
+                        image_data: ExternalFileMetricsData) -> ImageMetric:
+        self.image_data = image_data
         return self
 
     def pack(self: ImageMetric) -> metrics_pb2.Metric:
@@ -1593,15 +1593,14 @@ class ExternalFileMetricsData(BaseMetricsData['ExternalFileMetricsData']):
         msg = metrics_pb2.MetricsData()
         msg.metrics_data_id.id.CopyFrom(pack_uuid_to_proto(self.id))
         msg.name = self.name
-        msg.unit = None
 
         msg.is_per_category = False
-        msg.is_indexed = None
 
         assert len(self.filename) > 0, "Cannot pack an empty string."
 
         external_file = metrics_pb2.ExternalFile()
         external_file.path = self.filename
+        #this copy from wont world, i don't think
         msg.external_file.CopyFrom(external_file)
 
         return msg

--- a/resim/metrics/python/metrics.py
+++ b/resim/metrics/python/metrics.py
@@ -21,6 +21,7 @@ from typing import Any, Callable, Dict, Generic, List, Optional, Set, TypeAlias,
 
 import numpy as np
 
+from google.protobuf.struct_pb2 import Struct
 from resim.metrics.proto import metrics_pb2
 from resim.metrics.python.metrics_utils import (
     ResimMetricsOutput,
@@ -164,6 +165,10 @@ class Metric(ABC, Generic[MetricT]):
             unpacked = HistogramMetric(name=msg.name)
         elif msg.type == metrics_pb2.MetricType.Value('SCALAR_METRIC_TYPE'):
             unpacked = ScalarMetric(name=msg.name)
+        elif msg.type == metrics_pb2.MetricType.Value('PLOTLY_METRIC_TYPE'):
+            unpacked = PlotlyMetric(name=msg.name)
+        elif msg.type == metrics_pb2.MetricType.Value('IMAGE_METRIC_TYPE'):
+            unpacked = ImageMetric(name=msg.name)
         else:
             raise ValueError('Invalid metric type')
 
@@ -1126,6 +1131,119 @@ class DoubleSummaryMetric(Metric['DoubleSummaryMetric']):
         if self.status_data is not None:
             self.status_data.recursively_pack_into(metrics_output)
 
+@metric_dataclass
+class PlotlyMetric(Metric['PlotlyMetric']):
+    plotly_data: Optional[Struct]
+
+    def __init__(self: PlotlyMetric,
+                 name: str,
+                 description: Optional[str] = None,
+                 status: Optional[MetricStatus] = None,
+                 importance: Optional[MetricImportance] = None,
+                 blocking: Optional[bool] = None,
+                 should_display: Optional[bool] = None,
+                 parent_job_id: Optional[uuid.UUID] = None,
+                 order: Optional[float] = None,
+                 plotly_data: Optional[Struct] = None,
+                 ):
+        super().__init__(
+            name=name,
+            description=description,
+            status=status,
+            importance=importance,
+            blocking=blocking,
+            should_display=should_display,
+            parent_job_id=parent_job_id,
+            order=order)
+
+        self.plotly_data = plotly_data
+
+    def with_plotly_data(self: PlotlyMetric,
+                        plotly_data: Struct) -> PlotlyMetric:
+        self.plotly_data = plotly_data
+        return self
+
+    def pack(self: PlotlyMetric) -> metrics_pb2.Metric:
+        msg = super().pack()
+        msg.type = metrics_pb2.MetricType.Value('PLOTLY_METRIC_TYPE')
+
+        metric_values = msg.metric_values.plotly_metric_values
+
+        if self.plotly_data is not None:
+            metric_values.json = self.plotly_data
+            
+        return msg
+
+    def recursively_pack_into(
+            self: PlotlyMetric,
+            metrics_output: ResimMetricsOutput) -> None:
+        if self.id in metrics_output.packed_ids:
+            return
+        metrics_output.packed_ids.add(self.id)
+
+        metrics_output.metrics_msg.job_level_metrics.metrics.extend([
+                                                                    self.pack()])
+
+        if self.plotly_data is not None:
+            self.plotly_data.recursively_pack_into(metrics_output)
+
+@metric_dataclass
+class ImageMetric(Metric['ImageMetric']):
+    image_data: Optional[MetricsData]
+
+    def __init__(self: ImageMetric,
+                 name: str,
+                 description: Optional[str] = None,
+                 status: Optional[MetricStatus] = None,
+                 importance: Optional[MetricImportance] = None,
+                 blocking: Optional[bool] = None,
+                 should_display: Optional[bool] = None,
+                 parent_job_id: Optional[uuid.UUID] = None,
+                 order: Optional[float] = None,
+                 image_data: Optional[MetricsData] = None,
+                 ):
+        super().__init__(
+            name=name,
+            description=description,
+            status=status,
+            importance=importance,
+            blocking=blocking,
+            should_display=should_display,
+            parent_job_id=parent_job_id,
+            order=order)
+
+        self.image_data = image_data
+
+    def with_image_data(self: ImageMetric,
+                        image_data: MetricsData) -> ImageMetric:
+        self.image_data = image_data
+        return self
+
+    def pack(self: ImageMetric) -> metrics_pb2.Metric:
+        msg = super().pack()
+        msg.type = metrics_pb2.MetricType.Value('IMAGE_METRIC_TYPE')
+
+        metric_values = msg.metric_values.image_metric_values
+
+        if self.image_data is not None:
+            metric_values.image_data_id.id.CopyFrom(
+                pack_uuid_to_proto(self.image_data.id))
+
+        return msg
+
+    def recursively_pack_into(
+            self: ImageMetric,
+            metrics_output: ResimMetricsOutput) -> None:
+        if self.id in metrics_output.packed_ids:
+            return
+        metrics_output.packed_ids.add(self.id)
+
+        metrics_output.metrics_msg.job_level_metrics.metrics.extend([
+                                                                    self.pack()])
+
+        if self.image_data is not None:
+            self.image_data.recursively_pack_into(metrics_output)
+
 # -------------------
 # Data representation
 # -------------------
@@ -1438,5 +1556,45 @@ class GroupedMetricsData(MetricsData['GroupedMetricsData']):
 
     def recursively_pack_into(
             self: GroupedMetricsData,
+            metrics_output: ResimMetricsOutput) -> None:
+        super().recursively_pack_into(metrics_output)
+
+
+@metric_dataclass
+class ExternalFileMetricsData(MetricsData['ExternalFileMetricsData']):
+    filename: str 
+
+    def __init__(self: ExternalFileMetricsData,
+                 name: str,
+                 filename: Optional[str] = None,
+                 unit: Optional[str] = None,
+                 index_data: Optional[ExternalFileMetricsData] = None):
+        super().__init__(name=name, unit=unit, index_data=index_data)
+        self.filename = filename
+
+    def with_filename(self: ExternalFileMetricsData,
+                    filename: str) -> ExternalFileMetricsData:
+        self.filename = filename
+        return self
+
+    def pack(self: ExternalFileMetricsData) -> metrics_pb2.MetricsData:
+        msg = metrics_pb2.MetricsData()
+        msg.metrics_data_id.id.CopyFrom(pack_uuid_to_proto(self.id))
+        msg.name = self.name
+        msg.unit = None
+
+        msg.is_per_category = False
+        msg.is_indexed = None
+
+        assert len(self.filename) > 0, "Cannot pack an empty string."
+
+        external_file = metrics_pb2.ExternalFile() 
+        external_file.path = self.filename
+        msg.external_file.CopyFrom(external_file)
+
+        return msg
+
+    def recursively_pack_into(
+            self: ExternalFileMetricsData,
             metrics_output: ResimMetricsOutput) -> None:
         super().recursively_pack_into(metrics_output)

--- a/resim/metrics/python/metrics.py
+++ b/resim/metrics/python/metrics.py
@@ -1255,16 +1255,13 @@ MetricsDataT = TypeVar('MetricsDataT', bound='MetricsData')
 class BaseMetricsData(ABC, Generic[MetricsDataT]):
     id: uuid.UUID
     name: str
-    unit: Optional[str]
 
     @abstractmethod
     def __init__(self: MetricsDataT,
-                 name: str,
-                 unit: Optional[str] = None):
+                 name: str):
         assert name is not None
         self.id = uuid.uuid4()
         self.name = name
-        self.unit = unit
 
     def __eq__(self, __value: object) -> bool:
         if not isinstance(__value, type(self)):
@@ -1274,10 +1271,6 @@ class BaseMetricsData(ABC, Generic[MetricsDataT]):
                 __value.id is not None), "Cannot compare values without valid ids"
 
         return self.id == __value.id
-
-    def with_unit(self: MetricsDataT, unit: str) -> MetricsDataT:
-        self.unit = unit
-        return self
 
     @abstractmethod
     def pack(self: MetricsDataT) -> metrics_pb2.MetricsData:
@@ -1296,14 +1289,20 @@ class BaseMetricsData(ABC, Generic[MetricsDataT]):
 
 @metric_dataclass
 class MetricsData(BaseMetricsData, Generic[MetricsDataT]):
+    unit: Optional[str] = None
     index_data: Optional[MetricsDataT]
 
     def __init__(self: MetricsDataT,
                  name: str,
                  unit: Optional[str] = None,
                  index_data: Optional[MetricsDataT] = None):
-        super().__init__(name, unit)
+        super().__init__(name)
+        self.unit = unit
         self.index_data = index_data
+
+    def with_unit(self: MetricsDataT, unit: str) -> MetricsDataT:
+        self.unit = unit
+        return self
 
     def with_index_data(
             self: MetricsDataT,
@@ -1584,9 +1583,8 @@ class ExternalFileMetricsData(BaseMetricsData['ExternalFileMetricsData']):
 
     def __init__(self: ExternalFileMetricsData,
                  name: str,
-                 filename: Optional[str] = None,
-                 unit: Optional[str] = None):
-        super().__init__(name=name, unit=unit)
+                 filename: Optional[str] = None):
+        super().__init__(name=name)
         self.filename = filename
 
     def with_filename(self: ExternalFileMetricsData,

--- a/resim/metrics/python/metrics.py
+++ b/resim/metrics/python/metrics.py
@@ -1170,7 +1170,7 @@ class PlotlyMetric(Metric['PlotlyMetric']):
         metric_values = msg.metric_values.plotly_metric_values
 
         if self.plotly_data is not None:
-            metric_values.json = self.plotly_data
+            metric_values.json.CopyFrom(self.plotly_data)
 
         return msg
 
@@ -1183,9 +1183,6 @@ class PlotlyMetric(Metric['PlotlyMetric']):
 
         metrics_output.metrics_msg.job_level_metrics.metrics.extend([
                                                                     self.pack()])
-
-        if self.plotly_data is not None:
-            self.plotly_data.recursively_pack_into(metrics_output)
 
 @metric_dataclass
 class ImageMetric(Metric['ImageMetric']):
@@ -1216,7 +1213,7 @@ class ImageMetric(Metric['ImageMetric']):
 
     def with_image_data(self: ImageMetric,
                         image_data: MetricsData) -> ImageMetric:
-        self.image_data = image_data
+        self.image_data.CopyFrom(image_data)
         return self
 
     def pack(self: ImageMetric) -> metrics_pb2.Metric:

--- a/resim/metrics/python/metrics.py
+++ b/resim/metrics/python/metrics.py
@@ -1159,7 +1159,7 @@ class PlotlyMetric(Metric['PlotlyMetric']):
         self.plotly_data = plotly_data
 
     def with_plotly_data(self: PlotlyMetric,
-                        plotly_data: Struct) -> PlotlyMetric:
+                         plotly_data: Struct) -> PlotlyMetric:
         self.plotly_data = plotly_data
         return self
 

--- a/resim/metrics/python/metrics_test.py
+++ b/resim/metrics/python/metrics_test.py
@@ -334,7 +334,7 @@ class MetricsTest(unittest.TestCase):
         time_data = metrics.SeriesMetricsData(
             name="times",
             series=np.array([metrics_utils.Timestamp(secs=0, nanos=0),
-                             metrics_utils.Timestamp(secs=5, nanos=0)]),
+                                metrics_utils.Timestamp(secs=5, nanos=0)]),
             unit='m')
         value_data = metrics.SeriesMetricsData(
             name="values",
@@ -422,7 +422,7 @@ class MetricsTest(unittest.TestCase):
         self.assertEqual(len(output.metrics_msg.job_level_metrics.metrics), 1)
         self.assertEqual(len(output.metrics_msg.metrics_data), 3)
         ids = [uuid.UUID(data.metrics_data_id.id.data)
-               for data in output.metrics_msg.metrics_data]
+                for data in output.metrics_msg.metrics_data]
         self.assertIn(value_data.id, ids)
         self.assertIn(status_data.id, ids)
         self.assertIn(time_data.id, ids)
@@ -1259,117 +1259,117 @@ class MetricsTest(unittest.TestCase):
         self.assertEqual(len(output.metrics_msg.job_level_metrics.metrics), 2)
         self.assertEqual(len(output.metrics_msg.metrics_data), 2)
 
-def test_plotly_metric(self) -> None:
-    # CONSTRUCTION
-    job_id = uuid.uuid4()
-    metric = metrics.PlotlyMetric(
-        "test_metric",
-        "A metric for testing",
-        MetricStatus.PASSED_METRIC_STATUS,
-        MetricImportance.ZERO_IMPORTANCE,
-        should_display=True,
-        blocking=False,
-        parent_job_id=job_id,
-        order=None,
-        plotly_data=None,
-    )
+    def test_plotly_metric(self) -> None:
+        # CONSTRUCTION
+        job_id = uuid.uuid4()
+        metric = metrics.PlotlyMetric(
+            "test_metric",
+            "A metric for testing",
+            MetricStatus.PASSED_METRIC_STATUS,
+            MetricImportance.ZERO_IMPORTANCE,
+            should_display=True,
+            blocking=False,
+            parent_job_id=job_id,
+            order=None,
+            plotly_data=None,
+        )
 
-    # SETTING
-    test_data = Struct()
-    test_data["test"] = "test"
-    self.assertIs(metric, metric.with_plotly_data(test_data))
-    self.assertEqual(metric.plotly_data, test_data)
+        # SETTING
+        test_data = Struct()
+        test_data["test"] = "test"
+        self.assertIs(metric, metric.with_plotly_data(test_data))
+        self.assertEqual(metric.plotly_data, test_data)
 
-    # PACKING
-    msg = metric.pack()
-    self.assertEqual(msg.type, mp.MetricType.Value("PLOTLY_METRIC_TYPE"))
-    self.assertTrue(msg.metric_values.HasField('plotly_metric_values'))
-    values = msg.metric_values.plotly_metric_values
-    self.assertEqual(values.plotly_data, metric.plotly_data)
+        # PACKING
+        msg = metric.pack()
+        self.assertEqual(msg.type, mp.MetricType.Value("PLOTLY_METRIC_TYPE"))
+        self.assertTrue(msg.metric_values.HasField('plotly_metric_values'))
+        values = msg.metric_values.plotly_metric_values
+        self.assertEqual(values.plotly_data, metric.plotly_data)
 
-    output = metrics_utils.ResimMetricsOutput()
-    metric.recursively_pack_into(output)
-    self.assertIn(metric.id, output.packed_ids)
-    self.assertEqual(len(output.metrics_msg.job_level_metrics.metrics), 1)
-    self.assertEqual(output.metrics_msg.job_level_metrics.metrics[0], msg)
+        output = metrics_utils.ResimMetricsOutput()
+        metric.recursively_pack_into(output)
+        self.assertIn(metric.id, output.packed_ids)
+        self.assertEqual(len(output.metrics_msg.job_level_metrics.metrics), 1)
+        self.assertEqual(output.metrics_msg.job_level_metrics.metrics[0], msg)
 
-    # Check no duplication
-    metric.recursively_pack_into(output)
-    self.assertEqual(len(output.metrics_msg.job_level_metrics.metrics), 1)
+        # Check no duplication
+        metric.recursively_pack_into(output)
+        self.assertEqual(len(output.metrics_msg.job_level_metrics.metrics), 1)
 
-def test_image_metric(self) -> None:
-    job_id = uuid.uuid4()
+    def test_image_metric(self) -> None:
+        job_id = uuid.uuid4()
 
-    file_data = metrics.ExternalFileMetricsData(
-        name="an external image",
-        filename='test.gif')
+        file_data = metrics.ExternalFileMetricsData(
+            name="an external image",
+            filename='test.gif')
 
-    metric = metrics.ImageMetric(
-        name='test metric',
-        description='a test image metric',
-        status=MetricStatus.PASSED_METRIC_STATUS,
-        importance=MetricImportance.ZERO_IMPORTANCE,
-        blocking=False,
-        should_display=True,
-        parent_job_id=job_id,
-        order=0.5,
-    )
+        metric = metrics.ImageMetric(
+            name='test metric',
+            description='a test image metric',
+            status=MetricStatus.PASSED_METRIC_STATUS,
+            importance=MetricImportance.ZERO_IMPORTANCE,
+            blocking=False,
+            should_display=True,
+            parent_job_id=job_id,
+            order=0.5,
+        )
 
-    self.assertEqual(metric.image_data, None)
+        self.assertEqual(metric.image_data, None)
 
-    self.assertEqual(
-        metric, metric.with_image_data(
-            file_data))
+        self.assertEqual(
+            metric, metric.with_image_data(
+                file_data))
 
-def test_image_metric_pack(self) -> None:
-    job_id = uuid.uuid4()
+    def test_image_metric_pack(self) -> None:
+        job_id = uuid.uuid4()
 
-    image_data = metrics.ExternalFileMetricsData(
-        name="an external image",
-        filename='test.gif')
+        image_data = metrics.ExternalFileMetricsData(
+            name="an external image",
+            filename='test.gif')
 
-    # Use the constructor to initialize the data this time, in contrast with
-    # the above test.
-    metric = metrics.ImageMetric(
-        name='test metric',
-        description='a test image metric',
-        status=MetricStatus.PASSED_METRIC_STATUS,
-        importance=MetricImportance.ZERO_IMPORTANCE,
-        blocking=False,
-        should_display=True,
-        parent_job_id=job_id,
-        order=0.5,
-        image_data=image_data
-    )
+        # Use the constructor to initialize the data this time, in contrast with
+        # the above test.
+        metric = metrics.ImageMetric(
+            name='test metric',
+            description='a test image metric',
+            status=MetricStatus.PASSED_METRIC_STATUS,
+            importance=MetricImportance.ZERO_IMPORTANCE,
+            blocking=False,
+            should_display=True,
+            parent_job_id=job_id,
+            order=0.5,
+            image_data=image_data
+        )
 
-    msg = metric.pack()
+        msg = metric.pack()
 
-    self.assert_common_fields_match(msg=msg, metric=metric)
-    self.assertEqual(msg.type, mp.MetricType.Value(
-        "IMAGE_METRIC_TYPE"))
-    self.assertTrue(msg.metric_values.HasField(
-        "image_metric_values"))
-    values = msg.metric_values.image_metric_values
-    self.assertEqual(len(values.image_metric_values), 1)
-    self.assertEqual(
-        values.image_data_id[0].id,
-        metrics_utils.pack_uuid_to_proto(
-            image_data.id))
+        self.assert_common_fields_match(msg=msg, metric=metric)
+        self.assertEqual(msg.type, mp.MetricType.Value(
+            "IMAGE_METRIC_TYPE"))
+        self.assertTrue(msg.metric_values.HasField(
+            "image_metric_values"))
+        values = msg.metric_values.image_metric_values
+        self.assertEqual(len(values.image_metric_values), 1)
+        self.assertEqual(
+            values.image_data_id[0].id,
+            metrics_utils.pack_uuid_to_proto(
+                image_data.id))
 
-    output = metrics_utils.ResimMetricsOutput()
-    metric.recursively_pack_into(output)
-    self.assertIn(metric.id, output.packed_ids)
-    self.assertEqual(len(output.metrics_msg.job_level_metrics.metrics), 1)
-    self.assertEqual(len(output.metrics_msg.metrics_data), 1)
-    ids = [uuid.UUID(data.metrics_data_id.id.data)
-            for data in output.metrics_msg.metrics_data]
-    self.assertIn(image_data.id, ids)
-    self.assertEqual(output.metrics_msg.job_level_metrics.metrics[0], msg)
+        output = metrics_utils.ResimMetricsOutput()
+        metric.recursively_pack_into(output)
+        self.assertIn(metric.id, output.packed_ids)
+        self.assertEqual(len(output.metrics_msg.job_level_metrics.metrics), 1)
+        self.assertEqual(len(output.metrics_msg.metrics_data), 1)
+        ids = [uuid.UUID(data.metrics_data_id.id.data)
+                for data in output.metrics_msg.metrics_data]
+        self.assertIn(image_data.id, ids)
+        self.assertEqual(output.metrics_msg.job_level_metrics.metrics[0], msg)
 
-    # Check no duplication
-    metric.recursively_pack_into(output)
-    self.assertEqual(len(output.metrics_msg.job_level_metrics.metrics), 1)
-    self.assertEqual(len(output.metrics_msg.metrics_data), 1)
-
+        # Check no duplication
+        metric.recursively_pack_into(output)
+        self.assertEqual(len(output.metrics_msg.job_level_metrics.metrics), 1)
+        self.assertEqual(len(output.metrics_msg.metrics_data), 1)
+    
 if __name__ == "__main__":
     unittest.main()

--- a/resim/metrics/python/metrics_test.py
+++ b/resim/metrics/python/metrics_test.py
@@ -1296,6 +1296,6 @@ def test_plotly_metric(self) -> None:
     # Check no duplication
     metric.recursively_pack_into(output)
     self.assertEqual(len(output.metrics_msg.job_level_metrics.metrics), 1)
-    
+
 if __name__ == "__main__":
     unittest.main()

--- a/resim/metrics/python/metrics_test.py
+++ b/resim/metrics/python/metrics_test.py
@@ -1369,6 +1369,6 @@ class MetricsTest(unittest.TestCase):
         metric.recursively_pack_into(output)
         self.assertEqual(len(output.metrics_msg.job_level_metrics.metrics), 1)
         self.assertEqual(len(output.metrics_msg.metrics_data), 1)
-    
+
 if __name__ == "__main__":
     unittest.main()

--- a/resim/metrics/python/metrics_test.py
+++ b/resim/metrics/python/metrics_test.py
@@ -1285,7 +1285,7 @@ class MetricsTest(unittest.TestCase):
         self.assertEqual(msg.type, mp.MetricType.Value("PLOTLY_METRIC_TYPE"))
         self.assertTrue(msg.metric_values.HasField('plotly_metric_values'))
         values = msg.metric_values.plotly_metric_values
-        self.assertEqual(values.plotly_data, metric.plotly_data)
+        self.assertEqual(values.json, metric.plotly_data)
 
         output = metrics_utils.ResimMetricsOutput()
         metric.recursively_pack_into(output)
@@ -1350,9 +1350,8 @@ class MetricsTest(unittest.TestCase):
         self.assertTrue(msg.metric_values.HasField(
             "image_metric_values"))
         values = msg.metric_values.image_metric_values
-        self.assertEqual(len(values.image_metric_values), 1)
         self.assertEqual(
-            values.image_data_id[0].id,
+            values.image_data_id.id,
             metrics_utils.pack_uuid_to_proto(
                 image_data.id))
 

--- a/resim/metrics/python/metrics_test.py
+++ b/resim/metrics/python/metrics_test.py
@@ -170,8 +170,7 @@ class MetricsTest(unittest.TestCase):
             (mp.MetricType.Value('DOUBLE_SUMMARY_METRIC_TYPE'), metrics.DoubleSummaryMetric),
             (mp.MetricType.Value('SCALAR_METRIC_TYPE'), metrics.ScalarMetric),
             (mp.MetricType.Value('PLOTLY_METRIC_TYPE'), metrics.PlotlyMetric),
-            (mp.MetricType.Value('IMAGE_METRIC_TYPE'), metrics.ImageMetric),
-            (mp.MetricType.Value('VIDEO_METRIC_TYPE'), metrics.VideoMetric)]
+            (mp.MetricType.Value('IMAGE_METRIC_TYPE'), metrics.ImageMetric)]
 
         for metric_type, metric_class in metric_type_list:
             modified_msg = copy.copy(msg)
@@ -1260,463 +1259,43 @@ class MetricsTest(unittest.TestCase):
         self.assertEqual(len(output.metrics_msg.job_level_metrics.metrics), 2)
         self.assertEqual(len(output.metrics_msg.metrics_data), 2)
 
-    def test_plotly_metric(self) -> None:
+def test_plotly_metric(self) -> None:
+        # CONSTRUCTION
         job_id = uuid.uuid4()
-        value_data = metrics.SeriesMetricsData(
-            name="values",
-            series=np.array([0.5]),
-            unit='m')
-        status_data = metrics.SeriesMetricsData(
-            name="statuses",
-            series=np.array([MetricStatus.PASSED_METRIC_STATUS]),
-            unit='')
-        index = 0
-        failure_definition = metrics_utils.DoubleFailureDefinition(
-            fails_above=1.0,
-            fails_below=0.0,
-        )
-        metric = metrics.DoubleSummaryMetric(
-            name='test metric',
-            description='a test histogram metric',
-            status=MetricStatus.PASSED_METRIC_STATUS,
-            importance=MetricImportance.ZERO_IMPORTANCE,
-            blocking=False,
+        metric = metrics.PlotlyMetric(
+            "test_metric",
+            "A metric for testing",
+            MetricStatus.PASSED_METRIC_STATUS,
+            MetricImportance.ZERO_IMPORTANCE,
             should_display=True,
-            parent_job_id=job_id,
-            order=0.5,
-        )
-
-        self.assertIs(metric.value_data, None)
-        self.assertIs(metric.status_data, None)
-        self.assertIs(metric.index, None)
-        self.assertIs(metric.failure_definition, None)
-
-        self.assertEqual(
-            metric, metric.with_value_data(value_data))
-        self.assertEqual(metric.value_data, value_data)
-
-        self.assertEqual(
-            metric, metric.with_status_data(status_data))
-        self.assertEqual(metric.status_data, status_data)
-
-        self.assertEqual(
-            metric, metric.with_index(index))
-        self.assertEqual(metric.index, index)
-
-        self.assertEqual(
-            metric, metric.with_failure_definition(failure_definition))
-        self.assertEqual(metric.failure_definition, failure_definition)
-
-    def test_double_summary_metric_pack(self) -> None:
-        job_id = uuid.uuid4()
-        value_data = metrics.SeriesMetricsData(
-            name="values",
-            series=np.array([0.5]),
-            unit='m')
-        status_data = metrics.SeriesMetricsData(
-            name="statuses",
-            series=np.array([MetricStatus.PASSED_METRIC_STATUS]),
-            unit='')
-        index = 0
-        failure_definition = metrics_utils.DoubleFailureDefinition(
-            fails_above=1.0,
-            fails_below=0.0,
-        )
-        metric = metrics.DoubleSummaryMetric(
-            name='test metric',
-            description='a test histogram metric',
-            status=MetricStatus.PASSED_METRIC_STATUS,
-            importance=MetricImportance.ZERO_IMPORTANCE,
             blocking=False,
-            should_display=True,
             parent_job_id=job_id,
-            order=0.5,
-            value_data=value_data,
-            status_data=status_data,
-            index=index,
-            failure_definition=failure_definition,
+            order=None,
+            plotly_data=None,
         )
 
+        # SETTING
+        test_data = Struct()
+        test_data["test"] = "test"
+        self.assertIs(metric, metric.with_plotly_data(test_data))
+        self.assertEqual(metric.plotly_data, test_data)
+
+        # PACKING
         msg = metric.pack()
-
-        self.assert_common_fields_match(msg=msg, metric=metric)
-        self.assertEqual(msg.type, mp.MetricType.Value(
-            "DOUBLE_SUMMARY_METRIC_TYPE"))
-        self.assertTrue(msg.metric_values.HasField(
-            "double_metric_values"))
-        values = msg.metric_values.double_metric_values
-        self.assertEqual(values.value_data_id.id,
-                         metrics_utils.pack_uuid_to_proto(value_data.id))
-        self.assertEqual(values.status_data_id.id,
-                         metrics_utils.pack_uuid_to_proto(status_data.id))
-        self.assertTrue(values.HasField('series_index'))
-        self.assertEqual(values.series_index, metric.index)
-        assert metric.failure_definition is not None
-        self.assertEqual(
-            values.failure_definition,
-            metric.failure_definition.pack())
-
-        # Now set things to None:
-        def get_values(msg: Any) -> Any:
-            return msg.metric_values.double_metric_values
-
-        for attr in ('value_data', 'status_data'):
-            modified_metric = copy.copy(metric)
-            setattr(modified_metric, attr, None)
-            modified_msg = modified_metric.pack()
-            self.assertFalse(get_values(modified_msg).HasField(attr + "_id"))
-
-        modified_metric = copy.copy(metric)
-        modified_metric.index = None
-        modified_msg = modified_metric.pack()
-        self.assertIs(get_values(modified_msg).WhichOneof('index'), None)
-
-        modified_metric = copy.copy(metric)
-        modified_metric.index = 'string key'
-        modified_msg = modified_metric.pack()
-        self.assertEqual(get_values(modified_msg).string_index, 'string key')
-
-        uuid_key = uuid.uuid4()
-        modified_metric = copy.copy(metric)
-        modified_metric.index = uuid_key
-        modified_msg = modified_metric.pack()
-        self.assertEqual(
-            get_values(modified_msg).uuid_index,
-            metrics_utils.pack_uuid_to_proto(uuid_key))
-
-        time_key = metrics_utils.Timestamp(secs=1, nanos=3)
-        modified_metric = copy.copy(metric)
-        modified_metric.index = time_key
-        modified_msg = modified_metric.pack()
-        self.assertEqual(
-            get_values(modified_msg).timestamp_index,
-            time_key.pack())
-
-        bad_type_key = cast(None, metrics.SeriesMetricsData(name="whoops"))
-        modified_metric = copy.copy(metric)
-        modified_metric.index = bad_type_key
-        with self.assertRaises(ValueError):
-            modified_msg = modified_metric.pack()
-
-        modified_metric = copy.copy(metric)
-        modified_metric.failure_definition = None
-        modified_msg = modified_metric.pack()
-        self.assertFalse(
-            get_values(modified_msg).HasField('failure_definition'))
-
-    def test_double_summary_metric_recursive_pack(self) -> None:
-        job_id = uuid.uuid4()
-        value_data = metrics.SeriesMetricsData(
-            name="values",
-            series=np.array([0.5]),
-            unit='m')
-        status_data = metrics.SeriesMetricsData(
-            name="statuses",
-            series=np.array([MetricStatus.PASSED_METRIC_STATUS]),
-            unit='')
-        index = 0
-        failure_definition = metrics_utils.DoubleFailureDefinition(
-            fails_above=1.0,
-            fails_below=0.0,
-        )
-        metric = metrics.DoubleSummaryMetric(
-            name='test metric',
-            description='a test histogram metric',
-            status=MetricStatus.PASSED_METRIC_STATUS,
-            importance=MetricImportance.ZERO_IMPORTANCE,
-            blocking=False,
-            should_display=True,
-            parent_job_id=job_id,
-            order=0.5,
-            value_data=value_data,
-            status_data=status_data,
-            index=index,
-            failure_definition=failure_definition,
-        )
-        msg = metric.pack()
+        self.assertEqual(msg.type, mp.MetricType.Value("PLOTLY_METRIC_TYPE"))
+        self.assertTrue(msg.metric_values.HasField('plotly_metric_values'))
+        values = msg.metric_values.plotly_metric_values
+        self.assertEqual(values.plotly_data, metric.plotly_data)
 
         output = metrics_utils.ResimMetricsOutput()
         metric.recursively_pack_into(output)
         self.assertIn(metric.id, output.packed_ids)
         self.assertEqual(len(output.metrics_msg.job_level_metrics.metrics), 1)
-        self.assertEqual(len(output.metrics_msg.metrics_data), 2)
-        ids = [uuid.UUID(data.metrics_data_id.id.data)
-               for data in output.metrics_msg.metrics_data]
-        self.assertIn(value_data.id, ids)
-        self.assertIn(status_data.id, ids)
         self.assertEqual(output.metrics_msg.job_level_metrics.metrics[0], msg)
 
         # Check no duplication
         metric.recursively_pack_into(output)
         self.assertEqual(len(output.metrics_msg.job_level_metrics.metrics), 1)
-        self.assertEqual(len(output.metrics_msg.metrics_data), 2)
-
-        # Check empty series, mainly for test coverage
-        metric = metrics.DoubleSummaryMetric(name="some empty metric")
-        metric.recursively_pack_into(output)
-        self.assertEqual(len(output.metrics_msg.job_level_metrics.metrics), 2)
-        self.assertEqual(len(output.metrics_msg.metrics_data), 2)
         
-    def test_metrics_data(self) -> None:
-        index_data = metrics.SeriesMetricsData(
-            name="index data",
-            series=np.array([1., 2., 3.]),
-        )
-        metrics_data = metrics.SeriesMetricsData(
-            name="metrics data",
-            series=np.array([1., 2., 3.]),
-        )
-        unit = 'm'
-
-        self.assertEqual(metrics_data, metrics_data.with_unit(unit))
-        self.assertEqual(metrics_data.unit, unit)
-
-        self.assertEqual(
-            metrics_data,
-            metrics_data.with_index_data(index_data))
-        self.assertEqual(metrics_data.index_data, index_data)
-
-        self.assertEqual(metrics_data, metrics_data)
-        self.assertNotEqual(metrics_data, 4)
-        self.assertNotEqual(metrics_data, index_data)
-
-        with self.assertRaises(NotImplementedError):
-            metrics.MetricsData.map(metrics_data, lambda *_: _, '')
-        with self.assertRaises(NotImplementedError):
-            metrics.MetricsData.group_by(metrics_data, index_data)
-        with self.assertRaises(NotImplementedError):
-            metrics.MetricsData.pack(metrics_data)
-
-        output = metrics_utils.ResimMetricsOutput()
-        metrics_data.recursively_pack_into(output)
-        self.assertEqual(output.packed_ids, {index_data.id, metrics_data.id})
-        self.assertEqual({uuid.UUID(md.metrics_data_id.id.data)
-                         for md in output.metrics_msg.metrics_data},
-                         {index_data.id, metrics_data.id})
-        metrics_data.recursively_pack_into(output)
-        self.assertEqual(output.packed_ids, {index_data.id, metrics_data.id})
-        self.assertEqual({uuid.UUID(md.metrics_data_id.id.data)
-                         for md in output.metrics_msg.metrics_data},
-                         {index_data.id, metrics_data.id})
-
-    def test_series_metrics_data(self) -> None:
-        index_data = metrics.SeriesMetricsData(
-            name="index data",
-            series=np.array([1., 2., 3.]),
-        )
-        series = np.array([4., 5., 6.])
-        metrics_data = metrics.SeriesMetricsData(
-            name="metrics data",
-            unit='m',
-            index_data=index_data,
-        )
-        self.assertEqual(metrics_data, metrics_data.with_series(series))
-        self.assertTrue((metrics_data.series == series).all())
-
-        negated_metrics_data = metrics_data.map(lambda arr, i: -arr[i],
-                                                'negated metrics data',
-                                                'm')
-
-        for normal, negated in zip(metrics_data.series,
-                                   negated_metrics_data.series):
-            self.assertEqual(normal, -negated)
-
-        grouping_data = metrics.SeriesMetricsData(
-            name="grouping data",
-            series=np.array(["yes", "no", "yes"])
-        )
-
-        grouped_data = metrics_data.group_by(grouping_data,
-                                             'grouped data',
-                                             'grouped data index')
-
-        expected = {"yes": np.array([4., 6.]),
-                    "no": np.array([5.])}
-        expected_index = {"yes": np.array([1., 3.]),
-                          "no": np.array([2.])}
-
-        assert grouped_data is not None
-        assert grouped_data.index_data is not None
-        for key, val in expected.items():
-            self.assertTrue(
-                (val == grouped_data.category_to_series[key]).all())
-            self.assertTrue(
-                (expected_index[key] == grouped_data.index_data.category_to_series[key]).all())
-
-        self.assertEqual(grouped_data.name, 'grouped data')
-        self.assertEqual(grouped_data.index_data.name, 'grouped data index')
-
-        # Cover the override case:
-        regrouped_index = index_data.group_by(grouping_data,
-                                              'regrouped data',
-                                              'regrouped data index',
-                                              grouped_data.index_data)
-
-        for key, val in expected_index.items():
-            self.assertTrue(
-                (val == regrouped_index.category_to_series[key]).all())
-        self.assertEqual(regrouped_index.index_data, grouped_data.index_data)
-
-        assert regrouped_index is not None
-        assert regrouped_index.index_data is not None
-
-        self.assertEqual(regrouped_index.name, 'regrouped data')
-        self.assertEqual(regrouped_index.index_data.name, 'grouped data index')
-
-        # Check the auto naming:
-        autonamed_grouped_data = metrics_data.group_by(grouping_data)
-        assert autonamed_grouped_data is not None
-        assert autonamed_grouped_data.index_data is not None
-
-        self.assertEqual(
-            autonamed_grouped_data.name,
-            "metrics data-grouped-by-grouping data")
-        self.assertEqual(
-            autonamed_grouped_data.index_data.name,
-            "index data-grouped-by-grouping data")
-
-        autonamed_grouped_index = index_data.group_by(grouping_data)
-        assert autonamed_grouped_index is not None
-        assert autonamed_grouped_index.index_data is None
-
-        self.assertEqual(
-            autonamed_grouped_index.name,
-            "index data-grouped-by-grouping data")
-
-    def test_series_metrics_data_pack(self) -> None:
-        index_data = metrics.SeriesMetricsData(
-            name="index data",
-            series=np.array([1., 2., 3.]),
-        )
-        series = np.array([4., 5., 6.])
-        metrics_data = metrics.SeriesMetricsData(
-            name="metrics data",
-            series=series,
-            unit='m',
-            index_data=index_data,
-        )
-
-        msg = metrics_data.pack()
-        self.assertEqual(
-            msg.metrics_data_id.id,
-            metrics_utils.pack_uuid_to_proto(
-                metrics_data.id))
-        self.assertEqual(msg.data_type, mp.MetricsDataType.Value(
-            'INDEXED_DOUBLE_SERIES_DATA_TYPE'))
-
-        self.assertEqual(msg.name, metrics_data.name)
-        self.assertEqual(msg.unit, metrics_data.unit)
-        self.assertFalse(msg.is_per_category)
-        self.assertEqual(len(msg.category_names), 0)
-        self.assertTrue(msg.is_indexed)
-        self.assertEqual(
-            msg.index_data_id.id,
-            metrics_utils.pack_uuid_to_proto(
-                index_data.id))
-        self.assertEqual(
-            msg.index_data_type,
-            mp.MetricsDataType.Value('DOUBLE_SERIES_DATA_TYPE'))
-        for packed_val, val in zip(msg.series.doubles.series, series):
-            self.assertEqual(packed_val, val)
-
-    def test_grouped_metrics_data(self) -> None:
-        category_to_series = {"yes": np.array([4., 6.]),
-                              "no": np.array([5.])}
-
-        metrics_data = metrics.GroupedMetricsData(
-            name="grouped metrics data",
-            unit='m')
-
-        self.assertEqual(
-            metrics_data,
-            metrics_data.with_category_to_series(category_to_series))
-
-        # Check the case where the category_to_series is passed into the
-        # constructor
-        other_data = metrics.GroupedMetricsData(
-            name="other metrics data",
-            category_to_series=category_to_series,
-            unit="m",
-        )
-
-        for key, val in category_to_series.items():
-            self.assertTrue((other_data.category_to_series[key] == val).all())
-
-        negated_data = metrics_data.map(lambda arr, i, cat: -arr[i],
-                                        'negated data',
-                                        'm')
-
-        self.assertEqual(negated_data.name, 'negated data')
-        self.assertEqual(negated_data.unit, 'm')
-        for key, val in category_to_series.items():
-            self.assertTrue(
-                (negated_data.category_to_series[key] == -val).all())
-
-        with self.assertRaises(NotImplementedError):
-            metrics_data.group_by(metrics_data)
-
-        new_series = np.array([5.0, 6.0])
-        metrics_data.add_category('maybe', new_series)
-        self.assertIn('maybe', metrics_data.category_to_series)
-        self.assertTrue(
-            (metrics_data.category_to_series['maybe'] == new_series).all())
-
-    def test_grouped_metrics_data_pack(self) -> None:
-        index_category_to_series = {"yes": np.array([1., 2.]),
-                                    "no": np.array([3.])}
-        category_to_series = {"yes": np.array([4., 6.]),
-                              "no": np.array([5.])}
-
-        index_data = metrics.GroupedMetricsData(
-            name="index metrics data",
-            category_to_series=index_category_to_series,
-        )
-
-        metrics_data = metrics.GroupedMetricsData(
-            name="metrics data",
-            category_to_series=category_to_series,
-            unit='m',
-            index_data=index_data,
-        )
-
-        msg = metrics_data.pack()
-        self.assertEqual(
-            msg.metrics_data_id.id,
-            metrics_utils.pack_uuid_to_proto(
-                metrics_data.id))
-        self.assertEqual(msg.data_type, mp.MetricsDataType.Value(
-            'INDEXED_DOUBLE_SERIES_DATA_TYPE'))
-
-        self.assertEqual(msg.name, metrics_data.name)
-        self.assertEqual(msg.unit, metrics_data.unit)
-        self.assertTrue(msg.is_per_category)
-        self.assertEqual(set(msg.category_names), {"yes", "no"})
-        self.assertTrue(msg.is_indexed)
-        self.assertEqual(
-            msg.index_data_id.id,
-            metrics_utils.pack_uuid_to_proto(
-                index_data.id))
-        self.assertEqual(
-            msg.index_data_type,
-            mp.MetricsDataType.Value('DOUBLE_SERIES_DATA_TYPE'))
-
-        for key, packed_series in msg.series_per_category.category_to_series.items():
-            for packed_val, val in zip(
-                    packed_series.doubles.series, category_to_series[key]):
-                self.assertEqual(packed_val, val)
-
-        output = metrics_utils.ResimMetricsOutput()
-        metrics_data.recursively_pack_into(output)
-        self.assertEqual(output.packed_ids, {index_data.id, metrics_data.id})
-        self.assertEqual({uuid.UUID(md.metrics_data_id.id.data)
-                         for md in output.metrics_msg.metrics_data},
-                         {index_data.id, metrics_data.id})
-        metrics_data.recursively_pack_into(output)
-        self.assertEqual(output.packed_ids, {index_data.id, metrics_data.id})
-        self.assertEqual({uuid.UUID(md.metrics_data_id.id.data)
-                         for md in output.metrics_msg.metrics_data},
-                         {index_data.id, metrics_data.id})
-
-
 if __name__ == "__main__":
     unittest.main()

--- a/resim/metrics/python/metrics_test.py
+++ b/resim/metrics/python/metrics_test.py
@@ -1369,7 +1369,7 @@ def test_image_metric_pack(self) -> None:
     # Check no duplication
     metric.recursively_pack_into(output)
     self.assertEqual(len(output.metrics_msg.job_level_metrics.metrics), 1)
-    self.assertEqual(len(output.metrics_msg.metrics_data), )
+    self.assertEqual(len(output.metrics_msg.metrics_data), 1)
 
 if __name__ == "__main__":
     unittest.main()

--- a/resim/metrics/python/metrics_test.py
+++ b/resim/metrics/python/metrics_test.py
@@ -1629,7 +1629,7 @@ class MetricsTest(unittest.TestCase):
                          for md in output.metrics_msg.metrics_data},
                          {index_data.id, metrics_data.id})
 
-    def test_external_metrics_data(self) -> None:
+    def test_external_file_metrics_data(self) -> None:
         filename = "my_file.gif"
         metrics_data = metrics.ExternalFileMetricsData(
             name="file data",
@@ -1637,7 +1637,7 @@ class MetricsTest(unittest.TestCase):
         self.assertEqual(metrics_data, metrics_data.with_filename(filename))
         self.assertTrue(metrics_data.filename == filename)
 
-    def test_series_metrics_data_pack(self) -> None:
+    def test_external_file_metrics_data_pack(self) -> None:
         filename = "my_file.gif"
         metrics_data = metrics.ExternalFileMetricsData(
             name="metrics data",

--- a/resim/metrics/python/metrics_test.py
+++ b/resim/metrics/python/metrics_test.py
@@ -1629,6 +1629,32 @@ class MetricsTest(unittest.TestCase):
                          for md in output.metrics_msg.metrics_data},
                          {index_data.id, metrics_data.id})
 
+    def test_external_metrics_data(self) -> None:
+        filename = "my_file.gif"
+        metrics_data = metrics.ExternalFileMetricsData(
+            name="file data",
+        )
+        self.assertEqual(metrics_data, metrics_data.with_filename(filename))
+        self.assertTrue(metrics_data.filename == filename)
+
+    def test_series_metrics_data_pack(self) -> None:
+        filename = "my_file.gif"
+        metrics_data = metrics.ExternalFileMetricsData(
+            name="metrics data",
+            filename=filename,
+        )
+
+        msg = metrics_data.pack()
+        self.assertEqual(
+            msg.metrics_data_id.id,
+            metrics_utils.pack_uuid_to_proto(
+                metrics_data.id))
+        self.assertEqual(msg.data_type, mp.MetricsDataType.Value(
+            'EXTERNAL_FILE_DATA_TYPE'))
+
+        self.assertEqual(msg.name, metrics_data.name)
+        self.assertEqual(msg.external_file.path, filename)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/resim/metrics/python/metrics_test.py
+++ b/resim/metrics/python/metrics_test.py
@@ -333,7 +333,7 @@ class MetricsTest(unittest.TestCase):
         time_data = metrics.SeriesMetricsData(
             name="times",
             series=np.array([metrics_utils.Timestamp(secs=0, nanos=0),
-                                metrics_utils.Timestamp(secs=5, nanos=0)]),
+                             metrics_utils.Timestamp(secs=5, nanos=0)]),
             unit='m')
         value_data = metrics.SeriesMetricsData(
             name="values",
@@ -421,7 +421,7 @@ class MetricsTest(unittest.TestCase):
         self.assertEqual(len(output.metrics_msg.job_level_metrics.metrics), 1)
         self.assertEqual(len(output.metrics_msg.metrics_data), 3)
         ids = [uuid.UUID(data.metrics_data_id.id.data)
-                for data in output.metrics_msg.metrics_data]
+               for data in output.metrics_msg.metrics_data]
         self.assertIn(value_data.id, ids)
         self.assertIn(status_data.id, ids)
         self.assertIn(time_data.id, ids)
@@ -1628,6 +1628,7 @@ class MetricsTest(unittest.TestCase):
         self.assertEqual({uuid.UUID(md.metrics_data_id.id.data)
                          for md in output.metrics_msg.metrics_data},
                          {index_data.id, metrics_data.id})
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/resim/metrics/python/metrics_test.py
+++ b/resim/metrics/python/metrics_test.py
@@ -1260,42 +1260,42 @@ class MetricsTest(unittest.TestCase):
         self.assertEqual(len(output.metrics_msg.metrics_data), 2)
 
 def test_plotly_metric(self) -> None:
-        # CONSTRUCTION
-        job_id = uuid.uuid4()
-        metric = metrics.PlotlyMetric(
-            "test_metric",
-            "A metric for testing",
-            MetricStatus.PASSED_METRIC_STATUS,
-            MetricImportance.ZERO_IMPORTANCE,
-            should_display=True,
-            blocking=False,
-            parent_job_id=job_id,
-            order=None,
-            plotly_data=None,
-        )
+    # CONSTRUCTION
+    job_id = uuid.uuid4()
+    metric = metrics.PlotlyMetric(
+        "test_metric",
+        "A metric for testing",
+        MetricStatus.PASSED_METRIC_STATUS,
+        MetricImportance.ZERO_IMPORTANCE,
+        should_display=True,
+        blocking=False,
+        parent_job_id=job_id,
+        order=None,
+        plotly_data=None,
+    )
 
-        # SETTING
-        test_data = Struct()
-        test_data["test"] = "test"
-        self.assertIs(metric, metric.with_plotly_data(test_data))
-        self.assertEqual(metric.plotly_data, test_data)
+    # SETTING
+    test_data = Struct()
+    test_data["test"] = "test"
+    self.assertIs(metric, metric.with_plotly_data(test_data))
+    self.assertEqual(metric.plotly_data, test_data)
 
-        # PACKING
-        msg = metric.pack()
-        self.assertEqual(msg.type, mp.MetricType.Value("PLOTLY_METRIC_TYPE"))
-        self.assertTrue(msg.metric_values.HasField('plotly_metric_values'))
-        values = msg.metric_values.plotly_metric_values
-        self.assertEqual(values.plotly_data, metric.plotly_data)
+    # PACKING
+    msg = metric.pack()
+    self.assertEqual(msg.type, mp.MetricType.Value("PLOTLY_METRIC_TYPE"))
+    self.assertTrue(msg.metric_values.HasField('plotly_metric_values'))
+    values = msg.metric_values.plotly_metric_values
+    self.assertEqual(values.plotly_data, metric.plotly_data)
 
-        output = metrics_utils.ResimMetricsOutput()
-        metric.recursively_pack_into(output)
-        self.assertIn(metric.id, output.packed_ids)
-        self.assertEqual(len(output.metrics_msg.job_level_metrics.metrics), 1)
-        self.assertEqual(output.metrics_msg.job_level_metrics.metrics[0], msg)
+    output = metrics_utils.ResimMetricsOutput()
+    metric.recursively_pack_into(output)
+    self.assertIn(metric.id, output.packed_ids)
+    self.assertEqual(len(output.metrics_msg.job_level_metrics.metrics), 1)
+    self.assertEqual(output.metrics_msg.job_level_metrics.metrics[0], msg)
 
-        # Check no duplication
-        metric.recursively_pack_into(output)
-        self.assertEqual(len(output.metrics_msg.job_level_metrics.metrics), 1)
-        
+    # Check no duplication
+    metric.recursively_pack_into(output)
+    self.assertEqual(len(output.metrics_msg.job_level_metrics.metrics), 1)
+    
 if __name__ == "__main__":
     unittest.main()

--- a/resim/metrics/python/metrics_writer.py
+++ b/resim/metrics/python/metrics_writer.py
@@ -16,6 +16,9 @@ from resim.metrics.python.metrics import (
     ScalarMetric,
     BarChartMetric,
     LinePlotMetric,
+    PlotlyMetric,
+    ImageMetric,
+    VideoMetric,
     DoubleSummaryMetric,
     DoubleOverTimeMetric,
     HistogramMetric,
@@ -96,6 +99,21 @@ class ResimMetricsWriter:
 
     def add_double_summary_metric(self, name: str) -> DoubleSummaryMetric:
         metric = DoubleSummaryMetric(name=name, parent_job_id=self.job_id)
+        self.add_metric(metric)
+        return metric
+    
+    def add_plotly_metric(self, name: str) -> PlotlyMetric:
+        metric = PlotlyMetric(name=name, parent_job_id=self.job_id)
+        self.add_metric(metric)
+        return metric
+
+    def add_image_metric(self, name: str) -> ImageMetric:
+        metric = ImageMetric(name=name, parent_job_id=self.job_id)
+        self.add_metric(metric)
+        return metric
+
+    def add_video_metric(self, name: str) -> VideoMetric:
+        metric = VideoMetric(name=name, parent_job_id=self.job_id)
         self.add_metric(metric)
         return metric
 

--- a/resim/metrics/python/metrics_writer.py
+++ b/resim/metrics/python/metrics_writer.py
@@ -24,6 +24,7 @@ from resim.metrics.python.metrics import (
     StatesOverTimeMetric,
     GroupedMetricsData,
     SeriesMetricsData,
+    ExternalFileMetricsData,
     Metric,
     MetricsData,
     MetricsDataT,
@@ -110,6 +111,11 @@ class ResimMetricsWriter:
         metric = ImageMetric(name=name, parent_job_id=self.job_id)
         self.add_metric(metric)
         return metric
+
+    def add_external_file_metrics_data(self, name: str) -> ExternalFileMetricsData:
+        metrics_data = ExternalFileMetricsData(name=name)
+        self.add_metrics_data(metrics_data)
+        return metrics_data
 
     def write(self) -> ResimMetricsOutput:
         output = ResimMetricsOutput()

--- a/resim/metrics/python/metrics_writer.py
+++ b/resim/metrics/python/metrics_writer.py
@@ -100,7 +100,7 @@ class ResimMetricsWriter:
         metric = DoubleSummaryMetric(name=name, parent_job_id=self.job_id)
         self.add_metric(metric)
         return metric
-    
+
     def add_plotly_metric(self, name: str) -> PlotlyMetric:
         metric = PlotlyMetric(name=name, parent_job_id=self.job_id)
         self.add_metric(metric)

--- a/resim/metrics/python/metrics_writer.py
+++ b/resim/metrics/python/metrics_writer.py
@@ -18,7 +18,6 @@ from resim.metrics.python.metrics import (
     LinePlotMetric,
     PlotlyMetric,
     ImageMetric,
-    VideoMetric,
     DoubleSummaryMetric,
     DoubleOverTimeMetric,
     HistogramMetric,
@@ -109,11 +108,6 @@ class ResimMetricsWriter:
 
     def add_image_metric(self, name: str) -> ImageMetric:
         metric = ImageMetric(name=name, parent_job_id=self.job_id)
-        self.add_metric(metric)
-        return metric
-
-    def add_video_metric(self, name: str) -> VideoMetric:
-        metric = VideoMetric(name=name, parent_job_id=self.job_id)
         self.add_metric(metric)
         return metric
 

--- a/resim/metrics/python/metrics_writer_test.py
+++ b/resim/metrics/python/metrics_writer_test.py
@@ -563,41 +563,41 @@ class TestMetricsWriter(unittest.TestCase):
     def tearDown(self) -> None:
         pass
 
-def test_plotly_metric(self) -> None:
-    METRIC_NAME = "Plotly metric"
-    METRIC_DESCRIPTION = "Description"
-    METRIC_BLOCKING = True
-    METRIC_DISPLAY = True
-    METRIC_IMPORTANCE = MetricImportance.HIGH_IMPORTANCE
-    METRIC_STATUS = MetricStatus.PASSED_METRIC_STATUS
-    METRIC_DATA = Struct()
+    def test_plotly_metric(self) -> None:
+        METRIC_NAME = "Plotly metric"
+        METRIC_DESCRIPTION = "Description"
+        METRIC_BLOCKING = True
+        METRIC_DISPLAY = True
+        METRIC_IMPORTANCE = MetricImportance.HIGH_IMPORTANCE
+        METRIC_STATUS = MetricStatus.PASSED_METRIC_STATUS
+        METRIC_DATA = Struct()
 
-    (
-        self.writer
-        .add_plotly_metric(METRIC_NAME)
-        .with_plotly_data(METRIC_DATA)
-        .with_description(METRIC_DESCRIPTION)
-        .with_blocking(METRIC_BLOCKING)
-        .with_should_display(METRIC_DISPLAY)
-        .with_importance(METRIC_IMPORTANCE)
-        .with_status(METRIC_STATUS)
-    )
+        (
+            self.writer
+            .add_plotly_metric(METRIC_NAME)
+            .with_plotly_data(METRIC_DATA)
+            .with_description(METRIC_DESCRIPTION)
+            .with_blocking(METRIC_BLOCKING)
+            .with_should_display(METRIC_DISPLAY)
+            .with_importance(METRIC_IMPORTANCE)
+            .with_status(METRIC_STATUS)
+        )
 
-    output = self.writer.write()
-    self.assertEqual(len(output.packed_ids), 1)
-    self.assertEqual(len(output.metrics_msg.job_level_metrics.metrics), 1)
-    self.assertEqual(len(output.metrics_msg.metrics_data), 0)
+        output = self.writer.write()
+        self.assertEqual(len(output.packed_ids), 1)
+        self.assertEqual(len(output.metrics_msg.job_level_metrics.metrics), 1)
+        self.assertEqual(len(output.metrics_msg.metrics_data), 0)
 
-    metric_base = output.metrics_msg.job_level_metrics.metrics[0]
-    metric_values = metric_base.metric_values.scalar_metric_values
+        metric_base = output.metrics_msg.job_level_metrics.metrics[0]
+        metric_values = metric_base.metric_values.scalar_metric_values
 
-    self.assertEqual(metric_base.description, METRIC_DESCRIPTION)
-    self.assertEqual(metric_base.blocking, METRIC_BLOCKING)
-    self.assertEqual(metric_base.should_display, METRIC_DISPLAY)
-    self.assertEqual(metric_base.importance, METRIC_IMPORTANCE.value)
-    self.assertEqual(metric_base.status, METRIC_STATUS.value)
-    self.assertEqual(metric_base.name, METRIC_NAME)
-    self.assertEqual(metric_values.plotly_data, METRIC_DATA)
+        self.assertEqual(metric_base.description, METRIC_DESCRIPTION)
+        self.assertEqual(metric_base.blocking, METRIC_BLOCKING)
+        self.assertEqual(metric_base.should_display, METRIC_DISPLAY)
+        self.assertEqual(metric_base.importance, METRIC_IMPORTANCE.value)
+        self.assertEqual(metric_base.status, METRIC_STATUS.value)
+        self.assertEqual(metric_base.name, METRIC_NAME)
+        self.assertEqual(metric_values.plotly_data, METRIC_DATA)
 
 # This is the entry point of the unittest script
 if __name__ == '__main__':

--- a/resim/metrics/python/metrics_writer_test.py
+++ b/resim/metrics/python/metrics_writer_test.py
@@ -560,9 +560,6 @@ class TestMetricsWriter(unittest.TestCase):
         self.assertEqual(
             self.writer.metrics_data[metrics_data.id], metrics_data)
 
-    def tearDown(self) -> None:
-        pass
-
     def test_plotly_metric(self) -> None:
         METRIC_NAME = "Plotly metric"
         METRIC_DESCRIPTION = "Description"
@@ -589,7 +586,7 @@ class TestMetricsWriter(unittest.TestCase):
         self.assertEqual(len(output.metrics_msg.metrics_data), 0)
 
         metric_base = output.metrics_msg.job_level_metrics.metrics[0]
-        metric_values = metric_base.metric_values.scalar_metric_values
+        metric_values = metric_base.metric_values.plotly_metric_values
 
         self.assertEqual(metric_base.description, METRIC_DESCRIPTION)
         self.assertEqual(metric_base.blocking, METRIC_BLOCKING)
@@ -597,7 +594,10 @@ class TestMetricsWriter(unittest.TestCase):
         self.assertEqual(metric_base.importance, METRIC_IMPORTANCE.value)
         self.assertEqual(metric_base.status, METRIC_STATUS.value)
         self.assertEqual(metric_base.name, METRIC_NAME)
-        self.assertEqual(metric_values.plotly_data, METRIC_DATA)
+        self.assertEqual(metric_values.json, METRIC_DATA)
+
+    def tearDown(self) -> None:
+        pass
 
 # This is the entry point of the unittest script
 if __name__ == '__main__':

--- a/resim/metrics/python/metrics_writer_test.py
+++ b/resim/metrics/python/metrics_writer_test.py
@@ -16,8 +16,8 @@ from resim.metrics.python.metrics_utils import (
     MetricImportance
 )
 from resim.metrics.python.metrics import (
-    ExternalFileMetricsData, 
-    SeriesMetricsData, 
+    ExternalFileMetricsData,
+    SeriesMetricsData,
     GroupedMetricsData)
 from resim.metrics.python.metrics_writer import ResimMetricsWriter
 
@@ -634,7 +634,7 @@ class TestMetricsWriter(unittest.TestCase):
         self.assertEqual(metric_base.status, METRIC_STATUS.value)
         self.assertEqual(metric_base.name, METRIC_NAME)
         self.assertEqual(uuid.UUID(metric_values.image_data_id.id.data), METRIC_DATA.id)
-    
+
     def test_external_file_metrics_data(self) -> None:
         """Test that we can add an external file metrics data."""
         NAME = "test_metrics_data"

--- a/resim/metrics/python/metrics_writer_test.py
+++ b/resim/metrics/python/metrics_writer_test.py
@@ -7,6 +7,7 @@ from typing import List, Optional
 
 import numpy as np
 
+from google.protobuf.struct_pb2 import Struct
 from resim.metrics.python.metrics_utils import (
     Timestamp,
     DoubleFailureDefinition,
@@ -562,6 +563,41 @@ class TestMetricsWriter(unittest.TestCase):
     def tearDown(self) -> None:
         pass
 
+def test_plotly_metric(self) -> None:
+    METRIC_NAME = "Plotly metric"
+    METRIC_DESCRIPTION = "Description"
+    METRIC_BLOCKING = True
+    METRIC_DISPLAY = True
+    METRIC_IMPORTANCE = MetricImportance.HIGH_IMPORTANCE
+    METRIC_STATUS = MetricStatus.PASSED_METRIC_STATUS
+    METRIC_DATA = Struct()
+
+    (
+        self.writer
+        .add_plotly_metric(METRIC_NAME)
+        .with_plotly_data(METRIC_DATA)
+        .with_description(METRIC_DESCRIPTION)
+        .with_blocking(METRIC_BLOCKING)
+        .with_should_display(METRIC_DISPLAY)
+        .with_importance(METRIC_IMPORTANCE)
+        .with_status(METRIC_STATUS)
+    )
+
+    output = self.writer.write()
+    self.assertEqual(len(output.packed_ids), 1)
+    self.assertEqual(len(output.metrics_msg.job_level_metrics.metrics), 1)
+    self.assertEqual(len(output.metrics_msg.metrics_data), 0)
+
+    metric_base = output.metrics_msg.job_level_metrics.metrics[0]
+    metric_values = metric_base.metric_values.scalar_metric_values
+
+    self.assertEqual(metric_base.description, METRIC_DESCRIPTION)
+    self.assertEqual(metric_base.blocking, METRIC_BLOCKING)
+    self.assertEqual(metric_base.should_display, METRIC_DISPLAY)
+    self.assertEqual(metric_base.importance, METRIC_IMPORTANCE.value)
+    self.assertEqual(metric_base.status, METRIC_STATUS.value)
+    self.assertEqual(metric_base.name, METRIC_NAME)
+    self.assertEqual(metric_values.plotly_data, METRIC_DATA)
 
 # This is the entry point of the unittest script
 if __name__ == '__main__':

--- a/resim/metrics/python/unpack_metrics.py
+++ b/resim/metrics/python/unpack_metrics.py
@@ -34,7 +34,6 @@ from resim.metrics.python.metrics import (
     StatesOverTimeMetric,
     PlotlyMetric,
     ImageMetric,
-    VideoMetric,
     GroupedMetricsData,
     SeriesMetricsData,
     Metric,
@@ -176,7 +175,6 @@ def _unpack_metric(metric: mp.Metric,
         ScalarMetric: _unpack_scalar_metric,
         PlotlyMetric: _unpack_plotly_metric,
         ImageMetric: _unpack_image_metric,
-        VideoMetric: _unpack_video_metric,
 
     }
     unpacker: Callable = unpackers[type(unpacked)]

--- a/resim/metrics/python/unpack_metrics.py
+++ b/resim/metrics/python/unpack_metrics.py
@@ -32,6 +32,9 @@ from resim.metrics.python.metrics import (
     DoubleOverTimeMetric,
     HistogramMetric,
     StatesOverTimeMetric,
+    PlotlyMetric,
+    ImageMetric,
+    VideoMetric,
     GroupedMetricsData,
     SeriesMetricsData,
     Metric,
@@ -171,6 +174,10 @@ def _unpack_metric(metric: mp.Metric,
         StatesOverTimeMetric: _unpack_states_over_time_metric,
         HistogramMetric: _unpack_histogram_metric,
         ScalarMetric: _unpack_scalar_metric,
+        PlotlyMetric: _unpack_plotly_metric,
+        ImageMetric: _unpack_image_metric,
+        VideoMetric: _unpack_video_metric,
+
     }
     unpacker: Callable = unpackers[type(unpacked)]
     unpacker(metric, unpacked, id_to_unpacked_metrics_data)
@@ -328,3 +335,17 @@ def _unpack_scalar_metric(metric: mp.Metric,
         _unpack_double_failure_definition(
             values.failure_definition)).with_unit(
                 values.unit)
+
+def _unpack_plotly_metric(metric: mp.Metric,
+                          unpacked: PlotlyMetric,
+                          _: dict[uuid.UUID, MetricsData]) -> None:
+    plotly_data = metric.metric_values.plotly_metric_values
+    unpacked.with_value(
+        plotly_data.value)
+
+def _unpack_image_metric(metric: mp.Metric,
+                          unpacked: ImageMetric,
+                          _: dict[uuid.UUID, MetricsData]) -> None:
+    image_data = metric.metric_values.image_metric_values
+    unpacked.with_value(
+        image_data.value)

--- a/resim/metrics/python/unpack_metrics.py
+++ b/resim/metrics/python/unpack_metrics.py
@@ -129,6 +129,7 @@ def _unpack_metrics_data(metrics_data: mp.MetricsData,
                                                            MetricsData]) -> None:
     data_id = _unpack_uuid(metrics_data.metrics_data_id.id)
     if metrics_data.data_type == mp.EXTERNAL_FILE_DATA_TYPE:
+        print("unpacking an external file metrics data")
         unpacked: MetricsData = ExternalFileMetricsData(
             name=metrics_data.name,
             filename=metrics_data.external_file.path
@@ -340,12 +341,14 @@ def _unpack_scalar_metric(metric: mp.Metric,
             values.failure_definition)).with_unit(
                 values.unit)
 
+
 def _unpack_plotly_metric(metric: mp.Metric,
                           unpacked: PlotlyMetric,
                           _: dict[uuid.UUID, MetricsData]) -> None:
     plotly_data = metric.metric_values.plotly_metric_values.json
     unpacked.with_plotly_data(
         plotly_data)
+
 
 def _unpack_image_metric(metric: mp.Metric,
                           unpacked: ImageMetric,

--- a/resim/metrics/python/unpack_metrics.py
+++ b/resim/metrics/python/unpack_metrics.py
@@ -129,7 +129,6 @@ def _unpack_metrics_data(metrics_data: mp.MetricsData,
                                                            MetricsData]) -> None:
     data_id = _unpack_uuid(metrics_data.metrics_data_id.id)
     if metrics_data.data_type == mp.EXTERNAL_FILE_DATA_TYPE:
-        print("unpacking an external file metrics data")
         unpacked: MetricsData = ExternalFileMetricsData(
             name=metrics_data.name,
             filename=metrics_data.external_file.path

--- a/resim/metrics/python/unpack_metrics.py
+++ b/resim/metrics/python/unpack_metrics.py
@@ -351,8 +351,8 @@ def _unpack_plotly_metric(metric: mp.Metric,
 
 
 def _unpack_image_metric(metric: mp.Metric,
-                          unpacked: ImageMetric,
-                          id_to_unpacked_metrics_data: dict[uuid.UUID, MetricsData]) -> None:
+                         unpacked: ImageMetric,
+                         id_to_unpacked_metrics_data: dict[uuid.UUID, MetricsData]) -> None:
     image_data = metric.metric_values.image_metric_values
     data = id_to_unpacked_metrics_data[_unpack_uuid(image_data.image_data_id.id)]
     unpacked.with_image_data(


### PR DESCRIPTION
## Description of change

Extends the ReSim metrics schema to support storing a serialized plotly chart or an arbitrary image.

## Guide to reproduce test results.

```
bazel test //...
```
## Checklist:
- [X] I have self-reviewed this change.
- [X] I have tested this change.
- [X] This change is covered by tests that are already landed, or in this PR.
