### PR TITLE
Events SDK

### DIFF
--- a/resim/metrics/python/metrics.py
+++ b/resim/metrics/python/metrics.py
@@ -29,6 +29,7 @@ from resim.metrics.python.metrics_utils import (
     DoubleFailureDefinition,
     HistogramBucket,
     pack_uuid_to_proto,
+    pack_uuid_to_metric_id,
     pack_series_to_proto,
     MetricImportance,
     MetricStatus)
@@ -1715,7 +1716,7 @@ class Event():
     def pack(self: Event) -> metrics_pb2.Event:
         msg = metrics_pb2.Event()
 
-        msg.metric_id.id.CopyFrom(pack_uuid_to_proto(self.id))
+        msg.event_id.id.CopyFrom(pack_uuid_to_proto(self.id))
         msg.name = self.name
 
         if self.description is not None:
@@ -1728,13 +1729,13 @@ class Event():
             msg.importance = self.importance.value
 
         if self.timestamp is not None:
-            msg.timestamp.CopyFrom(self.start_time.pack())
+            msg.timestamp.CopyFrom(self.timestamp.pack())
 
         if self.tags is not None:
-            msg.tags = self.tags
+            msg.tags.extend(self.tags)
 
         if self.metrics is not None:
-            msg.metrics.extend([m.metric_id for m in self.metrics])
+            msg.metrics.extend([pack_uuid_to_metric_id(m.id) for m in self.metrics])
 
         return msg
 

--- a/resim/metrics/python/metrics.py
+++ b/resim/metrics/python/metrics.py
@@ -1712,9 +1712,8 @@ class Event():
         self.metrics = metrics
         return self
 
-    @abstractmethod
-    def pack(self: MetricT) -> metrics_pb2.Metric:
-        msg = metrics_pb2.Metric()
+    def pack(self: Event) -> metrics_pb2.Event:
+        msg = metrics_pb2.Event()
 
         msg.metric_id.id.CopyFrom(pack_uuid_to_proto(self.id))
         msg.name = self.name
@@ -1728,74 +1727,22 @@ class Event():
         if self.importance is not None:
             msg.importance = self.importance.value
 
-        if self.should_display is not None:
-            msg.should_display = self.should_display
+        if self.timestamp is not None:
+            msg.timestamp.CopyFrom(self.start_time.pack())
 
-        if self.blocking is not None:
-            msg.blocking = self.blocking
+        if self.tags is not None:
+            msg.tags = self.tags
 
-        if self.parent_job_id is not None:
-            msg.job_id.id.CopyFrom(pack_uuid_to_proto(self.parent_job_id))
-
-        if self.order is not None:
-            msg.order = self.order
+        if self.metrics is not None:
+            msg.metrics.extend([m.metric_id for m in self.metrics])
 
         return msg
 
