### PR TITLE
Event Metrics and Validation

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -330,9 +330,9 @@ def resim_core_dependencies():
     maybe(
         http_archive,
         name = "resim-python-client",
-        sha256 = "aca1518c2dcf29406b5ce64e18c4b2b0af27716eaa07e79d5c7d2c6cecc6fb34",
-        strip_prefix = "resim-python-client-a28eca31985d175d976b868d38c7f3adc315155b",
-        url = "https://github.com/resim-ai/resim-python-client/archive/a28eca31985d175d976b868d38c7f3adc315155b.zip",
+        sha256 = "87af6d8e8ca652c95ca97526144d4540f9331a1832ffdbc2ef7f67004607efe9",
+        strip_prefix = "resim-python-client-6c485d1450e93be66cbee85f02077ff0c2b65198",
+        url = "https://github.com/resim-ai/resim-python-client/archive/6c485d1450e93be66cbee85f02077ff0c2b65198.zip",
     )
 
     # Protobuf schemas for communications with foxglove

--- a/resim/metrics/proto/BUILD
+++ b/resim/metrics/proto/BUILD
@@ -103,6 +103,5 @@ py_test(
     deps = [
         ":generate_test_metrics",
         ":validate_metrics_proto",
-        "@com_google_protobuf//:protobuf_python",
     ],
 )

--- a/resim/metrics/proto/BUILD
+++ b/resim/metrics/proto/BUILD
@@ -93,6 +93,7 @@ py_library(
     visibility = ["//visibility:public"],
     deps = [
         ":metrics_proto_py",
+        "@com_google_protobuf//:protobuf_python",
     ],
 )
 
@@ -102,5 +103,6 @@ py_test(
     deps = [
         ":generate_test_metrics",
         ":validate_metrics_proto",
+        "@com_google_protobuf//:protobuf_python",
     ],
 )

--- a/resim/metrics/proto/generate_test_metrics.py
+++ b/resim/metrics/proto/generate_test_metrics.py
@@ -718,7 +718,7 @@ def _add_image_metric(job_metrics: mp.JobMetrics) -> None:
     image_metric_values.image_data_id.CopyFrom(metrics_data.metrics_data_id)
 
 
-def _add_event_scalar_metric(job_metrics: mp.JobMetrics) -> mp.MetricId:
+def _add_event_scalar_metric(job_metrics: mp.JobMetrics, tag_as_event: bool) -> mp.MetricId:
     metric = job_metrics.job_level_metrics.metrics.add()
     metric.metric_id.id.data = _get_uuid_str()
     metric.name = "Scalar for an event"
@@ -731,6 +731,7 @@ def _add_event_scalar_metric(job_metrics: mp.JobMetrics) -> mp.MetricId:
     metric.order = 42.0
     metric.job_id.CopyFrom(job_metrics.job_id)
     metric.metric_values.scalar_metric_values.value = 1.61803398875
+    metric.event_metric = tag_as_event
     return metric.metric_id
 
 def _add_event(job_metrics: mp.JobMetrics, metric_id: mp.MetricId) -> None:
@@ -781,7 +782,18 @@ def generate_test_metrics(block_fail: bool=False) -> mp.JobMetrics:
     _add_image_metric(job_metrics)
     _populate_metrics_statuses(job_metrics)
     # Test events:
-    event_metric_id = _add_event_scalar_metric(job_metrics)
+    event_metric_id = _add_event_scalar_metric(job_metrics, True)
+    _add_event(job_metrics, event_metric_id)
+
+    return job_metrics
+
+def generate_bad_events() -> mp.JobMetrics:
+    """
+    Generate a set of test metrics with a badly tagged event metric.
+    """
+    job_metrics = mp.JobMetrics()
+    job_metrics.job_id.id.data = _get_uuid_str()
+    event_metric_id = _add_event_scalar_metric(job_metrics, False)
     _add_event(job_metrics, event_metric_id)
 
     return job_metrics

--- a/resim/metrics/proto/generate_test_metrics.py
+++ b/resim/metrics/proto/generate_test_metrics.py
@@ -681,6 +681,7 @@ def _add_scalar_metric(job_metrics: mp.JobMetrics) -> None:
     metric.job_id.CopyFrom(job_metrics.job_id)
     metric.metric_values.scalar_metric_values.value = 6.28318530718
 
+
 def _add_plotly_metric(job_metrics: mp.JobMetrics) -> None:
     metric = job_metrics.job_level_metrics.metrics.add()
     metric.metric_id.id.data = _get_uuid_str()
@@ -691,9 +692,10 @@ def _add_plotly_metric(job_metrics: mp.JobMetrics) -> None:
     metric.should_display = True
     metric.blocking = False
     metric.importance = mp.ZERO_IMPORTANCE
-    metric.order = 12.0
+    metric.order = 13.0
     metric.job_id.CopyFrom(job_metrics.job_id)
     metric.metric_values.plotly_metric_values.json.CopyFrom(Struct())
+
 
 def _add_image_metric(job_metrics: mp.JobMetrics) -> None:
     metric = job_metrics.job_level_metrics.metrics.add()
@@ -714,6 +716,33 @@ def _add_image_metric(job_metrics: mp.JobMetrics) -> None:
     metrics_data.external_file.path ="my_tree.gif"
     image_metric_values = metric.metric_values.image_metric_values
     image_metric_values.image_data_id.CopyFrom(metrics_data.metrics_data_id)
+
+
+def _add_event_scalar_metric(job_metrics: mp.JobMetrics) -> mp.MetricId:
+    metric = job_metrics.job_level_metrics.metrics.add()
+    metric.metric_id.id.data = _get_uuid_str()
+    metric.name = "Scalar for an event"
+    metric.type = mp.SCALAR_METRIC_TYPE
+    metric.description = "A sample event metric"
+    metric.status = mp.NOT_APPLICABLE_METRIC_STATUS
+    metric.should_display = True
+    metric.blocking = False
+    metric.importance = mp.ZERO_IMPORTANCE
+    metric.order = 42.0
+    metric.job_id.CopyFrom(job_metrics.job_id)
+    metric.metric_values.scalar_metric_values.value = 1.61803398875
+    return metric.metric_id
+    
+def _add_event(job_metrics: mp.JobMetrics, metric_id: mp.MetricId) -> None:
+    event = job_metrics.events.add()
+    event.event_id.id.data = _get_uuid_str()
+    event.name = "Emergency Stop"
+    event.description = "Actor 2 changes lanes"
+    event.tags.extend(["tag1", "tag2", "tag3"])
+    event.status = mp.FAIL_BLOCK_METRIC_STATUS
+    event.importance = mp.LOW_IMPORTANCE
+    event.timestamp.seconds = 42
+    event.metrics.append(metric_id)
 
 def _populate_metrics_statuses(job_metrics: mp.JobMetrics) -> None:
     collection = job_metrics.job_level_metrics
@@ -751,5 +780,8 @@ def generate_test_metrics(block_fail: bool=False) -> mp.JobMetrics:
     _add_plotly_metric(job_metrics)
     _add_image_metric(job_metrics)
     _populate_metrics_statuses(job_metrics)
-
+    # Test events:
+    event_metric_id = _add_event_scalar_metric(job_metrics)
+    _add_event(job_metrics, event_metric_id)
+    
     return job_metrics

--- a/resim/metrics/proto/generate_test_metrics.py
+++ b/resim/metrics/proto/generate_test_metrics.py
@@ -759,7 +759,7 @@ def _add_event(job_metrics: mp.JobMetrics, metric_ids: list[mp.MetricId]) -> Non
     event.status = mp.FAIL_BLOCK_METRIC_STATUS
     event.importance = mp.LOW_IMPORTANCE
     event.timestamp.seconds = 42
-    event.metrics.extend(metric_ids)
+    event.metrics.add().MergeFrom(metric_ids)
 
 def _populate_metrics_statuses(job_metrics: mp.JobMetrics) -> None:
     collection = job_metrics.job_level_metrics

--- a/resim/metrics/proto/generate_test_metrics.py
+++ b/resim/metrics/proto/generate_test_metrics.py
@@ -751,11 +751,11 @@ def _add_event_plotly_metric(job_metrics: mp.JobMetrics, tag_as_event: bool) -> 
     return metric.metric_id
 
 
