### PR TITLE
Add toolchain to cross compile for aarch64

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,6 +6,7 @@ LABEL description="Core development container"
 RUN apt-get update && apt-get -y upgrade
 RUN apt-get install -y ca-certificates curl gnupg lsb-release software-properties-common
 RUN apt-get install -y g++ clang lcov clang-format clang-tidy clangd
+RUN apt-get install -y g++-12-aarch64-linux-gnu qemu-user
 RUN apt-get install -y openssh-server unzip groff man
 RUN apt-get install -y emacs vim zsh tmux
 RUN apt-get install -y cgdb

--- a/BUILD
+++ b/BUILD
@@ -3,3 +3,11 @@
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
+
+platform(
+    name = "aarch64_linux",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:aarch64",
+    ],
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -58,6 +58,7 @@ use_repo(pip, "resim_python_deps")
 
 register_toolchains(
     "@resim_open_core//resim/toolchain:cc_toolchain_for_k8",
+    "@resim_open_core//resim/toolchain:aarch64_cross_toolchain_for_amd64",
 )
 
 resim_version_extension = use_extension("@resim_open_core//:version.bzl", "resim_version_extension")

--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -76,7 +76,10 @@ py_wheel(
     distribution = "resim-open-core",
     homepage = "https://www.resim.ai/",
     license = LICENSE,
-    platform = "manylinux2014_x86_64",
+    platform = select({
+        "@platforms//cpu:aarch64": "manylinux2014_aarch64",
+        "@platforms//cpu:x86_64": "manylinux2014_x86_64",
+    }),
     python_tag = "py3",
     requires = [
         "protobuf>=4.24.4",
@@ -144,7 +147,10 @@ py_wheel(
     distribution = "resim_metrics",
     homepage = "https://www.resim.ai/",
     license = LICENSE,
-    platform = "manylinux2014_x86_64",
+    platform = select({
+        "@platforms//cpu:aarch64": "manylinux2014_aarch64",
+        "@platforms//cpu:x86_64": "manylinux2014_x86_64",
+    }),
     python_tag = "py3",
     requires = [
         "protobuf>=4.24.4",
@@ -202,7 +208,10 @@ py_wheel(
     distribution = "resim_ros2",
     homepage = "https://www.resim.ai/",
     license = LICENSE,
-    platform = "manylinux2014_x86_64",
+    platform = select({
+        "@platforms//cpu:aarch64": "manylinux2014_aarch64",
+        "@platforms//cpu:x86_64": "manylinux2014_x86_64",
+    }),
     python_tag = "py3",
     requires = [
         "protobuf>=4.24.4",

--- a/resim/ros2/primitives_from_ros2.cc
+++ b/resim/ros2/primitives_from_ros2.cc
@@ -121,7 +121,7 @@ std_msgs::msg::Int64 convert_to_ros2(const msg::Int64 &resim_msg) {
 
 msg::Int8 convert_from_ros2(const std_msgs::msg::Int8 &ros2_msg) {
   msg::Int8 result;
-  result.set_data(std::string{ros2_msg.data});
+  result.set_data(std::string{static_cast<char>(ros2_msg.data)});
   return result;
 }
 

--- a/resim/toolchain/BUILD
+++ b/resim/toolchain/BUILD
@@ -8,9 +8,11 @@
 
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test", "cc_toolchain", "cc_toolchain_suite")
 load("@rules_python//python:defs.bzl", "py_test")
-load(":cc_toolchain_config.bzl", "cc_toolchain_config")
+load(":cc_toolchain_config.bzl", "cc_toolchain_config", "cc_toolchain_config_amd64_aarch64_cross")
 
 cc_toolchain_config(name = "k8_toolchain_config")
+
+cc_toolchain_config_amd64_aarch64_cross(name = "amd64_aarch64_cross_toolchain_config")
 
 cc_toolchain_suite(
     name = "clang_suite",
@@ -36,6 +38,20 @@ cc_toolchain(
     visibility = ["//visibility:public"],
 )
 
+cc_toolchain(
+    name = "amd64_aarch64_cross_toolchain",
+    all_files = ":empty",
+    compiler_files = ":empty",
+    dwp_files = ":empty",
+    linker_files = ":empty",
+    objcopy_files = ":empty",
+    strip_files = ":empty",
+    supports_param_files = 0,
+    toolchain_config = ":amd64_aarch64_cross_toolchain_config",
+    toolchain_identifier = "amd64-aarch64-cross-toolchain",
+    visibility = ["//visibility:public"],
+)
+
 toolchain(
     name = "cc_toolchain_for_k8",
     exec_compatible_with = [
@@ -47,6 +63,20 @@ toolchain(
         "@platforms//os:linux",
     ],
     toolchain = ":k8_toolchain",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+)
+
+toolchain(
+    name = "aarch64_cross_toolchain_for_amd64",
+    exec_compatible_with = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
+    target_compatible_with = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
+    toolchain = ":amd64_aarch64_cross_toolchain",
     toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
 )
 


### PR DESCRIPTION
## Description of change
This will allow us to start releasing python wheels for aarch64/arm64 platforms.

## Guide to reproduce test results.
```
./.devcontainer/build.sh
./.devcontainer/run_local.sh
bazel test --action_env "QEMU_LD_PREFIX=/usr/aarch64-linux-gnu/" --run_under "qemu-aarch64"  --platforms "//:aarch64_linux" //resim/toolchain:check_compiler_test
```
## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [ ] This change is covered by tests that are already landed, or in this PR. **Will be covered in future PR once image changes are available in GH actions.** 
