### PR TITLE
Fix python auth missing directory & expired tokens

### DIFF
--- a/resim/auth/python/BUILD
+++ b/resim/auth/python/BUILD
@@ -14,6 +14,7 @@ py_library(
     deps = [
         requirement("polling2"),
         requirement("requests"),
+        ":check_expiration",
     ],
 )
 
@@ -22,5 +23,21 @@ py_test(
     srcs = ["device_code_client_test.py"],
     deps = [
         ":device_code_client",
+    ],
+)
+
+py_library(
+    name = "check_expiration",
+    srcs = ["check_expiration.py"],
+    visibility = ["//visibility:public"],
+    deps = [
+    ],
+)
+
+py_test(
+    name = "check_expiration_test",
+    srcs = ["check_expiration_test.py"],
+    deps = [
+        ":check_expiration",
     ],
 )

--- a/resim/auth/python/check_expiration.py
+++ b/resim/auth/python/check_expiration.py
@@ -18,9 +18,7 @@ def add_expiration_time(*, token_data: dict) -> None:
     Args:
       token_data: A token data dict, as returned upon successful
                   resolution of the device code flow.
-
     """
-
     DURATION_KEY = "expires_in"
     if not DURATION_KEY in token_data:
         raise ValueError("No expiration lifetime in token data")
@@ -39,9 +37,7 @@ def is_expired(*, token_data: dict) -> bool:
     Args:
       token_data: A token data dict, as returned upon successful
                   resolution of the device code flow.
-
     """
