### PR TITLE
Don't fetch external file metrics data

### DIFF
--- a/resim/metrics/fetch_metrics_urls.py
+++ b/resim/metrics/fetch_metrics_urls.py
@@ -54,7 +54,8 @@ def fetch_metrics_data_urls(
     """Fetch all metrics data urls for a given job_id."""
 
     def is_standard(data: MetricsData) -> bool:
-        return data.metrics_data_type == MetricsDataType.STANDARD
+        result: bool = data.metrics_data_type == MetricsDataType.STANDARD
+        return result
 
     return [
         metrics_data.metrics_data_url

--- a/resim/metrics/fetch_metrics_urls.py
+++ b/resim/metrics/fetch_metrics_urls.py
@@ -17,6 +17,8 @@ from resim_python_client.api.batches import (
     list_metrics_for_job,
 )
 from resim_python_client.client import AuthenticatedClient
+from resim_python_client.models.metrics_data import MetricsData
+from resim_python_client.models.metrics_data_type import MetricsDataType
 
 from resim.metrics.fetch_all_pages import fetch_all_pages
 
@@ -50,6 +52,10 @@ def fetch_metrics_data_urls(
     client: AuthenticatedClient
 ) -> list[str]:
     """Fetch all metrics data urls for a given job_id."""
+
+    def is_standard(data: MetricsData) -> bool:
+        return data.metrics_data_type == MetricsDataType.STANDARD
+
     return [
         metrics_data.metrics_data_url
         for metrics_data_response in fetch_all_pages(
@@ -60,4 +66,5 @@ def fetch_metrics_data_urls(
             client=client,
         )
         for metrics_data in metrics_data_response.metrics_data
+        if is_standard(metrics_data)
     ]

--- a/resim/metrics/fetch_metrics_urls_test.py
+++ b/resim/metrics/fetch_metrics_urls_test.py
@@ -46,6 +46,7 @@ class MockMetricsData:
     """
 
     metrics_data_url: str
+    metrics_data_type: str
 
 
 @dataclass
@@ -146,8 +147,9 @@ class FetchMetricsUrlsTest(unittest.TestCase):
                     metrics_data=[
                         MockMetricsData(
                             metrics_data_url=f"https://www.test_url.com/metrics_{i}_{j}.binproto",
+                            metrics_data_type="STANDARD" if i % 2 else "EXTERNAL_FILE",
                         )
-                        for i in range(3)
+                        for i in range(5)
                     ]
                 )
                 for j in range(3)
@@ -155,7 +157,7 @@ class FetchMetricsUrlsTest(unittest.TestCase):
 
         with patch(
             "resim.metrics.fetch_metrics_urls.fetch_all_pages", new=mock_fetch_all_pages
-        ) as _:
+        ):
             metrics_data_urls = fetch_metrics_urls.fetch_metrics_data_urls(
                 project_id=test_project_id,
                 batch_id=test_batch_id,
@@ -167,7 +169,8 @@ class FetchMetricsUrlsTest(unittest.TestCase):
                 [
                     f"https://www.test_url.com/metrics_{i}_{j}.binproto"
                     for j in range(3)
-                    for i in range(3)
+                    for i in range(5)
+                    if i % 2
                 ],
             )
 


### PR DESCRIPTION
## Description of change
Currently the metrics data urls for external file metrics are just the original files themselves. These obviously can't be unpacked as protobuf message types in the same was as the other metrics data, so we omit them for now to allow `fetch_job_metrics` to function properly.

## Guide to reproduce test results.
```bash
bazel test //resim/metrics:fetch_metrics_urls_test
```

## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