-def _add_event(job_metrics: mp.JobMetrics, metric_ids: list[mp.MetricId]) -> None:
+def _add_event(job_metrics: mp.JobMetrics, event_name: str, metric_ids: list[mp.MetricId]) -> None:
     event = job_metrics.events.add()
     event.event_id.id.data = _get_uuid_str()
-    event.name = "Emergency Stop"
-    event.description = "Actor 2 changes lanes"
+    event.name = event_name
+    event.description = "event description"
     event.tags.extend(["tag1", "tag2", "tag3"])
     event.status = mp.FAIL_BLOCK_METRIC_STATUS
     event.importance = mp.LOW_IMPORTANCE
@@ -801,8 +801,8 @@ def generate_test_metrics(block_fail: bool=False) -> mp.JobMetrics:
     # Test events:
     scalar_event_metric_id = _add_event_scalar_metric(job_metrics, True)
     plotly_event_metric_id = _add_event_plotly_metric(job_metrics, True)
-    _add_event(job_metrics, [scalar_event_metric_id,plotly_event_metric_id])
-    _add_event(job_metrics, [scalar_event_metric_id,plotly_event_metric_id])
+    _add_event(job_metrics, "first event", [scalar_event_metric_id,plotly_event_metric_id])
+    _add_event(job_metrics, "second event", [scalar_event_metric_id,plotly_event_metric_id])
 
     return job_metrics
 
@@ -815,10 +815,10 @@ def generate_bad_events(expect_event: bool) -> mp.JobMetrics:
     scalar_event_metric_id = _add_event_scalar_metric(job_metrics, False)
     plotly_event_metric_id = _add_event_plotly_metric(job_metrics, True)
     if expect_event:
-        _add_event(job_metrics, [scalar_event_metric_id,plotly_event_metric_id])
+        _add_event(job_metrics, "event", [scalar_event_metric_id,plotly_event_metric_id])
     else:
         random_id = mp.MetricId()
         random_id.id.data =  _get_uuid_str()
-        _add_event(job_metrics, [random_id])
+        _add_event(job_metrics, "event", [random_id])
 
     return job_metrics

--- a/resim/metrics/proto/generate_test_metrics.py
+++ b/resim/metrics/proto/generate_test_metrics.py
@@ -734,7 +734,23 @@ def _add_event_scalar_metric(job_metrics: mp.JobMetrics, tag_as_event: bool) -> 
     metric.event_metric = tag_as_event
     return metric.metric_id
 
-def _add_event(job_metrics: mp.JobMetrics, metric_id: mp.MetricId) -> None:
+def _add_event_plotly_metric(job_metrics: mp.JobMetrics, tag_as_event: bool) -> None:
+    metric = job_metrics.job_level_metrics.metrics.add()
+    metric.metric_id.id.data = _get_uuid_str()
+    metric.name = "A plotly chart for an event"
+    metric.type = mp.PLOTLY_METRIC_TYPE
+    metric.description = "The plotliest of plotly events"
+    metric.status = mp.NOT_APPLICABLE_METRIC_STATUS
+    metric.should_display = True
+    metric.blocking = False
+    metric.importance = mp.ZERO_IMPORTANCE
+    metric.order = 13.0
+    metric.job_id.CopyFrom(job_metrics.job_id)
+    metric.event_metric = tag_as_event
+    metric.metric_values.plotly_metric_values.json.CopyFrom(Struct())
+
+
+def _add_event(job_metrics: mp.JobMetrics, metric_ids: list[mp.MetricId]) -> None:
     event = job_metrics.events.add()
     event.event_id.id.data = _get_uuid_str()
     event.name = "Emergency Stop"
@@ -743,7 +759,7 @@ def _add_event(job_metrics: mp.JobMetrics, metric_id: mp.MetricId) -> None:
     event.status = mp.FAIL_BLOCK_METRIC_STATUS
     event.importance = mp.LOW_IMPORTANCE
     event.timestamp.seconds = 42
-    event.metrics.append(metric_id)
+    event.metrics.extend(metric_ids)
 
 def _populate_metrics_statuses(job_metrics: mp.JobMetrics) -> None:
     collection = job_metrics.job_level_metrics
@@ -782,8 +798,10 @@ def generate_test_metrics(block_fail: bool=False) -> mp.JobMetrics:
     _add_image_metric(job_metrics)
     _populate_metrics_statuses(job_metrics)
     # Test events:
-    event_metric_id = _add_event_scalar_metric(job_metrics, True)
-    _add_event(job_metrics, event_metric_id)
+    scalar_event_metric_id = _add_event_scalar_metric(job_metrics, True)
+    plotly_event_metric_id = _add_event_plotly_metric(job_metrics, True)
+    _add_event(job_metrics, [scalar_event_metric_id,plotly_event_metric_id])
+    _add_event(job_metrics, [scalar_event_metric_id,plotly_event_metric_id])
 
     return job_metrics
 