-
     if not _KEY in token_data:
         return True
     return datetime.now(timezone.utc) + timedelta(hours=1) > datetime.fromisoformat(

--- a/resim/auth/python/check_expiration.py
+++ b/resim/auth/python/check_expiration.py
@@ -1,0 +1,49 @@
+# Copyright 2024 ReSim, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+from datetime import datetime, timedelta, timezone
+
+_KEY = "expires_at"
+
+
+def add_expiration_time(*, token_data: dict) -> None:
+    """Adds the "expires_at" key to token data.
+
+    Adds an "expires_at" key computed from the current time and the
+    "expires_in" key in the token_data dict.
+
+    Args:
+      token_data: A token data dict, as returned upon successful
+                  resolution of the device code flow.
+
+    """
+
+    DURATION_KEY = "expires_in"
+    if not DURATION_KEY in token_data:
+        raise ValueError("No expiration lifetime in token data")
+    token_data[_KEY] = (
+        datetime.now(timezone.utc) + timedelta(seconds=token_data[DURATION_KEY])
+    ).isoformat()
+
+
+def is_expired(*, token_data: dict) -> bool:
+    """Checks whether the given token is expired.
+
+    Defaults to true if the "expires_at" key is not present in the
+    token_data. Otherwise, returns expired if we're within 1 hour of
+    the nominal expiration time.
+
+    Args:
+      token_data: A token data dict, as returned upon successful
+                  resolution of the device code flow.
+
+    """
+
+    if not _KEY in token_data:
+        return True
+    return datetime.now(timezone.utc) + timedelta(hours=1) > datetime.fromisoformat(
+        token_data[_KEY]
+    )

--- a/resim/auth/python/check_expiration_test.py
+++ b/resim/auth/python/check_expiration_test.py
@@ -1,0 +1,84 @@
+# Copyright 2024 ReSim, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+"""
+Unit test for our client token expiration logic.
+"""
+
+import unittest
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import resim.auth.python.check_expiration as check_exp
+
+
+class CheckExpirationTest(unittest.TestCase):
+    """
+    Our tests for this library.
+    """
+
+    NOW_MOCK = datetime(1918, 11, 11, hour=11, minute=11, tzinfo=timezone.utc)
+
+    @patch("__main__.check_exp.datetime")
+    def test_add_expiration_time(self, mock_now) -> None:
+        # SETUP
+        mock_now.now.return_value = self.NOW_MOCK
+
+        lifetime_s = 34
+        token_data = {"expires_in": lifetime_s}
+
+        # ACTION
+        check_exp.add_expiration_time(token_data=token_data)
+
+        # VERIFICATION
+        self.assertIn("expires_at", token_data)
+        self.assertEqual(
+            datetime.fromisoformat(token_data["expires_at"])
+            - timedelta(seconds=lifetime_s),
+            self.NOW_MOCK,
+        )
+
+        # ACTION / VERIFICATION
+        with self.assertRaises(ValueError):
+            check_exp.add_expiration_time(token_data={})
+
+    @patch("__main__.check_exp.datetime")
+    def test_is_expired(self, mock_now) -> None:
+        # SETUP
+        mock_now.now.return_value = self.NOW_MOCK
+        mock_now.fromisoformat.side_effect = datetime.fromisoformat
+
+        lifetime_s = 7200
+        token_data = {"expires_in": lifetime_s}
+
+        # ACTION / VERIFICATION
+        self.assertTrue(check_exp.is_expired(token_data=token_data))
+
+        # SETUP
+        check_exp.add_expiration_time(token_data=token_data)
+
+        # Some time passes
+        ONE_HOUR_S = 3600
+        mock_now.now.return_value = self.NOW_MOCK + timedelta(
+            seconds=(lifetime_s - ONE_HOUR_S)
+        )
+
+        # ACTION / VERIFICATION
+        self.assertFalse(check_exp.is_expired(token_data=token_data))
+
+        # SETUP
+        # Some more time passes
+        ONE_HOUR_S = 3600
+        mock_now.now.return_value = self.NOW_MOCK + timedelta(
+            seconds=(lifetime_s - ONE_HOUR_S + 1)
+        )
+
+        # ACTION / VERIFICATION
+        self.assertTrue(check_exp.is_expired(token_data=token_data))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/resim/auth/python/check_expiration_test.py
+++ b/resim/auth/python/check_expiration_test.py
@@ -10,7 +10,8 @@ Unit test for our client token expiration logic.
 
 import unittest
 from datetime import datetime, timedelta, timezone
-from unittest.mock import patch
+from typing import Any
+from unittest.mock import MagicMock, patch
 
 import resim.auth.python.check_expiration as check_exp
 
@@ -23,12 +24,13 @@ class CheckExpirationTest(unittest.TestCase):
     NOW_MOCK = datetime(1918, 11, 11, hour=11, minute=11, tzinfo=timezone.utc)
 
     @patch("__main__.check_exp.datetime")
-    def test_add_expiration_time(self, mock_now) -> None:
+    def test_add_expiration_time(self, mock_now: MagicMock) -> None:
+        print(f"TYPE:{type(mock_now)}")
         # SETUP
         mock_now.now.return_value = self.NOW_MOCK
 
         lifetime_s = 34
-        token_data = {"expires_in": lifetime_s}
+        token_data: dict[str, Any] = {"expires_in": lifetime_s}
 
         # ACTION
         check_exp.add_expiration_time(token_data=token_data)
@@ -46,7 +48,7 @@ class CheckExpirationTest(unittest.TestCase):
             check_exp.add_expiration_time(token_data={})
 
     @patch("__main__.check_exp.datetime")
-    def test_is_expired(self, mock_now) -> None:
+    def test_is_expired(self, mock_now: MagicMock) -> None:
         # SETUP
         mock_now.now.return_value = self.NOW_MOCK
         mock_now.fromisoformat.side_effect = datetime.fromisoformat

--- a/resim/auth/python/device_code_client.py
+++ b/resim/auth/python/device_code_client.py
@@ -18,6 +18,8 @@ from http import HTTPStatus
 import polling2
 import requests
 
+import resim.auth.python.check_expiration as check_exp
+
 DEFAULT_SCOPE = "offline_access"
 DEFAULT_AUDIENCE = "https://api.resim.ai"
 DEFAULT_CACHE_LOCATION = pathlib.Path.home() / ".resim" / "token.json"
@@ -58,16 +60,17 @@ class DeviceCodeClient:
             assert (
                 self._cache_location.is_file()
             ), "Directory detected in cache location!"
-            self._cache_location.parent.mkdir(parents=True, exist_ok=True)
             with open(self._cache_location, "r", encoding="utf-8") as cache:
                 self._token = json.load(cache)
-        elif self._token is None:
+
+        if self._token is None or check_exp.is_expired(token_data=self._token):
             self._token = _get_new_token(
                 domain=self._domain,
                 client_id=self._client_id,
                 scope=self._scope,
                 audience=self._audience,
             )
+            self._cache_location.parent.mkdir(parents=True, exist_ok=True)
             with open(self._cache_location, "w", encoding="utf-8") as cache:
                 cache.write(json.dumps(self._token, indent=4))
         return self._token
@@ -112,5 +115,7 @@ Please navigate to: {device_code_data["verification_uri_complete"]}
     token_response = polling2.poll(poll_once, step=polling_interval, timeout=timeout)
 
     token_data: dict[str, typing.Any] = token_response.json()
+
+    check_exp.add_expiration_time(token_data=token_data)
 
     return token_data

--- a/resim/auth/python/device_code_client.py
+++ b/resim/auth/python/device_code_client.py
@@ -58,6 +58,7 @@ class DeviceCodeClient:
             assert (
                 self._cache_location.is_file()
             ), "Directory detected in cache location!"
+            self._cache_location.parent.mkdir(parents=True, exist_ok=True)
             with open(self._cache_location, "r", encoding="utf-8") as cache:
                 self._token = json.load(cache)
         elif self._token is None:

--- a/resim/auth/python/device_code_client_test.py
+++ b/resim/auth/python/device_code_client_test.py
@@ -37,7 +37,7 @@ REFRESH_TOKEN = (
 class MockServer:
     """A mock server to be patched into our DeviceCodeClient unit test below"""
 
-    def __init__(self, *, testcase: unittest.TestCase, expires_in=7200):
+    def __init__(self, *, testcase: unittest.TestCase, expires_in: int = 7200):
         self._device_code = self._generate_device_code()
         self._user_code = self._generate_user_code()
         self._authenticated = False

--- a/resim/auth/python/device_code_client_test.py
+++ b/resim/auth/python/device_code_client_test.py
@@ -94,7 +94,7 @@ class MockServer:
             "device_code": self._device_code,
             "user_code": self._user_code,
             "verification_uri": verification_uri,
-            "expires_in": self._expires_in,
+            "expires_in": 900,
             "interval": 0,  # Since this is a unit test
             "verification_uri_complete": f"{verification_uri}?user_code={self._user_code}",
         }

--- a/resim/auth/python/device_code_client_test.py
+++ b/resim/auth/python/device_code_client_test.py
@@ -188,6 +188,9 @@ class DeviceCodeClientTest(unittest.TestCase):
             self.assertEqual(server.num_token_requests, 2)
 
             # Test expiration
+            # We expect two separate requests for two separate
+            # "get_jwt()" calls because the token expires
+            # instantly due to the one hour buffer.
             server = MockServer(testcase=self, expires_in=3599)
             client.refresh()
             token = client.get_jwt()

--- a/resim/auth/python/device_code_client_test.py
+++ b/resim/auth/python/device_code_client_test.py
@@ -37,12 +37,13 @@ REFRESH_TOKEN = (
 class MockServer:
     """A mock server to be patched into our DeviceCodeClient unit test below"""
 
-    def __init__(self, *, testcase: unittest.TestCase):
+    def __init__(self, *, testcase: unittest.TestCase, expires_in=7200):
         self._device_code = self._generate_device_code()
         self._user_code = self._generate_user_code()
         self._authenticated = False
         self._testcase = testcase
         self._scope = ""
+        self._expires_in = expires_in
 
         self.num_device_code_requests = 0
         self.num_token_requests = 0
@@ -93,7 +94,7 @@ class MockServer:
             "device_code": self._device_code,
             "user_code": self._user_code,
             "verification_uri": verification_uri,
-            "expires_in": 900,
+            "expires_in": self._expires_in,
             "interval": 0,  # Since this is a unit test
             "verification_uri_complete": f"{verification_uri}?user_code={self._user_code}",
         }
@@ -125,7 +126,7 @@ class MockServer:
                 "access_token": TOKEN,
                 "refresh_token": REFRESH_TOKEN,
                 "scope": self._scope,
-                "expires_in": 86400,
+                "expires_in": self._expires_in,
                 "token_type": "Bearer",
             }
 
@@ -185,6 +186,14 @@ class DeviceCodeClientTest(unittest.TestCase):
             self.assertEqual(token["access_token"], TOKEN)
             self.assertEqual(server.num_device_code_requests, 1)
             self.assertEqual(server.num_token_requests, 2)
+
+            # Test expiration
+            server = MockServer(testcase=self, expires_in=3599)
+            client.refresh()
+            token = client.get_jwt()
+            self.assertEqual(token["access_token"], TOKEN)
+            self.assertEqual(client.get_jwt()["access_token"], TOKEN)
+            self.assertEqual(server.num_device_code_requests, 2)
 
     def test_fail_on_404(self) -> None:
         """


### PR DESCRIPTION
## Description of change
Make sure that the directory where we cache python credentials exists and also record the absolute expiration time in the cached token so we can refresh it when the time comes.

## Guide to reproduce test results.
```
bazel test //resim/auth/python/...
```
## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