-    @classmethod
-    def unpack_common_fields(cls, msg: metrics_pb2.Metric) -> Metric[Any]:
-        if msg.type == metrics_pb2.MetricType.Value('NO_METRIC_TYPE'):
-            raise ValueError('Cannot unpack with no metric type')
-        if msg.type == metrics_pb2.MetricType.Value(
-                'DOUBLE_SUMMARY_METRIC_TYPE'):
-            unpacked: Metric[Any] = DoubleSummaryMetric(name=msg.name)
-        elif msg.type == metrics_pb2.MetricType.Value('DOUBLE_OVER_TIME_METRIC_TYPE'):
-            unpacked = DoubleOverTimeMetric(name=msg.name)
-        elif msg.type == metrics_pb2.MetricType.Value('LINE_PLOT_METRIC_TYPE'):
-            unpacked = LinePlotMetric(name=msg.name)
-        elif msg.type == metrics_pb2.MetricType.Value('BAR_CHART_METRIC_TYPE'):
-            unpacked = BarChartMetric(name=msg.name)
-        elif msg.type == metrics_pb2.MetricType.Value('STATES_OVER_TIME_METRIC_TYPE'):
-            unpacked = StatesOverTimeMetric(name=msg.name)
-        elif msg.type == metrics_pb2.MetricType.Value('HISTOGRAM_METRIC_TYPE'):
-            unpacked = HistogramMetric(name=msg.name)
-        elif msg.type == metrics_pb2.MetricType.Value('SCALAR_METRIC_TYPE'):
-            unpacked = ScalarMetric(name=msg.name)
-        elif msg.type == metrics_pb2.MetricType.Value('PLOTLY_METRIC_TYPE'):
-            unpacked = PlotlyMetric(name=msg.name)
-        elif msg.type == metrics_pb2.MetricType.Value('IMAGE_METRIC_TYPE'):
-            unpacked = ImageMetric(name=msg.name)
-        else:
-            raise ValueError('Invalid metric type')
-
-        unpacked.id = uuid.UUID(msg.metric_id.id.data)
-        unpacked.description = msg.description
-        unpacked.status = MetricStatus(msg.status)
-        unpacked.importance = MetricImportance(msg.importance)
-        if msg.HasField('should_display'):
-            unpacked.should_display = msg.should_display
-        else:
-            unpacked.should_display = None
-
-        if msg.HasField('blocking'):
-            unpacked.blocking = msg.blocking
-        else:
-            unpacked.blocking = None
-
-        if msg.HasField('job_id'):
-            unpacked.parent_job_id = uuid.UUID(msg.job_id.id.data)
-        else:
-            unpacked.parent_job_id = None
-
-        if msg.HasField('order'):
-            unpacked.order = msg.order
-        else:
-            unpacked.order = None
-
-        return unpacked
-
-    @abstractmethod
     def recursively_pack_into(
             self,
             metrics_output: ResimMetricsOutput) -> None:
-        raise NotImplementedError()
+        if self.id in metrics_output.packed_ids:
+            return
+        metrics_output.packed_ids.add(self.id)
+
+        metrics_output.metrics_msg.events.extend([self.pack()])

--- a/resim/metrics/python/metrics.py
+++ b/resim/metrics/python/metrics.py
@@ -1700,12 +1700,16 @@ class Event():
         self.importance = importance
         return self
 
-    def with_should_display(self: MetricT, should_display: bool) -> MetricT:
-        self.should_display = should_display
+    def with_tags(self: MetricT, tags: List[str]) -> MetricT:
+        self.tags = tags
         return self
 
-    def with_blocking(self: MetricT, blocking: bool) -> MetricT:
-        self.blocking = blocking
+    def with_timestamp(self: MetricT, timestamp: Timestamp) -> MetricT:
+        self.timestamp = timestamp
+        return self
+
+    def with_metrics(self: MetricT, metrics: List[Metric]) -> MetricT:
+        self.metrics = metrics
         return self
 
     @abstractmethod