@@ -793,8 +811,9 @@ def generate_bad_events(expect_event: bool) -> mp.JobMetrics:
     """
     job_metrics = mp.JobMetrics()
     job_metrics.job_id.id.data = _get_uuid_str()
-    event_metric_id = _add_event_scalar_metric(job_metrics, False)
+    scalar_event_metric_id = _add_event_scalar_metric(job_metrics, False)
+    plotly_event_metric_id = _add_event_plotly_metric(job_metrics, True)
     if expect_event:
-        _add_event(job_metrics, event_metric_id)
+        _add_event(job_metrics, [scalar_event_metric_id,plotly_event_metric_id])
 
     return job_metrics

--- a/resim/metrics/proto/generate_test_metrics.py
+++ b/resim/metrics/proto/generate_test_metrics.py
@@ -732,7 +732,7 @@ def _add_event_scalar_metric(job_metrics: mp.JobMetrics) -> mp.MetricId:
     metric.job_id.CopyFrom(job_metrics.job_id)
     metric.metric_values.scalar_metric_values.value = 1.61803398875
     return metric.metric_id
-    
+
 def _add_event(job_metrics: mp.JobMetrics, metric_id: mp.MetricId) -> None:
     event = job_metrics.events.add()
     event.event_id.id.data = _get_uuid_str()
@@ -783,5 +783,5 @@ def generate_test_metrics(block_fail: bool=False) -> mp.JobMetrics:
     # Test events:
     event_metric_id = _add_event_scalar_metric(job_metrics)
     _add_event(job_metrics, event_metric_id)
-    
+
     return job_metrics

--- a/resim/metrics/proto/generate_test_metrics.py
+++ b/resim/metrics/proto/generate_test_metrics.py
@@ -734,7 +734,7 @@ def _add_event_scalar_metric(job_metrics: mp.JobMetrics, tag_as_event: bool) -> 
     metric.event_metric = tag_as_event
     return metric.metric_id
 
-def _add_event_plotly_metric(job_metrics: mp.JobMetrics, tag_as_event: bool) -> None:
+def _add_event_plotly_metric(job_metrics: mp.JobMetrics, tag_as_event: bool) -> mp.MetricId:
     metric = job_metrics.job_level_metrics.metrics.add()
     metric.metric_id.id.data = _get_uuid_str()
     metric.name = "A plotly chart for an event"
@@ -748,6 +748,7 @@ def _add_event_plotly_metric(job_metrics: mp.JobMetrics, tag_as_event: bool) -> 
     metric.job_id.CopyFrom(job_metrics.job_id)
     metric.event_metric = tag_as_event
     metric.metric_values.plotly_metric_values.json.CopyFrom(Struct())
+    return metric.metric_id
 
 
 def _add_event(job_metrics: mp.JobMetrics, metric_ids: list[mp.MetricId]) -> None:
@@ -759,7 +760,7 @@ def _add_event(job_metrics: mp.JobMetrics, metric_ids: list[mp.MetricId]) -> Non
     event.status = mp.FAIL_BLOCK_METRIC_STATUS
     event.importance = mp.LOW_IMPORTANCE
     event.timestamp.seconds = 42
-    event.metrics.add().MergeFrom(metric_ids)
+    event.metrics.extend(metric_ids)
 
 def _populate_metrics_statuses(job_metrics: mp.JobMetrics) -> None:
     collection = job_metrics.job_level_metrics

--- a/resim/metrics/proto/generate_test_metrics.py
+++ b/resim/metrics/proto/generate_test_metrics.py
@@ -816,5 +816,9 @@ def generate_bad_events(expect_event: bool) -> mp.JobMetrics:
     plotly_event_metric_id = _add_event_plotly_metric(job_metrics, True)
     if expect_event:
         _add_event(job_metrics, [scalar_event_metric_id,plotly_event_metric_id])
+    else:
+        random_id = mp.MetricId()
+        random_id.id.data =  _get_uuid_str()
+        _add_event(job_metrics, [random_id])
 
     return job_metrics

--- a/resim/metrics/proto/generate_test_metrics.py
+++ b/resim/metrics/proto/generate_test_metrics.py
@@ -787,13 +787,14 @@ def generate_test_metrics(block_fail: bool=False) -> mp.JobMetrics:
 
     return job_metrics
 
-def generate_bad_events() -> mp.JobMetrics:
+def generate_bad_events(expect_event: bool) -> mp.JobMetrics:
     """
     Generate a set of test metrics with a badly tagged event metric.
     """
     job_metrics = mp.JobMetrics()
     job_metrics.job_id.id.data = _get_uuid_str()
     event_metric_id = _add_event_scalar_metric(job_metrics, False)
-    _add_event(job_metrics, event_metric_id)
+    if expect_event:
+        _add_event(job_metrics, event_metric_id)
 
     return job_metrics

--- a/resim/metrics/proto/metrics.proto
+++ b/resim/metrics/proto/metrics.proto
@@ -165,7 +165,11 @@ message JobId {
     resim.proto.UUID id = 1;
 }
 
-// All metrics  associated with a given job.
+message EventId {
+    resim.proto.UUID id = 1;
+}
+
+// All metrics associated with a given job.
 // This is the type output by metrics scripts for validation.
 message JobMetrics {
     JobId job_id = 1;
@@ -175,6 +179,8 @@ message JobMetrics {
     repeated MetricsData metrics_data = 3;
 
     MetricStatus metrics_status = 4;
+
+    repeated Event events = 5;
 }
 
 // Top-level generic metric collection within JobMetrics.
@@ -224,6 +230,39 @@ message Metric {
     // therefore ordered (alphabetically in the case of multiple) after any set
     // fields.
     optional float order = 11;
+
+    // An optional boolean to be set to true in the case that this metric
+    // should not be displayed outside the context of the event.
+    optional bool event_metric = 12;
+}
+
+// An event is a tagged timestamp, reflecting, well, what it sounds like:
+// something happened. That event could be good, bad, neutral (and thus contains
+// the usual statues), but by definition is something worth looking at, at
+// provides an insight. Thus, events, provide a way to index into the experience
+// to find what matters.
+//
+// Events are associated with metrics, and can be used to provide insight into
+// the nature of the event.
+//
+// We allow events to be given names (not required unique in a job) and a list
+// of tags.
+message Event {
+    EventId event_id = 1;
+
+    string name = 2;
+
+    string description = 3;
+
+    repeated string tags = 4;
+
+    repeated MetricId metrics = 5;
+
+    MetricStatus status = 6;
+
+    google.protobuf.Timestamp timestamp = 7;
+
+    MetricImportance importance = 8;
 }
 
 message MetricValues {

--- a/resim/metrics/proto/metrics.proto
+++ b/resim/metrics/proto/metrics.proto
@@ -239,7 +239,7 @@ message Metric {
 // An event is a tagged timestamp, reflecting, well, what it sounds like:
 // something happened. That event could be good, bad, neutral (and thus contains
 // the usual statues), but by definition is something worth looking at, at
-// provides an insight. Thus, events, provide a way to index into the experience
+// provides an insight. Thus, events provide a way to index into the experience
 // to find what matters.
 //
 // Events are associated with metrics, and can be used to provide insight into

--- a/resim/metrics/proto/metrics.proto
+++ b/resim/metrics/proto/metrics.proto
@@ -242,7 +242,7 @@ message Metric {
 // provides an insight. Thus, events provide a way to index into the experience
 // to find what matters.
 //
-// Events are associated with metrics, and can be used to provide insight into
+// Events are associated with metrics, and these metrics can be used to provide insight into
 // the nature of the event.
 //
 // We allow events to be given names (not required unique in a job) and a list

--- a/resim/metrics/proto/metrics.proto
+++ b/resim/metrics/proto/metrics.proto
@@ -238,12 +238,12 @@ message Metric {
 
 // An event is a tagged timestamp, reflecting, well, what it sounds like:
 // something happened. That event could be good, bad, neutral (and thus contains
-// the usual statues), but by definition is something worth looking at, at
+// the usual statuses), but by definition is something worth looking at, at
 // provides an insight. Thus, events provide a way to index into the experience
 // to find what matters.
 //
-// Events are associated with metrics, and these metrics can be used to provide insight into
-// the nature of the event.
+// Events are associated with metrics, and these metrics can be used to provide
+// insight into the nature of the event.
 //
 // We allow events to be given names (not required unique in a job) and a list
 // of tags.

--- a/resim/metrics/proto/validate_metrics_proto.py
+++ b/resim/metrics/proto/validate_metrics_proto.py
@@ -15,6 +15,7 @@ contents that can be posted to the metrics endpoint.
 
 import uuid
 
+import google.protobuf.timestamp_pb2 as timestamp_proto
 import resim.metrics.proto.metrics_pb2 as mp
 import resim.utils.proto.uuid_pb2 as uuid_proto
 
@@ -64,6 +65,13 @@ def _validate_job_id(job_id: mp.JobId) -> None:
 def _validate_metric_id(metric_id: mp.MetricId) -> None:
     _validate_uuid(metric_id.id)
 
+def _validate_event_id(event_id: mp.EventId) -> None:
+    _validate_uuid(event_id.id)
+
+def _validate_timestamp(timestamp: timestamp_proto.Timestamp) -> None:
+    _metrics_assert(timestamp.seconds >= 0)
+    _metrics_assert(timestamp.nanos >= 0)
+    _metrics_assert(timestamp.nanos < 1e9)
 
 _ALL_SERIES_DATA_TYPES = {
     mp.DOUBLE_SERIES_DATA_TYPE,
@@ -412,6 +420,7 @@ def _validate_scalar_metric_values(
     """
     _metrics_assert(scalar_metric_values.HasField('value'))
 
+
 def _validate_plotly_metric_values(
         plotly_metric_values: mp.PlotlyMetricValues) -> None:
     """
@@ -421,6 +430,7 @@ def _validate_plotly_metric_values(
         plotly_metric_values: The metric values to check.
     """
     _metrics_assert(plotly_metric_values.HasField('json'))
