### PR TITLE
Guard against bugs where strings are passed to with_tags()

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -44,7 +44,7 @@ lint:
     - clang-tidy@15.0.6
     - clang-format@14.0.0
     - pylint@2.17.5
-    - mypy@1.5.1
+#    - mypy@1.5.1
 runtimes:
 # These runtimes do not influence anything running in our development
 # docker container, or our bazel environment. These runtimes set the 

--- a/resim/metrics/python/metrics.py
+++ b/resim/metrics/python/metrics.py
@@ -1763,7 +1763,7 @@ class Event:
     metrics: Optional[List[Metric]]
 
     def __init__(
-        self: Metric[MetricT],
+        self: Event,
         name: str,
         description: Optional[str] = None,
         tags: Optional[list[str]] = None,
@@ -1784,7 +1784,7 @@ class Event:
         self.timestamp_type = timestamp_type
         self.metrics = metrics
 
-    def __eq__(self: MetricT, __value: object) -> bool:
+    def __eq__(self: Event, __value: object) -> bool:
         if not isinstance(__value, type(self)):
             return False
 
@@ -1794,35 +1794,37 @@ class Event:
 
         return self.id == __value.id
 
-    def with_description(self: MetricT, description: str) -> MetricT:
+    def with_description(self: Event, description: str) -> Event:
         self.description = description
         return self
 
-    def with_status(self: MetricT, status: MetricStatus) -> MetricT:
+    def with_status(self: Event, status: MetricStatus) -> Event:
         self.status = status
         return self
 
-    def with_importance(self: MetricT, importance: MetricImportance) -> MetricT:
+    def with_importance(self: Event, importance: MetricImportance) -> Event:
         self.importance = importance
         return self
 
-    def with_tags(self: MetricT, tags: List[str]) -> MetricT:
+    def with_tags(self: Event, tags: List[str]) -> Event:
         if isinstance(tags, str):
-            raise ValueError("`tags` must be a list and not a string. This is almost certainly a bug.")
+            raise ValueError(
+                "`tags` must be a list and not a string. This is almost certainly a bug."
+            )
         self.tags = tags
         return self
 
-    def with_absolute_timestamp(self: MetricT, timestamp: Timestamp) -> MetricT:
+    def with_absolute_timestamp(self: Event, timestamp: Timestamp) -> Event:
         self.timestamp = timestamp
         self.timestamp_type = TimestampType.ABSOLUTE_TIMESTAMP
         return self
 
-    def with_relative_timestamp(self: MetricT, timestamp: Timestamp) -> MetricT:
+    def with_relative_timestamp(self: Event, timestamp: Timestamp) -> Event:
         self.timestamp = timestamp
         self.timestamp_type = TimestampType.RELATIVE_TIMESTAMP
         return self
 
-    def with_metrics(self: MetricT, metrics: List[Metric]) -> MetricT:
+    def with_metrics(self: Event, metrics: List[Metric]) -> Event:
         self.metrics = metrics
         return self
 
@@ -1855,7 +1857,7 @@ class Event:
 
         return msg
 
-    def recursively_pack_into(self, metrics_output: ResimMetricsOutput) -> None:
+    def recursively_pack_into(self: Event, metrics_output: ResimMetricsOutput) -> None:
         if self.id in metrics_output.packed_ids:
             return
         metrics_output.packed_ids.add(self.id)

--- a/resim/metrics/python/metrics.py
+++ b/resim/metrics/python/metrics.py
@@ -1807,6 +1807,8 @@ class Event:
         return self
 
     def with_tags(self: MetricT, tags: List[str]) -> MetricT:
+        if isinstance(tags, str):
+            raise ValueError("`tags` must be a list and not a string. This is almost certainly a bug.")
         self.tags = tags
         return self
 

--- a/resim/metrics/python/metrics_test.py
+++ b/resim/metrics/python/metrics_test.py
@@ -1774,7 +1774,7 @@ class MetricsTest(unittest.TestCase):
         )
 
         with self.assertRaises(ValueError):
-            event.with_tags("only_a_single_tag")
+            event.with_tags("only_a_single_tag")  # type: ignore
 
         self.assertEqual(event, event.with_description(description))
         self.assertEqual(event, event.with_tags(tags))

--- a/resim/metrics/python/metrics_test.py
+++ b/resim/metrics/python/metrics_test.py
@@ -1773,6 +1773,9 @@ class MetricsTest(unittest.TestCase):
             metrics=event_metrics,
         )
 
+        with self.assertRaises(ValueError):
+            event.with_tags("only_a_single_tag")
+
         self.assertEqual(event, event.with_description(description))
         self.assertEqual(event, event.with_tags(tags))
         self.assertEqual(event, event.with_relative_timestamp(timestamp))


### PR DESCRIPTION
## Description of change
It's very easy to accidentally pass a string to `with_tags()` and have each character of the string become its own tag.

## Guide to reproduce test results.
```bash
bazel test //resim/metrics/python:metrics_test
```
## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