--- a/resim/metrics/python/metrics_test.py
+++ b/resim/metrics/python/metrics_test.py
@@ -1665,7 +1665,7 @@ class MetricsTest(unittest.TestCase):
             value=24.0)
         metric_2 = metrics.ScalarMetric(
             name="test_metric_2",
-            value=24.0)
+            value=48.0)
 
         event = metrics.Event(
             name="my_event",

--- a/resim/metrics/python/metrics_test.py
+++ b/resim/metrics/python/metrics_test.py
@@ -1771,8 +1771,25 @@ class MetricsTest(unittest.TestCase):
         self.assertEqual(msg.timestamp, event.timestamp.pack())
         self.assertTrue(msg.importance == getattr(event.importance, "value"))
         self.assertTrue(msg.status == getattr(event.status, "value"))
-        # here. Need to figure out how to compare the metrics
-        # self.assertTrue(msg.metrics == event_metrics)
+
+        metric_id_uuids = list(map(lambda m: m.id, msg.metrics))
+        for metric in event_metrics:
+            self.assertIn(metrics_utils.pack_uuid_to_proto(metric.id), metric_id_uuids)
+
+        # output = metrics_utils.ResimMetricsOutput()
+        # event.recursively_pack_into(output)
+        # self.assertIn(event.id, output.packed_ids)
+        # self.assertEqual(len(output.metrics_msg.job_level_metrics.metrics), 1)
+        # self.assertEqual(len(output.metrics_msg.metrics_data), 1)
+        # ids = [uuid.UUID(data.metrics_data_id.id.data)
+        #         for data in output.metrics_msg.metrics_data]
+        # self.assertIn(image_data.id, ids)
+        # self.assertEqual(output.metrics_msg.job_level_metrics.metrics[0], msg)
+
+        # # Check no duplication
+        # metric.recursively_pack_into(output)
+        # self.assertEqual(len(output.metrics_msg.job_level_metrics.metrics), 1)
+        # self.assertEqual(len(output.metrics_msg.metrics_data), 1)
 
 if __name__ == "__main__":
     unittest.main()

--- a/resim/metrics/python/metrics_test.py
+++ b/resim/metrics/python/metrics_test.py
@@ -1776,20 +1776,19 @@ class MetricsTest(unittest.TestCase):
         for metric in event_metrics:
             self.assertIn(metrics_utils.pack_uuid_to_proto(metric.id), metric_id_uuids)
 
-        # output = metrics_utils.ResimMetricsOutput()
-        # event.recursively_pack_into(output)
-        # self.assertIn(event.id, output.packed_ids)
-        # self.assertEqual(len(output.metrics_msg.job_level_metrics.metrics), 1)
-        # self.assertEqual(len(output.metrics_msg.metrics_data), 1)
-        # ids = [uuid.UUID(data.metrics_data_id.id.data)
-        #         for data in output.metrics_msg.metrics_data]
-        # self.assertIn(image_data.id, ids)
-        # self.assertEqual(output.metrics_msg.job_level_metrics.metrics[0], msg)
+        output = metrics_utils.ResimMetricsOutput()
+        event.recursively_pack_into(output)
+        self.assertIn(event.id, output.packed_ids)
+        self.assertEqual(len(output.metrics_msg.events), 1)
+        self.assertEqual(len(output.metrics_msg.job_level_metrics.metrics), 0)
+        self.assertEqual(len(output.metrics_msg.metrics_data), 0)
+        self.assertEqual(output.metrics_msg.events[0], msg)
 
-        # # Check no duplication
-        # metric.recursively_pack_into(output)
-        # self.assertEqual(len(output.metrics_msg.job_level_metrics.metrics), 1)
-        # self.assertEqual(len(output.metrics_msg.metrics_data), 1)
+        # Check no duplication
+        event.recursively_pack_into(output)
+        self.assertEqual(len(output.metrics_msg.events), 1)
+        self.assertEqual(len(output.metrics_msg.job_level_metrics.metrics), 0)
+        self.assertEqual(len(output.metrics_msg.metrics_data), 0)
 
 if __name__ == "__main__":
     unittest.main()

--- a/resim/metrics/python/metrics_utils.py
+++ b/resim/metrics/python/metrics_utils.py
@@ -97,6 +97,10 @@ def pack_uuid_to_proto(uuid_obj: uuid.UUID) -> uuid_pb2.UUID:
     uuid_msg.data = str(uuid_obj)
     return uuid_msg
 
+def pack_uuid_to_metric_id (uuid_obj: uuid.UUID) -> metrics_pb2.MetricID:
+    metric_id = metrics_pb2.MetricId()
+    metric_id.id.CopyFrom(pack_uuid_to_proto(uuid_obj))
+    return metric_id
 
 def pack_series_to_proto(series: np.ndarray,
                          indexed: bool) -> Tuple[metrics_pb2.MetricsDataType,

--- a/resim/metrics/python/metrics_utils_test.py
+++ b/resim/metrics/python/metrics_utils_test.py
@@ -93,6 +93,16 @@ class MetricsUtilsTest(unittest.TestCase):
         # VERIFICATION
         self.assertEqual(uuid.UUID(packed.data), test_uuid)
 
+    def test_pack_uuid_to_metric_id(self) -> None:
+        # SETUP
+        test_uuid = uuid.uuid4()
+
+        # ACTION
+        packed = mu.pack_uuid_to_metric_id(test_uuid)
+
+        # VERIFICATION
+        self.assertEqual(uuid.UUID(packed.id.data), test_uuid)
+
     def test_pack_series_to_proto(self) -> None:
         # SETUP
         inputs = {

--- a/resim/metrics/python/metrics_writer.py
+++ b/resim/metrics/python/metrics_writer.py
@@ -117,9 +117,6 @@ class ResimMetricsWriter:
         self.add_metrics_data(metrics_data)
         return metrics_data
 
-    def get_metric_name_ids(self) -> Dict[str, uuid.UUID]:
-        return {metric.name: metric.id for metric in self.metrics.values()}
-    
     def write(self) -> ResimMetricsOutput:
         output = ResimMetricsOutput()
 

--- a/resim/metrics/python/metrics_writer.py
+++ b/resim/metrics/python/metrics_writer.py
@@ -117,6 +117,9 @@ class ResimMetricsWriter:
         self.add_metrics_data(metrics_data)
         return metrics_data
 
+    def get_metric_name_ids(self) -> Dict[str, uuid.UUID]:
+        return {metric.name: metric.id for metric in self.metrics.values()}
+    
     def write(self) -> ResimMetricsOutput:
         output = ResimMetricsOutput()
 

--- a/resim/metrics/python/metrics_writer.py
+++ b/resim/metrics/python/metrics_writer.py
@@ -25,6 +25,7 @@ from resim.metrics.python.metrics import (
     GroupedMetricsData,
     SeriesMetricsData,
     ExternalFileMetricsData,
+    Event,
     Metric,
     MetricsData,
     MetricsDataT,
@@ -36,6 +37,7 @@ class ResimMetricsWriter:
     job_id: uuid.UUID
     metrics: Dict[uuid.UUID, Metric]
     metrics_data: Dict[uuid.UUID, MetricsData]
+    events: Dict[uuid.UUID, Event]
 
     names: Set[str]
 
@@ -43,6 +45,7 @@ class ResimMetricsWriter:
         self.job_id = job_id
         self.metrics = {}
         self.metrics_data = {}
+        self.events = {}
         self.names = set()
 
     def add_metrics_data(self, data: MetricsDataT) -> MetricsDataT:
@@ -56,6 +59,16 @@ class ResimMetricsWriter:
         self.names.add(metric.name)
         self.metrics[metric.id] = metric
         return metric
+
+    def base_add_event(self, event: Event) -> Event:
+        assert event.name not in self.names
+        self.names.add(event.name)
+        self.events[event.id] = event
+        return event
+    
+    def add_event(self, name: str) -> Event:
+        event = Event(name=name)
+        return self.base_add_event(event)
 
     def add_series_metrics_data(self, name: str) -> SeriesMetricsData:
         metrics_data = SeriesMetricsData(name=name)
@@ -127,6 +140,9 @@ class ResimMetricsWriter:
 
         for metric_data in self.metrics_data.values():
             metric_data.recursively_pack_into(output)
+
+        for event in self.events.values():
+            event.recursively_pack_into(output)
 
         packed_job_id = pack_uuid_to_proto(self.job_id)
         output.metrics_msg.job_id.id.CopyFrom(packed_job_id)

--- a/resim/metrics/python/metrics_writer.py
+++ b/resim/metrics/python/metrics_writer.py
@@ -65,7 +65,7 @@ class ResimMetricsWriter:
         self.names.add(event.name)
         self.events[event.id] = event
         return event
-    
+
     def add_event(self, name: str) -> Event:
         event = Event(name=name)
         return self.base_add_event(event)

--- a/resim/metrics/python/metrics_writer_test.py
+++ b/resim/metrics/python/metrics_writer_test.py
@@ -653,16 +653,15 @@ class TestMetricsWriter(unittest.TestCase):
         METRIC_1_NAME = "Scalar metric 1"
         METRIC_2_NAME = "Scalar metric 2"
         METRIC_VALUE = 5.0
-        EVENT_METRIC = True
 
         metric_1 = (self.writer
             .add_scalar_metric(METRIC_1_NAME)
             .with_value(METRIC_VALUE)
-            .with_event_metric(EVENT_METRIC))
+            .is_event_metric())
         metric_2 = (self.writer
             .add_scalar_metric(METRIC_2_NAME)
             .with_value(METRIC_VALUE)
-            .with_event_metric(EVENT_METRIC))
+            .is_event_metric())
 
         # then create an event
         EVENT_NAME = "my_event"

--- a/resim/metrics/python/metrics_writer_test.py
+++ b/resim/metrics/python/metrics_writer_test.py
@@ -654,6 +654,58 @@ class TestMetricsWriter(unittest.TestCase):
         self.assertEqual(
             self.writer.metrics_data[metrics_data.id], metrics_data)
 
+    def test_event(self) -> None:
+        # first create a few scalar metrics
+        METRIC_1_NAME = "Scalar metric 1"
+        METRIC_2_NAME = "Scalar metric 2"
+        METRIC_VALUE = 5.0
+        EVENT_METRIC = True
+
+        metric_1 = (self.writer
+            .add_scalar_metric(METRIC_1_NAME)
+            .with_value(METRIC_VALUE)
+            .with_event_metric(EVENT_METRIC))
+        metric_2 = (self.writer
+            .add_scalar_metric(METRIC_2_NAME)
+            .with_value(METRIC_VALUE)
+            .with_event_metric(EVENT_METRIC))
+
+        # then create an event
+        EVENT_NAME = "my_event"
+        EVENT_DESCRIPTION = "event description"
+        EVENT_TAGS = ["a tag", "another tag"]
+        EVENT_TIMESTAMP = Timestamp(secs=1, nanos=2)
+        EVENT_IMPORTANCE = MetricImportance.CRITICAL_IMPORTANCE
+        EVENT_STATUS = MetricStatus.FAIL_WARN_METRIC_STATUS
+        (
+            self.writer
+            .add_event(EVENT_NAME)
+            .with_description(EVENT_DESCRIPTION)
+            .with_tags(EVENT_TAGS)
+            .with_timestamp(EVENT_TIMESTAMP)
+            .with_importance(EVENT_IMPORTANCE)
+            .with_status(EVENT_STATUS)
+            .with_metrics([metric_1,metric_2])
+        )
+
+        output = self.writer.write()
+        metrics = output.metrics_msg.job_level_metrics.metrics
+        self.assertEqual(len(output.packed_ids), 3)
+        self.assertEqual(len(metrics), 2)
+        self.assertEqual(len(output.metrics_msg.metrics_data), 0)
+        self.assertEqual(len(output.metrics_msg.events), 1)
+
+        event = output.metrics_msg.events[0]
+        self.assertEqual(event.description, EVENT_DESCRIPTION)
+        self.assertEqual(event.tags, EVENT_TAGS)
+        self.assertEqual(event.name, EVENT_NAME)
+        self.assertEqual(event.importance, EVENT_IMPORTANCE.value)
+        self.assertEqual(event.status, EVENT_STATUS.value)
+        self.assertEqual(event.timestamp.nanos, EVENT_TIMESTAMP.nanos)
+        self.assertEqual(event.timestamp.seconds, EVENT_TIMESTAMP.secs)
+        metric_id_uuids = list(map(lambda m: m.metric_id, metrics))
+        for metric_id in event.metrics:
+            self.assertIn(metric_id, metric_id_uuids)
 
     def tearDown(self) -> None:
         pass

--- a/resim/metrics/python/metrics_writer_test.py
+++ b/resim/metrics/python/metrics_writer_test.py
@@ -654,13 +654,7 @@ class TestMetricsWriter(unittest.TestCase):
         self.assertEqual(
             self.writer.metrics_data[metrics_data.id], metrics_data)
 
-    def test_get_name_id_map(self) -> None:
-        """Test that we can get a name to id map."""
-        NAME = "test_metrics_data"
-        metric = self.writer.add_external_file_metrics_data(name=NAME)
-        name_id_map = self.writer.get_name_id_map()
-        self.assertEqual(name_id_map, {NAME: metrics_data.id})
-    
+
     def tearDown(self) -> None:
         pass
 

--- a/resim/metrics/python/metrics_writer_test.py
+++ b/resim/metrics/python/metrics_writer_test.py
@@ -654,6 +654,13 @@ class TestMetricsWriter(unittest.TestCase):
         self.assertEqual(
             self.writer.metrics_data[metrics_data.id], metrics_data)
 
+    def test_get_name_id_map(self) -> None:
+        """Test that we can get a name to id map."""
+        NAME = "test_metrics_data"
+        metric = self.writer.add_external_file_metrics_data(name=NAME)
+        name_id_map = self.writer.get_name_id_map()
+        self.assertEqual(name_id_map, {NAME: metrics_data.id})
+    
     def tearDown(self) -> None:
         pass
 

--- a/resim/metrics/python/unpack_metrics.py
+++ b/resim/metrics/python/unpack_metrics.py
@@ -107,7 +107,7 @@ def unpack_metrics(*,
             {metrics_data.name for metrics_data in unpacked_metrics_data} |
             {events.name for events in unpacked_events})
 
-    # Enforce name uniqueness (events don't count)
+    # Enforce name uniqueness
     assert len(names) == len(unpacked_metrics) + len(unpacked_metrics_data) + len(unpacked_events)
 
     return UnpackedMetrics(

--- a/resim/metrics/python/unpack_metrics.py
+++ b/resim/metrics/python/unpack_metrics.py
@@ -22,6 +22,7 @@ import resim.utils.proto.uuid_pb2 as uuid_proto
 from resim.metrics.python.metrics_utils import (
     Timestamp,
     MetricStatus,
+    MetricImportance,
     DoubleFailureDefinition,
     HistogramBucket)
 from resim.metrics.python.metrics import (
@@ -37,6 +38,7 @@ from resim.metrics.python.metrics import (
     GroupedMetricsData,
     SeriesMetricsData,
     ExternalFileMetricsData,
+    Event,
     Metric,
     MetricsData)
 
@@ -46,16 +48,18 @@ class UnpackedMetrics:
     """A class representing unpacked metrics."""
     metrics: list[Metric]
     metrics_data: list[MetricsData]
+    events: list[Event]
     names: set[str]
 
 
 def unpack_metrics(*,
                    metrics: list[mp.Metric],
-                   metrics_data: list[mp.MetricsData]) -> UnpackedMetrics:
-    """The main unpacker for metrics and metrics data
+                   metrics_data: list[mp.MetricsData],
+                   events: list[mp.Event]) -> UnpackedMetrics:
+    """The main unpacker for metrics, metrics data, and events
 
-    This function reads a list of metrics and metrics data protobuf messages and
-    unpacks them into Metric and MetricsData classes wrapped in the
+    This function reads a list of metrics, metrics data, and event protobuf messages and
+    unpacks them into Metric, MetricsData, and Event classes wrapped in the
     UnpackedMetrics class.
     """
 
@@ -64,6 +68,12 @@ def unpack_metrics(*,
             md.metrics_data_id.id): md for md in metrics_data}
 
     id_to_unpacked_metrics_data: dict[uuid.UUID, MetricsData] = {}
+    
+    id_to_metrics_map = {
+        _unpack_uuid(
+            m.metric_id.id): m for m in metrics}
+
+    id_to_unpacked_metrics: dict[uuid.UUID, Metric] = {}
 
     def recursive_unpack_metrics_data(current_id: uuid.UUID) -> None:
         if current_id in id_to_unpacked_metrics_data:
@@ -89,14 +99,23 @@ def unpack_metrics(*,
 
     unpacked_metrics_data = list(id_to_unpacked_metrics_data.values())
     names = ({metric.name for metric in unpacked_metrics} |
-             {metrics_data.name for metrics_data in unpacked_metrics_data})
+             {metrics_data.name for metrics_data in unpacked_metrics_data} |
+             {events.name for events in unpacked_events})
 
-    # Enforce name uniqueness
+    unpacked_events = []
+    for event in events:
+        unpacked_events.append(
+            _unpack_event(
+                event,
+                id_to_unpacked_metrics))
+    
+    # Enforce name uniqueness (events don't count)
     assert len(names) == len(unpacked_metrics) + len(unpacked_metrics_data)
 
     return UnpackedMetrics(
         metrics=unpacked_metrics,
         metrics_data=unpacked_metrics_data,
+        events=unpacked_events,
         names=names)
 
 
@@ -356,3 +375,12 @@ def _unpack_image_metric(metric: mp.Metric,
     data = id_to_unpacked_metrics_data[_unpack_uuid(image_data.image_data_id.id)]
     unpacked.with_image_data(
         data)
+
+def _unpack_event(msg: mp.Event,
+                  id_to_unpacked_metrics: dict[uuid.UUID, Metric]) -> Event:
+    unpacked = Event(name=msg.name)
+    unpacked.id = uuid.UUID(msg.event_id.id.data)
+    unpacked.description = msg.description
+    unpacked.status = MetricStatus(msg.status)
+    unpacked.importance = MetricImportance(msg.importance)
+    return unpacked

--- a/resim/metrics/python/unpack_metrics.py
+++ b/resim/metrics/python/unpack_metrics.py
@@ -391,5 +391,5 @@ def _unpack_event(msg: mp.Event,
     for metric_id in msg.metrics:
         metrics.append(id_to_unpacked_metrics[_unpack_uuid(metric_id.id)])
     unpacked.with_metrics(metrics)
-    
+
     return unpacked

--- a/resim/metrics/python/unpack_metrics_test.py
+++ b/resim/metrics/python/unpack_metrics_test.py
@@ -25,7 +25,8 @@ class UnpackMetricsTest(unittest.TestCase):
 
         unpacked = um.unpack_metrics(
             metrics=test_metrics.job_level_metrics.metrics,
-            metrics_data=test_metrics.metrics_data)
+            metrics_data=test_metrics.metrics_data,
+            events=test_metrics.events)
 
         writer = mw.ResimMetricsWriter(
             job_id=uuid.UUID(
@@ -35,25 +36,32 @@ class UnpackMetricsTest(unittest.TestCase):
 
         for metric in unpacked.metrics:
             writer.add_metric(metric)
+        
+        for event in unpacked.events:
+            writer.base_add_event(event)
 
         repacked = writer.write().metrics_msg
         vmp.validate_job_metrics(repacked)
 
         reunpacked = um.unpack_metrics(
             metrics=repacked.job_level_metrics.metrics,
-            metrics_data=repacked.metrics_data)
+            metrics_data=repacked.metrics_data,
+            events=repacked.events)
 
         reunpacked_metrics_ids = {metric.id for metric in reunpacked.metrics}
         reunpacked_metrics_data_ids = {
             metric_data.id for metric_data in reunpacked.metrics_data}
+        repacked_event_ids = {event.id for event in reunpacked.events}
         unpacked_metrics_ids = {metric.id for metric in unpacked.metrics}
         unpacked_metrics_data_ids = {
             metric_data.id for metric_data in unpacked.metrics_data}
+        unpacked_event_ids = {event.id for event in unpacked.events}
 
         self.assertEqual(unpacked_metrics_ids, reunpacked_metrics_ids)
         self.assertEqual(
             unpacked_metrics_data_ids,
             reunpacked_metrics_data_ids)
+        self.assertEqual(unpacked_event_ids,repacked_event_ids)
 
 
 if __name__ == "__main__":

--- a/resim/metrics/python/unpack_metrics_test.py
+++ b/resim/metrics/python/unpack_metrics_test.py
@@ -36,7 +36,7 @@ class UnpackMetricsTest(unittest.TestCase):
 
         for metric in unpacked.metrics:
             writer.add_metric(metric)
-        
+
         for event in unpacked.events:
             writer.base_add_event(event)
 
@@ -62,6 +62,9 @@ class UnpackMetricsTest(unittest.TestCase):
             unpacked_metrics_data_ids,
             reunpacked_metrics_data_ids)
         self.assertEqual(unpacked_event_ids,repacked_event_ids)
+        
+        self.assertEqual(unpacked.metrics, reunpacked.metrics)
+        self.assertEqual(unpacked.events, reunpacked.events)
 
 
 if __name__ == "__main__":

--- a/resim/metrics/python/unpack_metrics_test.py
+++ b/resim/metrics/python/unpack_metrics_test.py
@@ -52,7 +52,7 @@ class UnpackMetricsTest(unittest.TestCase):
         reunpacked_metrics_data_ids = {
             metric_data.id for metric_data in reunpacked.metrics_data}
         reunpacked_event_ids = {event.id for event in reunpacked.events}
-        
+
         unpacked_metrics_ids = {metric.id for metric in unpacked.metrics}
         unpacked_metrics_data_ids = {
             metric_data.id for metric_data in unpacked.metrics_data}

--- a/resim/metrics/python/unpack_metrics_test.py
+++ b/resim/metrics/python/unpack_metrics_test.py
@@ -51,7 +51,8 @@ class UnpackMetricsTest(unittest.TestCase):
         reunpacked_metrics_ids = {metric.id for metric in reunpacked.metrics}
         reunpacked_metrics_data_ids = {
             metric_data.id for metric_data in reunpacked.metrics_data}
-        repacked_event_ids = {event.id for event in reunpacked.events}
+        reunpacked_event_ids = {event.id for event in reunpacked.events}
+        
         unpacked_metrics_ids = {metric.id for metric in unpacked.metrics}
         unpacked_metrics_data_ids = {
             metric_data.id for metric_data in unpacked.metrics_data}
@@ -61,7 +62,7 @@ class UnpackMetricsTest(unittest.TestCase):
         self.assertEqual(
             unpacked_metrics_data_ids,
             reunpacked_metrics_data_ids)
-        self.assertEqual(unpacked_event_ids,repacked_event_ids)
+        self.assertEqual(unpacked_event_ids,reunpacked_event_ids)
 
         self.assertEqual(unpacked.metrics, reunpacked.metrics)
         self.assertEqual(unpacked.events, reunpacked.events)

--- a/resim/metrics/python/unpack_metrics_test.py
+++ b/resim/metrics/python/unpack_metrics_test.py
@@ -62,7 +62,7 @@ class UnpackMetricsTest(unittest.TestCase):
             unpacked_metrics_data_ids,
             reunpacked_metrics_data_ids)
         self.assertEqual(unpacked_event_ids,repacked_event_ids)
-        
+
         self.assertEqual(unpacked.metrics, reunpacked.metrics)
         self.assertEqual(unpacked.events, reunpacked.events)
 


### PR DESCRIPTION
## Description of change

Extends the metrics SDK to support events.

## Guide to reproduce test results.

```
bazel test //...
```

## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