+
 
 def _validate_image_metric_values(
         image_metric_values: mp.ImageMetricValues,
@@ -439,6 +449,7 @@ def _validate_image_metric_values(
     _metrics_assert(id_str in metrics_data_map)
     value_data = metrics_data_map[id_str]
     _metrics_assert(value_data.data_type == mp.EXTERNAL_FILE_DATA_TYPE)
+
 
 def _validate_metric_values(
         metric_values: mp.MetricValues,
@@ -481,14 +492,31 @@ def _validate_metric_values(
             metric_values.image_metric_values, metrics_data_map)
 
 
+def _validate_metric_used_in_event(metric_id: mp.MetricId,
+                                   events_list: list[mp.Event]) -> None:
+    """
+    Check that the metric_id is valid and used in an event.
+    
+    Args:
+        metric_id: The metric_id to check.
+        events_list: A list of the events.
+    """
+    for event in events_list:
+        if metric_id in event.metrics:
+            return True
+    return False
+    
+     
 def _validate_metric(metric: mp.Metric,
-                     metrics_data_map: dict[str, mp.MetricsData]) -> None:
+                     metrics_data_map: dict[str, mp.MetricsData],
+                     events_list: list[mp.Event]) -> None:
     """
     Check that a Metric is valid.
 
     Args:
         metric: The metric to check.
         metrics_data_map: A map to find the metrics data in.
+        events_list: A list of the events.
     """
     _validate_metric_id(metric.metric_id)
     _metrics_assert(metric.name != "")
@@ -499,9 +527,13 @@ def _validate_metric(metric: mp.Metric,
     _validate_metric_values(metric.metric_values, metrics_data_map)
     # No constraints on blocking
     _validate_metric_importance(metric.importance)
+    
     _metrics_assert(metric.HasField("job_id"))
     _validate_job_id(metric.job_id)
 
+    if metric.event_metric:
+        _validate_metric_used_in_event(metric.metric_id, events_list)
+        
     if metric.type == mp.DOUBLE_SUMMARY_METRIC_TYPE:
         _metrics_assert(metric.metric_values.HasField('double_metric_values'))
     elif metric.type == mp.DOUBLE_OVER_TIME_METRIC_TYPE:
@@ -529,16 +561,18 @@ def _validate_metric(metric: mp.Metric,
 
 def _validate_job_level_metrics(
         job_level_metrics: mp.MetricCollection,
-        metrics_data_map: dict[str, mp.MetricsData]) -> None:
+        metrics_data_map: dict[str, mp.MetricsData],
+        events_list: list[mp.Event]) -> None:
     """
     Check that a MetricCollection is valid.
 
     Args:
         job_level_metrics: The MetricCollection to check.
         metrics_data_map: A map to find the metrics data in.
+        events_list: A list of all the events
     """
     for metric in job_level_metrics.metrics:
-        _validate_metric(metric, metrics_data_map)
+        _validate_metric(metric, metrics_data_map, events_list)
     _validate_metric_status(job_level_metrics.metrics_status)
 
 
@@ -638,6 +672,30 @@ def _validate_statuses(job_metrics: mp.JobMetrics) -> None:
                     job_metrics.metrics_status)
 
 
+def _validate_event(
+        event: mp.Event, metrics_map: dict[str, mp.Metric]) -> None:
+    """
+    Check that the Event is valid.
+
+    Args:
+        event: The Event to validate.
+        metrics_map: A map to find the metric in.
+    """
+    _validate_event_id(event.event_id)
+    _metrics_assert(event.name != "")
+    # No constraints on description
+    # No constraints on tags
+    
+    # Validate that each metric id is in the metrics_map:
+    for metric_id in event.metrics:
+        _validate_metric_id(metric_id)
+        _metrics_assert(metric_id.id.data in metrics_map)
+        
+    _validate_metric_status(event.status)
+    _validate_timestamp(event.timestamp)
+    _validate_metric_importance(event.importance)
+
+
 def build_metrics_data_map(
         job_metrics: mp.JobMetrics) -> dict[str, mp.MetricsData]:
     """
@@ -662,17 +720,67 @@ def build_metrics_data_map(
     return result
 
 
+def build_metrics_map(
+        job_metrics: mp.JobMetrics) -> dict[str, mp.Metric]:
+    """
+    Build a map of id (as a str) to mp.Metric.
+
+    We do this so we can quickly look these up while validating.
+
+    Args:
+        job_metrics: The job metrics to get the data from.
+
+    Returns:
+        A map of id -> mp.Metric from the job_level_metrics.metrics field
+        in the job_metrics.
+    """
+    result = {}
+    for metric in job_metrics.job_level_metrics.metrics:
+        _validate_metric_id(metric.metric_id)
+        result[metric.metric_id.id.data] = metric
+
+    # Checks uniqueness of ids
+    _metrics_assert(len(result) == len(job_metrics.job_level_metrics.metrics))
+    return result
+
+
+def build_events_list(
+        job_metrics: mp.JobMetrics) -> list[mp.Event]:
+    """
+    Build a list of mp.Event.
+
+    We do this so we can quickly look these up while validating.
+
+    Args:
+        job_metrics: The job metrics to get the data from.
+
+    Returns:
+        A list mp.Event from the events field
+        in the job_metrics.
+    """
+    result = []
+    for event in job_metrics.events:
+        _validate_event_id(event.event_id)
+        result.append(event)
+
+    # Checks uniqueness of ids
+    _metrics_assert(len(result) == len(job_metrics.events))
+    return result
+
+
 def validate_job_metrics(job_metrics: mp.JobMetrics) -> None:
     """
     Validate that the given JobMetrics is valid and can be posted to the
     endpoint.
     """
     metrics_data_map = build_metrics_data_map(job_metrics)
+    metrics_map = build_metrics_map(job_metrics)
+    events_list = build_events_list(job_metrics)
 
     _validate_job_id(job_metrics.job_id)
     _validate_job_level_metrics(
         job_metrics.job_level_metrics,
-        metrics_data_map)
+        metrics_data_map, events_list)
     _validate_metric_status(job_metrics.metrics_status)
 
     # Use a set to check for duplicated names
@@ -688,5 +796,8 @@ def validate_job_metrics(job_metrics: mp.JobMetrics) -> None:
         _metrics_assert(metric_data.name not in metric_data_names)
         metric_data_names.add(metric_data.name)
         _validate_metrics_data(metric_data, metrics_data_map)
+ 
+    for event in job_metrics.events:
+        _validate_event(event, metrics_map)
 
     _validate_statuses(job_metrics)

--- a/resim/metrics/proto/validate_metrics_proto.py
+++ b/resim/metrics/proto/validate_metrics_proto.py
@@ -533,7 +533,7 @@ def _validate_metric(metric: mp.Metric,
 
     if metric.event_metric:
         _validate_metric_used_in_event(metric.metric_id, events_list)
-  
+
     if metric.type == mp.DOUBLE_SUMMARY_METRIC_TYPE:
         _metrics_assert(metric.metric_values.HasField('double_metric_values'))
     elif metric.type == mp.DOUBLE_OVER_TIME_METRIC_TYPE:
@@ -690,7 +690,7 @@ def _validate_event(
     for metric_id in event.metrics:
         _validate_metric_id(metric_id)
         _metrics_assert(metric_id.id.data in metrics_map)
- 
+
     _validate_metric_status(event.status)
     _validate_timestamp(event.timestamp)
     _validate_metric_importance(event.importance)

--- a/resim/metrics/proto/validate_metrics_proto.py
+++ b/resim/metrics/proto/validate_metrics_proto.py
@@ -505,8 +505,8 @@ def _validate_metric_used_in_event(metric_id: mp.MetricId,
         if metric_id in event.metrics:
             return True
     return False
-    
-     
+
+
 def _validate_metric(metric: mp.Metric,
                      metrics_data_map: dict[str, mp.MetricsData],
                      events_list: list[mp.Event]) -> None:
@@ -527,13 +527,13 @@ def _validate_metric(metric: mp.Metric,
     _validate_metric_values(metric.metric_values, metrics_data_map)
     # No constraints on blocking
     _validate_metric_importance(metric.importance)
-    
+
     _metrics_assert(metric.HasField("job_id"))
     _validate_job_id(metric.job_id)
 
     if metric.event_metric:
         _validate_metric_used_in_event(metric.metric_id, events_list)
-        
+  
     if metric.type == mp.DOUBLE_SUMMARY_METRIC_TYPE:
         _metrics_assert(metric.metric_values.HasField('double_metric_values'))
     elif metric.type == mp.DOUBLE_OVER_TIME_METRIC_TYPE:
@@ -685,12 +685,12 @@ def _validate_event(
     _metrics_assert(event.name != "")
     # No constraints on description
     # No constraints on tags
-    
+
     # Validate that each metric id is in the metrics_map:
     for metric_id in event.metrics:
         _validate_metric_id(metric_id)
         _metrics_assert(metric_id.id.data in metrics_map)
-        
+ 
     _validate_metric_status(event.status)
     _validate_timestamp(event.timestamp)
     _validate_metric_importance(event.importance)
@@ -796,7 +796,7 @@ def validate_job_metrics(job_metrics: mp.JobMetrics) -> None:
         _metrics_assert(metric_data.name not in metric_data_names)
         metric_data_names.add(metric_data.name)
         _validate_metrics_data(metric_data, metrics_data_map)
- 
+
     for event in job_metrics.events:
         _validate_event(event, metrics_map)
 

--- a/resim/metrics/proto/validate_metrics_proto.py
+++ b/resim/metrics/proto/validate_metrics_proto.py
@@ -797,7 +797,11 @@ def validate_job_metrics(job_metrics: mp.JobMetrics) -> None:
         metric_data_names.add(metric_data.name)
         _validate_metrics_data(metric_data, metrics_data_map)
 
+    # Use a set to check for duplicated names
+    event_names = set()
     for event in job_metrics.events:
+        _metrics_assert(event.name not in event_names)
+        event_names.add(event.name)
         _validate_event(event, metrics_map)
 
     _validate_statuses(job_metrics)

--- a/resim/metrics/proto/validate_metrics_proto_test.py
+++ b/resim/metrics/proto/validate_metrics_proto_test.py
@@ -73,7 +73,7 @@ class ValidateMetricsProtoTest(unittest.TestCase):
         bad_event_job_proto = gtm.generate_bad_events()
         with self.assertRaises(vmp.InvalidMetricsException):
             vmp.validate_job_metrics(bad_event_job_proto)
-     
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/resim/metrics/proto/validate_metrics_proto_test.py
+++ b/resim/metrics/proto/validate_metrics_proto_test.py
@@ -65,7 +65,7 @@ class ValidateMetricsProtoTest(unittest.TestCase):
         data_empty = _make_data_empty(self._warn_metrics)
         with self.assertRaises(vmp.InvalidMetricsException):
             vmp.validate_job_metrics(data_empty)
-    
+
     def test_invalid_event_metric(self) -> None:
         """
         Test that the validator fails when a metric used in an event isn't tagged
@@ -73,7 +73,7 @@ class ValidateMetricsProtoTest(unittest.TestCase):
         bad_event_job_proto = gtm.generate_bad_events()
         with self.assertRaises(vmp.InvalidMetricsException):
             vmp.validate_job_metrics(bad_event_job_proto)
-        
+     
 
 if __name__ == '__main__':
     unittest.main()

--- a/resim/metrics/proto/validate_metrics_proto_test.py
+++ b/resim/metrics/proto/validate_metrics_proto_test.py
@@ -65,7 +65,15 @@ class ValidateMetricsProtoTest(unittest.TestCase):
         data_empty = _make_data_empty(self._warn_metrics)
         with self.assertRaises(vmp.InvalidMetricsException):
             vmp.validate_job_metrics(data_empty)
-
+    
+    def test_invalid_event_metric(self) -> None:
+        """
+        Test that the validator fails when a metric used in an event isn't tagged
+        """
+        bad_event_job_proto = gtm.generate_bad_events()
+        with self.assertRaises(vmp.InvalidMetricsException):
+            vmp.validate_job_metrics(bad_event_job_proto)
+        
 
 if __name__ == '__main__':
     unittest.main()

--- a/resim/metrics/proto/validate_metrics_proto_test.py
+++ b/resim/metrics/proto/validate_metrics_proto_test.py
@@ -69,10 +69,12 @@ class ValidateMetricsProtoTest(unittest.TestCase):
     def test_invalid_event_metric(self) -> None:
         """
         Test that the validator fails when a metric used in an event isn't tagged
+        or doesn't exist
         """
-        bad_event_job_proto = gtm.generate_bad_events()
-        with self.assertRaises(vmp.InvalidMetricsException):
-            vmp.validate_job_metrics(bad_event_job_proto)
+        for expected_event in [True, False]:
+            bad_event_job_proto = gtm.generate_bad_events(expect_event=expected_event)
+            with self.assertRaises(vmp.InvalidMetricsException):
+                vmp.validate_job_metrics(bad_event_job_proto)
 
 
 if __name__ == '__main__':

--- a/resim/metrics/python/metrics.py
+++ b/resim/metrics/python/metrics.py
@@ -29,6 +29,7 @@ from resim.metrics.python.metrics_utils import (
     DoubleFailureDefinition,
     HistogramBucket,
     pack_uuid_to_proto,
+    pack_uuid_to_metric_id,
     pack_series_to_proto,
     MetricImportance,
     MetricStatus)
@@ -63,6 +64,8 @@ class Metric(ABC, Generic[MetricT]):
     parent_job_id: Optional[uuid.UUID]
     order: Optional[float]
 
+    event_metric: Optional[bool]
+
     @abstractmethod
     def __init__(self: Metric[MetricT],
                  name: str,
@@ -72,7 +75,8 @@ class Metric(ABC, Generic[MetricT]):
                  should_display: Optional[bool] = None,
                  blocking: Optional[bool] = None,
                  parent_job_id: Optional[uuid.UUID] = None,
-                 order: Optional[float] = None
+                 order: Optional[float] = None,
+                 event_metric: Optional[bool] = None
                  ):
         assert name is not None
         self.id = uuid.uuid4()
@@ -84,6 +88,7 @@ class Metric(ABC, Generic[MetricT]):
         self.blocking = blocking
         self.parent_job_id = parent_job_id
         self.order = order
+        self.event_metric = event_metric
 
     def __eq__(self: MetricT, __value: object) -> bool:
         if not isinstance(__value, type(self)):
@@ -116,6 +121,10 @@ class Metric(ABC, Generic[MetricT]):
         self.blocking = blocking
         return self
 
+    def is_event_metric(self: MetricT) -> MetricT:
+        self.event_metric = True
+        return self
+
     @abstractmethod
     def pack(self: MetricT) -> metrics_pb2.Metric:
         msg = metrics_pb2.Metric()
@@ -143,6 +152,9 @@ class Metric(ABC, Generic[MetricT]):
 
         if self.order is not None:
             msg.order = self.order
+
+        if self.event_metric is not None:
+            msg.event_metric = self.event_metric
 
         return msg
 
@@ -196,6 +208,11 @@ class Metric(ABC, Generic[MetricT]):
         else:
             unpacked.order = None
 
+        if msg.HasField('event_metric'):
+            unpacked.event_metric = msg.event_metric
+        else:
+            unpacked.event_metric = None
+
         return unpacked
 
     @abstractmethod
@@ -220,6 +237,7 @@ class ScalarMetric(Metric['ScalarMetric']):
                  blocking: Optional[bool] = None,
                  parent_job_id: Optional[uuid.UUID] = None,
                  order: Optional[float] = None,
+                 event_metric: Optional[bool] = None,
                  value: Optional[float] = None,
                  failure_definition: Optional[DoubleFailureDefinition] = None,
                  unit: Optional[str] = None):
@@ -231,7 +249,8 @@ class ScalarMetric(Metric['ScalarMetric']):
             blocking=blocking,
             should_display=should_display,
             parent_job_id=parent_job_id,
-            order=order)
+            order=order,
+            event_metric=event_metric)
         self.value = value
         self.failure_definition = failure_definition
         self.unit = unit
