### PR TITLE
Make pod parser mutable

### DIFF
--- a/resim/converter/parser.hh
+++ b/resim/converter/parser.hh
@@ -65,8 +65,11 @@ auto make_parser(const Getters &getters) {
 }
 
 // Defines a getter for a field in a POD data structure
+// Note we use parentheses to avoid case one from
+// https://en.cppreference.com/w/cpp/language/decltype since we want
+// the lvalue reference.
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define POD_GETTER(field) [](auto &s) -> decltype(auto) { return s.field; }
+#define POD_GETTER(field) [](auto &s) -> decltype(auto) { return (s.field); }
 
 // Defines a getter for a non-primitive field in a generated protobuf C++
 // object.

--- a/resim/converter/parser_test.cc
+++ b/resim/converter/parser_test.cc
@@ -45,18 +45,29 @@ TEST(ParserTest, TestParserPOD) {
   // SETUP
   constexpr int X_VAL = 5;
   constexpr int Y_VAL = 6;
+  constexpr int NEW_X_VAL = 5;
+  constexpr int NEW_Y_VAL = 6;
 
   const test_namespace::CppStruct my_struct{
       .x = X_VAL,
       .y = Y_VAL,
   };
 
+  test_namespace::CppStruct my_mutable_struct{
+      .x = X_VAL,
+      .y = Y_VAL,
+  };
+
   // ACTION
   auto parser = get_parser(TypeTag<test_namespace::CppStruct>());
+  parser.get<0>(my_mutable_struct) = NEW_X_VAL;
+  parser.get<1>(my_mutable_struct) = NEW_Y_VAL;
 
   // VERIFICATION
-  EXPECT_EQ(parser.get<0>(my_struct), my_struct.x);
-  EXPECT_EQ(parser.get<1>(my_struct), my_struct.y);
+  EXPECT_EQ(&parser.get<0>(my_struct), &my_struct.x);
+  EXPECT_EQ(&parser.get<1>(my_struct), &my_struct.y);
+  EXPECT_EQ(parser.get<0>(my_mutable_struct), NEW_X_VAL);
+  EXPECT_EQ(parser.get<1>(my_mutable_struct), NEW_Y_VAL);
 }
 
 TEST(ParserTest, TestParserProto) {


### PR DESCRIPTION
## Description of change
Currently the macro used to define a "Plain-Old-Data" (POD) getter for POD structs doesn't allow mutable access to the contents of the struct even if the struct is mutable. This is due to the way in which `decltype()` functions. Particularly "unparenthesized class member access expression[s]" cause decltype to get the declared value of the field being accessed which is generally not a reference. We use parentheses to ameliorate this. See
[here](https://en.cppreference.com/w/cpp/language/decltype) for more details. We also added some tests to confirm this now works.

## Guide to reproduce test results.
```bash
bazel test //resim/converter:parser_test
```
## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