@@ -299,6 +318,7 @@ class DoubleOverTimeMetric(Metric['DoubleOverTimeMetric']):
                  should_display: Optional[bool] = None,
                  parent_job_id: Optional[uuid.UUID] = None,
                  order: Optional[float] = None,
+                 event_metric: Optional[bool] = None,
                  doubles_over_time_data: Optional[List[MetricsData]] = None,
                  statuses_over_time_data: Optional[List[MetricsData]] = None,
                  failure_definitions: Optional[List[DoubleFailureDefinition]] = None,
@@ -314,7 +334,8 @@ class DoubleOverTimeMetric(Metric['DoubleOverTimeMetric']):
             blocking=blocking,
             should_display=should_display,
             parent_job_id=parent_job_id,
-            order=order)
+            order=order,
+            event_metric=event_metric)
         if doubles_over_time_data is None:
             self.doubles_over_time_data = []
         else:
@@ -465,6 +486,7 @@ class StatesOverTimeMetric(Metric['StatesOverTimeMetric']):
                  should_display: Optional[bool] = None,
                  parent_job_id: Optional[uuid.UUID] = None,
                  order: Optional[float] = None,
+                 event_metric: Optional[bool] = None,
                  states_over_time_data: Optional[List[MetricsData]] = None,
                  statuses_over_time_data: Optional[List[MetricsData]] = None,
                  states_set: Optional[Set[str]] = None,
@@ -478,7 +500,8 @@ class StatesOverTimeMetric(Metric['StatesOverTimeMetric']):
             blocking=blocking,
             should_display=should_display,
             parent_job_id=parent_job_id,
-            order=order)
+            order=order,
+            event_metric=event_metric)
         if states_over_time_data is None:
             self.states_over_time_data = []
         else:
@@ -633,6 +656,7 @@ class LinePlotMetric(Metric['LinePlotMetric']):
                  should_display: Optional[bool] = None,
                  parent_job_id: Optional[uuid.UUID] = None,
                  order: Optional[float] = None,
+                 event_metric: Optional[bool] = None,
                  x_doubles_data: Optional[List[MetricsData]] = None,
                  y_doubles_data: Optional[List[MetricsData]] = None,
                  statuses_data: Optional[List[MetricsData]] = None,
@@ -647,7 +671,8 @@ class LinePlotMetric(Metric['LinePlotMetric']):
             blocking=blocking,
             should_display=should_display,
             parent_job_id=parent_job_id,
-            order=order)
+            order=order,
+            event_metric=event_metric)
         if x_doubles_data is None:
             self.x_doubles_data = []
         else:
@@ -778,6 +803,7 @@ class BarChartMetric(Metric['BarChartMetric']):
                  should_display: Optional[bool] = None,
                  parent_job_id: Optional[uuid.UUID] = None,
                  order: Optional[float] = None,
+                 event_metric: Optional[bool] = None,
                  values_data: Optional[List[MetricsData]] = None,
                  statuses_data: Optional[List[MetricsData]] = None,
                  legend_series_names: Optional[List[Optional[str]]] = None,
@@ -793,7 +819,8 @@ class BarChartMetric(Metric['BarChartMetric']):
             blocking=blocking,
             should_display=should_display,
             parent_job_id=parent_job_id,
-            order=order)
+            order=order,
+            event_metric=event_metric)
 
         if values_data is None:
             self.values_data = []
@@ -917,6 +944,7 @@ class HistogramMetric(Metric['HistogramMetric']):
                  should_display: Optional[bool] = None,
                  parent_job_id: Optional[uuid.UUID] = None,
                  order: Optional[float] = None,
+                 event_metric: Optional[bool] = None,
                  values_data: Optional[MetricsData] = None,
                  statuses_data: Optional[MetricsData] = None,
                  buckets: Optional[List[HistogramBucket]] = None,
@@ -932,7 +960,8 @@ class HistogramMetric(Metric['HistogramMetric']):
             blocking=blocking,
             should_display=should_display,
             parent_job_id=parent_job_id,
-            order=order)
+            order=order,
+            event_metric=event_metric)
 
         self.values_data = values_data
         self.statuses_data = statuses_data
@@ -1039,6 +1068,7 @@ class DoubleSummaryMetric(Metric['DoubleSummaryMetric']):
                  should_display: Optional[bool] = None,
                  parent_job_id: Optional[uuid.UUID] = None,
                  order: Optional[float] = None,
+                 event_metric: Optional[bool] = None,
                  value_data: Optional[MetricsData] = None,
                  status_data: Optional[MetricsData] = None,
                  index: Optional[IndexType] = None,
@@ -1052,7 +1082,8 @@ class DoubleSummaryMetric(Metric['DoubleSummaryMetric']):
             blocking=blocking,
             should_display=should_display,
             parent_job_id=parent_job_id,
-            order=order)
+            order=order,
+            event_metric=event_metric)
 
         self.value_data = value_data
         self.status_data = status_data
@@ -1144,6 +1175,7 @@ class PlotlyMetric(Metric['PlotlyMetric']):
                  should_display: Optional[bool] = None,
                  parent_job_id: Optional[uuid.UUID] = None,
                  order: Optional[float] = None,
+                 event_metric: Optional[bool] = None,
                  plotly_data: Optional[Struct] = None,
                  ):
         super().__init__(
@@ -1154,7 +1186,8 @@ class PlotlyMetric(Metric['PlotlyMetric']):
             blocking=blocking,
             should_display=should_display,
             parent_job_id=parent_job_id,
-            order=order)
+            order=order,
+            event_metric=event_metric)
 
         self.plotly_data = plotly_data
 
@@ -1197,6 +1230,7 @@ class ImageMetric(Metric['ImageMetric']):
                  should_display: Optional[bool] = None,
                  parent_job_id: Optional[uuid.UUID] = None,
                  order: Optional[float] = None,
+                 event_metric: Optional[bool] = None,
                  image_data: Optional[ExternalFileMetricsData] = None,
                  ):
         super().__init__(
@@ -1207,7 +1241,8 @@ class ImageMetric(Metric['ImageMetric']):
             blocking=blocking,
             should_display=should_display,
             parent_job_id=parent_job_id,
-            order=order)
+            order=order,
+            event_metric=event_metric)
 
         self.image_data = image_data
 
@@ -1608,3 +1643,107 @@ class ExternalFileMetricsData(BaseMetricsData['ExternalFileMetricsData']):
             self: ExternalFileMetricsData,
             metrics_output: ResimMetricsOutput) -> None:
         super().recursively_pack_into(metrics_output)
+
+# -------------------
+# Event representation
+# -------------------
+
+@metric_dataclass
+class Event():
+    id: uuid.UUID
+    name: str
+    description: Optional[str]
+    tags: Optional[list[str]]
+    status: Optional[MetricStatus]
+    importance: Optional[MetricImportance]
+    timestamp: Optional[Timestamp]
+    metrics: Optional[List[Metric]]
+
+    def __init__(self: Metric[MetricT],
+                 name: str,
+                 description: Optional[str] = None,
+                 tags: Optional[list[str]] = None,
+                 status: Optional[MetricStatus] = None,
+                 importance: Optional[MetricImportance] = None,
+                 timestamp: Optional[Timestamp] = None,
+                 metrics: Optional[List[Metric]] = None,
+                 ):
+        assert name is not None
+        self.id = uuid.uuid4()
+        self.name = name
+        self.description = description
+        self.tags = tags
+        self.status = status
+        self.importance = importance
+        self.timestamp = timestamp
+        self.metrics = metrics
+
+    def __eq__(self: MetricT, __value: object) -> bool:
+        if not isinstance(__value, type(self)):
+            return False
+
+        assert (self.id is not None and
+                __value.id is not None), "Cannot compare values without valid ids"
+
+        return self.id == __value.id
+
+    def with_description(self: MetricT, description: str) -> MetricT:
+        self.description = description
+        return self
+
+    def with_status(self: MetricT, status: MetricStatus) -> MetricT:
+        self.status = status
+        return self
+
+    def with_importance(
+            self: MetricT,
+            importance: MetricImportance) -> MetricT:
+        self.importance = importance
+        return self
+
+    def with_tags(self: MetricT, tags: List[str]) -> MetricT:
+        self.tags = tags
+        return self
+
+    def with_timestamp(self: MetricT, timestamp: Timestamp) -> MetricT:
+        self.timestamp = timestamp
+        return self
+
+    def with_metrics(self: MetricT, metrics: List[Metric]) -> MetricT:
+        self.metrics = metrics
+        return self
+
+    def pack(self: Event) -> metrics_pb2.Event:
+        msg = metrics_pb2.Event()
+
+        msg.event_id.id.CopyFrom(pack_uuid_to_proto(self.id))
+        msg.name = self.name
+
+        if self.description is not None:
+            msg.description = self.description
+
+        if self.status is not None:
+            msg.status = self.status.value
+
+        if self.importance is not None:
+            msg.importance = self.importance.value
+
+        if self.timestamp is not None:
+            msg.timestamp.CopyFrom(self.timestamp.pack())
+
+        if self.tags is not None:
+            msg.tags.extend(self.tags)
+
+        if self.metrics is not None:
+            msg.metrics.extend([pack_uuid_to_metric_id(m.id) for m in self.metrics])
+
+        return msg
+
+    def recursively_pack_into(
+            self,
+            metrics_output: ResimMetricsOutput) -> None:
+        if self.id in metrics_output.packed_ids:
+            return
+        metrics_output.packed_ids.add(self.id)
+
+        metrics_output.metrics_msg.events.extend([self.pack()])

--- a/resim/metrics/python/metrics_test.py
+++ b/resim/metrics/python/metrics_test.py
@@ -78,6 +78,9 @@ class MetricsTest(unittest.TestCase):
         self.assertEqual(metric, metric.with_blocking(True))
         self.assertTrue(metric.blocking)
 
+        self.assertEqual(metric, metric.is_event_metric())
+        self.assertTrue(metric.event_metric)
+
     def assert_common_fields_match(self, *,
                                    msg: mp.Metric,
                                    metric: metrics.Metric) -> None:
@@ -1655,6 +1658,137 @@ class MetricsTest(unittest.TestCase):
         self.assertEqual(msg.name, metrics_data.name)
         self.assertEqual(msg.external_file.path, filename)
 
+    def test_event_eq(self) -> None:
+        # SETUP
+        metric_1 = metrics.ScalarMetric(
+            name="test_metric_1",
+            value=24.0)
+        metric_2 = metrics.ScalarMetric(
+            name="test_metric_2",
+            value=48.0)
+
+        event = metrics.Event(
+            name="my_event",
+            description="event description",
+            tags=["a tag", "another tag"],
+            timestamp=metrics_utils.Timestamp(secs=1, nanos=2),
+            importance=MetricImportance.CRITICAL_IMPORTANCE,
+            status=MetricStatus.FAIL_BLOCK_METRIC_STATUS,
+            metrics=[metric_1, metric_2],
+        )
+
+        # Test equality
+        self.assertEqual(event, event)
+
+        # Different type
+        self.assertNotEqual(event, 3)
+
+        # Non-existent id
+        event_with_none_id = copy.copy(event)
+        event_with_none_id.id = cast(uuid.UUID, None)
+        with self.assertRaises(AssertionError):
+            _ = event_with_none_id == event
+        with self.assertRaises(AssertionError):
+            _ = event == event_with_none_id
+
+        # Different id
+        event_with_diff_id = copy.copy(event)
+        event_with_diff_id.id = uuid.uuid4()
+        self.assertNotEqual(event_with_diff_id, event)
+        self.assertNotEqual(event, event_with_diff_id)
+
+    def generate_event_metrics(self) -> list[metrics.Metric]:
+        metric_1 = metrics.ScalarMetric(
+            name="test_metric_1",
+            value=24.0)
+        metric_2 = metrics.ScalarMetric(
+            name="test_metric_2",
+            value=24.0)
+        return [metric_1, metric_2]
+
+    def test_event(self) -> None:
+        name = "my_event"
+        description = "event description"
+        tags = ["a tag", "another tag"]
+        timestamp = metrics_utils.Timestamp(secs=1, nanos=2)
+        importance = MetricImportance.CRITICAL_IMPORTANCE
+        status = MetricStatus.FAIL_WARN_METRIC_STATUS
+        event_metrics = self.generate_event_metrics()
+
+        event = metrics.Event(
+            name=name,
+            description=description,
+            tags=tags,
+            timestamp=timestamp,
+            importance=importance,
+            status=status,
+            metrics=event_metrics,
+        )
+
+        self.assertEqual(event, event.with_description(description))
+        self.assertEqual(event, event.with_tags(tags))
+        self.assertEqual(event, event.with_timestamp(timestamp))
+        self.assertEqual(event, event.with_importance(importance))
+        self.assertEqual(event, event.with_status(status))
+        self.assertEqual(event, event.with_metrics(event_metrics))
+
+        self.assertTrue(event.name == name)
+        self.assertTrue(event.description == description)
+        self.assertTrue(event.tags == tags)
+        self.assertTrue(event.timestamp == timestamp)
+        self.assertTrue(event.importance == importance)
+        self.assertTrue(event.status == status)
+        self.assertTrue(event.metrics == event_metrics)
+
+
+    def test_event_pack(self) -> None:
+        name = "my_event"
+        description = "event description"
+        tags = ["a tag", "another tag"]
+        timestamp = metrics_utils.Timestamp(secs=1, nanos=2)
+        importance = MetricImportance.CRITICAL_IMPORTANCE
+        status = MetricStatus.FAIL_WARN_METRIC_STATUS
+        event_metrics = self.generate_event_metrics()
+        event = metrics.Event(
+            name=name,
+            description=description,
+            tags=tags,
+            timestamp=timestamp,
+            importance=importance,
+            status=status,
+            metrics=event_metrics,
+        )
+
+        msg = event.pack()
+        self.assertEqual(
+            msg.event_id.id,
+            metrics_utils.pack_uuid_to_proto(
+                event.id))
+        self.assertEqual(msg.name, event.name)
+        self.assertTrue(msg.description == event.description)
+        self.assertTrue(msg.tags == event.tags)
+        assert event.timestamp is not None
+        self.assertEqual(msg.timestamp, event.timestamp.pack())
+        self.assertTrue(msg.importance == getattr(event.importance, "value"))
+        self.assertTrue(msg.status == getattr(event.status, "value"))
+
+        metric_id_uuids = list(map(lambda m: m.id, msg.metrics))
+        for metric in event_metrics:
+            self.assertIn(metrics_utils.pack_uuid_to_proto(metric.id), metric_id_uuids)
+
+        output = metrics_utils.ResimMetricsOutput()
+        event.recursively_pack_into(output)
+        self.assertIn(event.id, output.packed_ids)
+        self.assertEqual(len(output.metrics_msg.events), 1)
+        self.assertEqual(len(output.metrics_msg.job_level_metrics.metrics), 0)
+        self.assertEqual(len(output.metrics_msg.metrics_data), 0)
+        self.assertEqual(output.metrics_msg.events[0], msg)
+
+        # Check no duplication
+        event.recursively_pack_into(output)
+        self.assertEqual(len(output.metrics_msg.events), 1)
+        self.assertEqual(len(output.metrics_msg.job_level_metrics.metrics), 0)
+        self.assertEqual(len(output.metrics_msg.metrics_data), 0)
 
 if __name__ == "__main__":
     unittest.main()

--- a/resim/metrics/python/metrics_utils.py
+++ b/resim/metrics/python/metrics_utils.py
@@ -97,6 +97,10 @@ def pack_uuid_to_proto(uuid_obj: uuid.UUID) -> uuid_pb2.UUID:
     uuid_msg.data = str(uuid_obj)
     return uuid_msg
 
+def pack_uuid_to_metric_id (uuid_obj: uuid.UUID) -> metrics_pb2.MetricID:
+    metric_id = metrics_pb2.MetricId()
+    metric_id.id.CopyFrom(pack_uuid_to_proto(uuid_obj))
+    return metric_id
 
 def pack_series_to_proto(series: np.ndarray,
                          indexed: bool) -> Tuple[metrics_pb2.MetricsDataType,

--- a/resim/metrics/python/metrics_utils.py
+++ b/resim/metrics/python/metrics_utils.py
@@ -97,7 +97,7 @@ def pack_uuid_to_proto(uuid_obj: uuid.UUID) -> uuid_pb2.UUID:
     uuid_msg.data = str(uuid_obj)
     return uuid_msg
 
-def pack_uuid_to_metric_id (uuid_obj: uuid.UUID) -> metrics_pb2.MetricID:
+def pack_uuid_to_metric_id(uuid_obj: uuid.UUID) -> metrics_pb2.MetricID:
     metric_id = metrics_pb2.MetricId()
     metric_id.id.CopyFrom(pack_uuid_to_proto(uuid_obj))
     return metric_id

--- a/resim/metrics/python/metrics_utils_test.py
+++ b/resim/metrics/python/metrics_utils_test.py
@@ -93,6 +93,16 @@ class MetricsUtilsTest(unittest.TestCase):
         # VERIFICATION
         self.assertEqual(uuid.UUID(packed.data), test_uuid)
 
+    def test_pack_uuid_to_metric_id(self) -> None:
+        # SETUP
+        test_uuid = uuid.uuid4()
+
+        # ACTION
+        packed = mu.pack_uuid_to_metric_id(test_uuid)
+
+        # VERIFICATION
+        self.assertEqual(uuid.UUID(packed.id.data), test_uuid)
+
     def test_pack_series_to_proto(self) -> None:
         # SETUP
         inputs = {

--- a/resim/metrics/python/metrics_writer.py
+++ b/resim/metrics/python/metrics_writer.py
@@ -25,6 +25,7 @@ from resim.metrics.python.metrics import (
     GroupedMetricsData,
     SeriesMetricsData,
     ExternalFileMetricsData,
+    Event,
     Metric,
     MetricsData,
     MetricsDataT,
@@ -36,6 +37,7 @@ class ResimMetricsWriter:
     job_id: uuid.UUID
     metrics: Dict[uuid.UUID, Metric]
     metrics_data: Dict[uuid.UUID, MetricsData]
+    events: Dict[uuid.UUID, Event]
 
     names: Set[str]
 
@@ -43,6 +45,7 @@ class ResimMetricsWriter:
         self.job_id = job_id
         self.metrics = {}
         self.metrics_data = {}
+        self.events = {}
         self.names = set()
 
     def add_metrics_data(self, data: MetricsDataT) -> MetricsDataT:
@@ -56,6 +59,16 @@ class ResimMetricsWriter:
         self.names.add(metric.name)
         self.metrics[metric.id] = metric
         return metric
+
+    def base_add_event(self, event: Event) -> Event:
+        assert event.name not in self.names
+        self.names.add(event.name)
+        self.events[event.id] = event
+        return event
+
+    def add_event(self, name: str) -> Event:
+        event = Event(name=name)
+        return self.base_add_event(event)
 
     def add_series_metrics_data(self, name: str) -> SeriesMetricsData:
         metrics_data = SeriesMetricsData(name=name)
@@ -127,6 +140,9 @@ class ResimMetricsWriter:
 
         for metric_data in self.metrics_data.values():
             metric_data.recursively_pack_into(output)
+
+        for event in self.events.values():
+            event.recursively_pack_into(output)
 
         packed_job_id = pack_uuid_to_proto(self.job_id)
         output.metrics_msg.job_id.id.CopyFrom(packed_job_id)

--- a/resim/metrics/python/metrics_writer.py
+++ b/resim/metrics/python/metrics_writer.py
@@ -61,12 +61,28 @@ class ResimMetricsWriter:
         return metric
 
     def base_add_event(self, event: Event) -> Event:
+        """Given an existent event, add to the writer. 
+
+        Args:
+            event (Event): the event to add
+
+        Returns:
+            Event: the added event, for chaining
+        """
         assert event.name not in self.names
         self.names.add(event.name)
         self.events[event.id] = event
         return event
 
     def add_event(self, name: str) -> Event:
+        """Create an add an event with the given name.
+
+        Args:
+            name (str): the name of the event to add
+
+        Returns:
+            Event: the added event, for chaining
+        """
         event = Event(name=name)
         return self.base_add_event(event)
 

--- a/resim/metrics/python/metrics_writer_test.py
+++ b/resim/metrics/python/metrics_writer_test.py
@@ -97,6 +97,7 @@ class TestMetricsWriter(unittest.TestCase):
             .with_should_display(METRIC_DISPLAY)
             .with_importance(METRIC_IMPORTANCE)
             .with_status(METRIC_STATUS)
+            .is_event_metric()
         )
 
         output = self.writer.write()
@@ -581,6 +582,7 @@ class TestMetricsWriter(unittest.TestCase):
             .with_should_display(METRIC_DISPLAY)
             .with_importance(METRIC_IMPORTANCE)
             .with_status(METRIC_STATUS)
+            .is_event_metric()
         )
 
         output = self.writer.write()
@@ -645,6 +647,58 @@ class TestMetricsWriter(unittest.TestCase):
         self.assertIn(metrics_data.id, self.writer.metrics_data)
         self.assertEqual(
             self.writer.metrics_data[metrics_data.id], metrics_data)
+
+    def test_event(self) -> None:
+        # first create a few scalar metrics
+        METRIC_1_NAME = "Scalar metric 1"
+        METRIC_2_NAME = "Scalar metric 2"
+        METRIC_VALUE = 5.0
+
+        metric_1 = (self.writer
+            .add_scalar_metric(METRIC_1_NAME)
+            .with_value(METRIC_VALUE)
+            .is_event_metric())
+        metric_2 = (self.writer
+            .add_scalar_metric(METRIC_2_NAME)
+            .with_value(METRIC_VALUE)
+            .is_event_metric())
+
+        # then create an event
+        EVENT_NAME = "my_event"
+        EVENT_DESCRIPTION = "event description"
+        EVENT_TAGS = ["a tag", "another tag"]
+        EVENT_TIMESTAMP = Timestamp(secs=1, nanos=2)
+        EVENT_IMPORTANCE = MetricImportance.CRITICAL_IMPORTANCE
+        EVENT_STATUS = MetricStatus.FAIL_WARN_METRIC_STATUS
+        (
+            self.writer
+            .add_event(EVENT_NAME)
+            .with_description(EVENT_DESCRIPTION)
+            .with_tags(EVENT_TAGS)
+            .with_timestamp(EVENT_TIMESTAMP)
+            .with_importance(EVENT_IMPORTANCE)
+            .with_status(EVENT_STATUS)
+            .with_metrics([metric_1,metric_2])
+        )
+
+        output = self.writer.write()
+        metrics = output.metrics_msg.job_level_metrics.metrics
+        self.assertEqual(len(output.packed_ids), 3)
+        self.assertEqual(len(metrics), 2)
+        self.assertEqual(len(output.metrics_msg.metrics_data), 0)
+        self.assertEqual(len(output.metrics_msg.events), 1)
+
+        event = output.metrics_msg.events[0]
+        self.assertEqual(event.description, EVENT_DESCRIPTION)
+        self.assertEqual(event.tags, EVENT_TAGS)
+        self.assertEqual(event.name, EVENT_NAME)
+        self.assertEqual(event.importance, EVENT_IMPORTANCE.value)
+        self.assertEqual(event.status, EVENT_STATUS.value)
+        self.assertEqual(event.timestamp.nanos, EVENT_TIMESTAMP.nanos)
+        self.assertEqual(event.timestamp.seconds, EVENT_TIMESTAMP.secs)
+        metric_id_uuids = list(map(lambda m: m.metric_id, metrics))
+        for metric_id in event.metrics:
+            self.assertIn(metric_id, metric_id_uuids)
 
     def tearDown(self) -> None:
         pass

--- a/resim/metrics/python/unpack_metrics_test.py
+++ b/resim/metrics/python/unpack_metrics_test.py
@@ -25,7 +25,8 @@ class UnpackMetricsTest(unittest.TestCase):
 
         unpacked = um.unpack_metrics(
             metrics=test_metrics.job_level_metrics.metrics,
-            metrics_data=test_metrics.metrics_data)
+            metrics_data=test_metrics.metrics_data,
+            events=test_metrics.events)
 
         writer = mw.ResimMetricsWriter(
             job_id=uuid.UUID(
@@ -36,24 +37,35 @@ class UnpackMetricsTest(unittest.TestCase):
         for metric in unpacked.metrics:
             writer.add_metric(metric)
 
+        for event in unpacked.events:
+            writer.base_add_event(event)
+
         repacked = writer.write().metrics_msg
         vmp.validate_job_metrics(repacked)
 
         reunpacked = um.unpack_metrics(
             metrics=repacked.job_level_metrics.metrics,
-            metrics_data=repacked.metrics_data)
+            metrics_data=repacked.metrics_data,
+            events=repacked.events)
 
         reunpacked_metrics_ids = {metric.id for metric in reunpacked.metrics}
         reunpacked_metrics_data_ids = {
             metric_data.id for metric_data in reunpacked.metrics_data}
+        reunpacked_event_ids = {event.id for event in reunpacked.events}
+
         unpacked_metrics_ids = {metric.id for metric in unpacked.metrics}
         unpacked_metrics_data_ids = {
             metric_data.id for metric_data in unpacked.metrics_data}
+        unpacked_event_ids = {event.id for event in unpacked.events}
 
         self.assertEqual(unpacked_metrics_ids, reunpacked_metrics_ids)
         self.assertEqual(
             unpacked_metrics_data_ids,
             reunpacked_metrics_data_ids)
+        self.assertEqual(unpacked_event_ids,reunpacked_event_ids)
+
+        self.assertEqual(unpacked.metrics, reunpacked.metrics)
+        self.assertEqual(unpacked.events, reunpacked.events)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description of change

Extends the ReSim Metrics schema with a list of events, which can reference metrics defined in the metrics collection. This PR also introduces the required changes to the validator to support event validation.

the metrics SDK is updated to support events. 

## Guide to reproduce test results.

```
bazel test //...
```
## Checklist:
- [X] I have self-reviewed this change.
- [X] I have tested this change.
- [X] This change is covered by tests that are already landed, or in this PR.
