### PR TITLE
Add helper to kickoff a report based off of a test suite name

### DIFF
--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -58,6 +58,7 @@ py_package(
         "//resim/msg:pose_proto_py",
         "//resim/msg:primitives_proto_py",
         "//resim/msg:transform_proto_py",
+        "//resim/orchestration:kickoff_report",
         "//resim/transforms/proto:framed_vector_3_proto_py",
         "//resim/transforms/python:geodetic_python.so",
         "//resim/transforms/python:quaternion.so",

--- a/resim/orchestration/BUILD
+++ b/resim/orchestration/BUILD
@@ -15,6 +15,12 @@ py_library(
     ],
 )
 
+py_test(
+    name = "resim_python_client_mocks_test",
+    srcs = ["resim_python_client_mocks_test.py"],
+    deps = [":resim_python_client_mocks"],
+)
+
 py_library(
     name = "kickoff_report",
     srcs = ["kickoff_report.py"],

--- a/resim/orchestration/BUILD
+++ b/resim/orchestration/BUILD
@@ -1,0 +1,35 @@
+# Copyright 2024 ReSim, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
+
+py_library(
+    name = "resim_python_client_mocks",
+    testonly = True,
+    srcs = ["resim_python_client_mocks.py"],
+    deps = [
+        "@resim-python-client//:resim_python_client",
+    ],
+)
+
+py_library(
+    name = "kickoff_report",
+    srcs = ["kickoff_report.py"],
+    visibility = ["//pkg:__subpackages__"],
+    deps = [
+        "//resim/msg:detection_proto_py",
+        "@resim-python-client//:resim_python_client",
+    ],
+)
+
+py_test(
+    name = "kickoff_report_test",
+    srcs = ["kickoff_report_test.py"],
+    deps = [
+        ":kickoff_report",
+        ":resim_python_client_mocks",
+    ],
+)

--- a/resim/orchestration/kickoff_report.py
+++ b/resim/orchestration/kickoff_report.py
@@ -44,7 +44,7 @@ async def run_report_for_batch(
         project_id=str(project_id), test_suite_id=test_suite_id, client=client
     )
     if test_suite is None:
-        raise RuntimeError("Could not find test suite")
+        raise RuntimeError("Could not find test suite!")
 
     if test_suite_allowlist is not None and test_suite.name not in test_suite_allowlist:
         return None

--- a/resim/orchestration/kickoff_report.py
+++ b/resim/orchestration/kickoff_report.py
@@ -1,0 +1,65 @@
+# Copyright 2024 ReSim, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+import logging
+import uuid
+from datetime import datetime
+from typing import Any, Optional
+
+from resim_python_client.api.batches import get_batch
+from resim_python_client.api.reports import create_report
+from resim_python_client.api.test_suites import get_test_suite
+from resim_python_client.client import AuthenticatedClient
+from resim_python_client.models import Report, ReportInput
+
+logger = logging.getLogger(__name__)
+
+
+async def run_report_for_batch(
+    *,
+    project_id: uuid.UUID,
+    batch_id: uuid.UUID,
+    client: AuthenticatedClient,
+    start_timestamp: datetime,
+    test_suite_allowlist: Optional[set[str]] = None,
+    metrics_build_id: Optional[uuid.UUID] = None,
+    **kwargs: Any,
+) -> Optional[Report]:
+    batch = await get_batch.asyncio(
+        batch_id=str(batch_id), project_id=str(project_id), client=client
+    )
+    test_suite_id = batch.test_suite_id
+    if not test_suite_id:
+        return None
+    branch_id = batch.branch_id
+    if metrics_build_id is None:
+        metrics_build_id = uuid.UUID(batch.metrics_build_id)
+
+    test_suite = await get_test_suite.asyncio(
+        project_id=str(project_id), test_suite_id=test_suite_id, client=client
+    )
+    if test_suite is None:
+        raise RuntimeError("Could not find test suite")
+
+    if test_suite_allowlist is not None and test_suite.name not in test_suite_allowlist:
+        return None
+
+    report = await create_report.asyncio(
+        client=client,
+        project_id=str(project_id),
+        body=ReportInput(
+            branch_id=branch_id,
+            metrics_build_id=str(metrics_build_id),
+            start_timestamp=start_timestamp,
+            test_suite_id=test_suite_id,
+            **kwargs,
+        ),
+    )
+    if report is None:
+        raise RuntimeError("Failed to create report")
+
+    logger.info("Created report: %s", report.report_id)
+    return report

--- a/resim/orchestration/kickoff_report.py
+++ b/resim/orchestration/kickoff_report.py
@@ -28,6 +28,8 @@ async def run_report_for_batch(
     metrics_build_id: Optional[uuid.UUID] = None,
     **kwargs: Any,
 ) -> Optional[Report]:
+    if start_timestamp.tzinfo is None:
+        raise ValueError("start_timestamp must be localized!")
     batch = await get_batch.asyncio(
         batch_id=str(batch_id), project_id=str(project_id), client=client
     )

--- a/resim/orchestration/kickoff_report.py
+++ b/resim/orchestration/kickoff_report.py
@@ -44,7 +44,7 @@ async def run_report_for_batch(
         project_id=str(project_id), test_suite_id=test_suite_id, client=client
     )
     if test_suite is None:
-        raise RuntimeError("Could not find test suite!")
+        raise RuntimeError("Could not find test suite")
 
     if test_suite_allowlist is not None and test_suite.name not in test_suite_allowlist:
         return None

--- a/resim/orchestration/kickoff_report.py
+++ b/resim/orchestration/kickoff_report.py
@@ -28,6 +28,23 @@ async def run_report_for_batch(
     metrics_build_id: Optional[uuid.UUID] = None,
     **kwargs: Any,
 ) -> Optional[Report]:
+    """Run a report based on a given batch_id and start_timetamp.
+
+    Run a report using the same metrics build as the given batch, or one optionally provided. Also,
+    allow for a specific set of allowed test suite names to be provided (e.g. nightly test
+    suites). This function is useful for triggering a report as the final step of a batch on the
+    same test suite to ensure that the current batch gets included in the report.
+
+    Args:
+      project_id - The ID of this project,
+      batch_id - The ID of the batch to get the test suite and metrics build id from.
+      client - The client to use when querying the API.
+      start_timestamp - The time to start the report from.
+      test_suite_allowlist - The test suites to allow reports to be spawned for. If omitted, all are
+                             allowed
+      metrics_build_id - An optional metrics build override to use for the report.
+      kwargs - Keyword arguments forwarded to create_report.asyncio
+    """
     if start_timestamp.tzinfo is None:
         raise ValueError("start_timestamp must be localized!")
     batch = await get_batch.asyncio(

--- a/resim/orchestration/kickoff_report_test.py
+++ b/resim/orchestration/kickoff_report_test.py
@@ -23,6 +23,7 @@ import resim.orchestration.resim_python_client_mocks as mocks
 
 
 def make_mock_state() -> mocks.MockState:
+    """Helper to create a MockState containing what we need for this test."""
     state = mocks.MockState()
 
     for _ in range(5):

--- a/resim/orchestration/kickoff_report_test.py
+++ b/resim/orchestration/kickoff_report_test.py
@@ -10,7 +10,7 @@ Test for kickoff_report
 """
 
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import patch
 from uuid import UUID
@@ -57,7 +57,7 @@ class KickoffReportTest(unittest.IsolatedAsyncioTestCase):
         # SETUP
         client = mocks.get_mock_client(make_mock_state())
         batch: Batch = next(iter(client.state.batches.values()))
-        start_timestamp = datetime.now()
+        start_timestamp = datetime.now(tz=timezone.utc)
 
         # ACTION
         report: Report = await kr.run_report_for_batch(
@@ -78,7 +78,7 @@ class KickoffReportTest(unittest.IsolatedAsyncioTestCase):
         # SETUP
         client = mocks.get_mock_client(make_mock_state())
         batch = next(iter(client.state.batches.values()))
-        start_timestamp = datetime.now()
+        start_timestamp = datetime.now(tz=timezone.utc)
 
         # ACTION
         report = await kr.run_report_for_batch(
@@ -92,6 +92,22 @@ class KickoffReportTest(unittest.IsolatedAsyncioTestCase):
         # VERIFICATION
         self.assertIs(report, None)
 
+    async def test_kickoff_report_unlocalized(self) -> None:
+        # SETUP
+        client = mocks.get_mock_client(make_mock_state())
+        batch = next(iter(client.state.batches.values()))
+        start_timestamp = datetime.now()
+
+        # ACTION / VERIFICATION
+        with self.assertRaises(ValueError):
+            await kr.run_report_for_batch(
+                project_id=UUID(batch.project_id),
+                batch_id=UUID(batch.batch_id),
+                client=client,
+                start_timestamp=start_timestamp,
+                test_suite_allowlist=set(),
+            )
+
     async def test_kickoff_report_explicit_metrics_build(self) -> None:
         client = mocks.get_mock_client(make_mock_state())
         batch: Batch = next(iter(client.state.batches.values()))
@@ -103,7 +119,7 @@ class KickoffReportTest(unittest.IsolatedAsyncioTestCase):
             0
         ]  # Get another metrics build
         test_suite = client.state.test_suites[UUID(batch.test_suite_id)]
-        start_timestamp = datetime.now()
+        start_timestamp = datetime.now(tz=timezone.utc)
 
         # ACTION
         report: Report = await kr.run_report_for_batch(
@@ -127,7 +143,7 @@ class KickoffReportTest(unittest.IsolatedAsyncioTestCase):
         # SETUP
         client = mocks.get_mock_client(make_mock_state())
         batch = next(iter(client.state.batches.values()))
-        start_timestamp = datetime.now()
+        start_timestamp = datetime.now(tz=timezone.utc)
         test_suite = client.state.test_suites[UUID(batch.test_suite_id)]
         batch.test_suite_id = UNSET
 
@@ -147,7 +163,7 @@ class KickoffReportTest(unittest.IsolatedAsyncioTestCase):
         # SETUP
         client = mocks.get_mock_client(make_mock_state())
         batch = next(iter(client.state.batches.values()))
-        start_timestamp = datetime.now()
+        start_timestamp = datetime.now(tz=timezone.utc)
         test_suite = client.state.test_suites[UUID(batch.test_suite_id)]
 
         async def return_none(*_: Any, **__: Any) -> None:
@@ -169,7 +185,7 @@ class KickoffReportTest(unittest.IsolatedAsyncioTestCase):
         # SETUP
         client = mocks.get_mock_client(make_mock_state())
         batch = next(iter(client.state.batches.values()))
-        start_timestamp = datetime.now()
+        start_timestamp = datetime.now(tz=timezone.utc)
         test_suite = client.state.test_suites[UUID(batch.test_suite_id)]
 
         async def return_none(*_: Any, **__: Any) -> None:

--- a/resim/orchestration/kickoff_report_test.py
+++ b/resim/orchestration/kickoff_report_test.py
@@ -1,0 +1,192 @@
+# Copyright 2024 ReSim, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+
+"""
+Test for kickoff_report
+"""
+
+import unittest
+from datetime import datetime
+from typing import Any
+from unittest.mock import patch
+from uuid import UUID
+
+from resim_python_client.models import Batch, Report
+from resim_python_client.types import UNSET
+
+import resim.orchestration.kickoff_report as kr
+import resim.orchestration.resim_python_client_mocks as mocks
+
+
+def make_mock_state() -> mocks.MockState:
+    state = mocks.MockState()
+
+    for _ in range(5):
+        p = mocks.random_project(state)
+        state.projects[UUID(p.project_id)] = p
+
+    for _ in range(5):
+        mb = mocks.random_metrics_build(state)
+        state.metrics_builds[UUID(mb.metrics_build_id)] = mb
+
+    for _ in range(5):
+        ts = mocks.random_test_suite(state)
+        state.test_suites[UUID(ts.test_suite_id)] = ts
+
+    for _ in range(5):
+        b = mocks.random_batch(state)
+        state.batches[UUID(b.batch_id)] = b
+
+    return state
+
+
+GET_BATCH_FUNCTION = "resim.orchestration.kickoff_report.get_batch.asyncio"
+GET_TEST_SUITE_FUNCTION = "resim.orchestration.kickoff_report.get_test_suite.asyncio"
+CREATE_REPORT_FUNCTION = "resim.orchestration.kickoff_report.create_report.asyncio"
+
+
+@patch(GET_BATCH_FUNCTION, new=mocks.get_batch_asyncio)
+@patch(GET_TEST_SUITE_FUNCTION, new=mocks.get_test_suite_asyncio)
+@patch(CREATE_REPORT_FUNCTION, new=mocks.create_report_asyncio)
+class AsyncFetchAllPagesTest(unittest.IsolatedAsyncioTestCase):
+    async def test_kickoff_report(self) -> None:
+        # SETUP
+        client = mocks.get_mock_client(make_mock_state())
+        batch: Batch = next(iter(client.state.batches.values()))
+        start_timestamp = datetime.now()
+
+        # ACTION
+        report: Report = await kr.run_report_for_batch(
+            project_id=UUID(batch.project_id),
+            batch_id=UUID(batch.batch_id),
+            client=client,
+            start_timestamp=start_timestamp,
+        )
+
+        # VERIFICATION
+        self.assertEqual(report.branch_id, batch.branch_id)
+        self.assertEqual(report.metrics_build_id, batch.metrics_build_id)
+        self.assertEqual(report.test_suite_id, batch.test_suite_id)
+        self.assertEqual(report.start_timestamp, start_timestamp)
+        self.assertEqual(report.project_id, batch.project_id)
+
+    async def test_kickoff_report_denied(self) -> None:
+        # SETUP
+        client = mocks.get_mock_client(make_mock_state())
+        batch = next(iter(client.state.batches.values()))
+        start_timestamp = datetime.now()
+
+        # ACTION
+        report = await kr.run_report_for_batch(
+            project_id=UUID(batch.project_id),
+            batch_id=UUID(batch.batch_id),
+            client=client,
+            start_timestamp=start_timestamp,
+            test_suite_allowlist=set(),
+        )
+
+        # VERIFICATION
+        self.assertIs(report, None)
+
+    async def test_kickoff_report_explicit_metrics_build(self) -> None:
+        client = mocks.get_mock_client(make_mock_state())
+        batch: Batch = next(iter(client.state.batches.values()))
+        metrics_build_id = [
+            k
+            for k in client.state.metrics_builds.keys()
+            if str(k) != batch.metrics_build_id
+        ][
+            0
+        ]  # Get another metrics build
+        test_suite = client.state.test_suites[UUID(batch.test_suite_id)]
+        start_timestamp = datetime.now()
+
+        # ACTION
+        report: Report = await kr.run_report_for_batch(
+            project_id=UUID(batch.project_id),
+            batch_id=UUID(batch.batch_id),
+            client=client,
+            start_timestamp=start_timestamp,
+            metrics_build_id=metrics_build_id,
+            test_suite_allowlist={test_suite.name},
+        )
+
+        # VERIFICATION
+        self.assertEqual(report.branch_id, batch.branch_id)
+        self.assertEqual(report.metrics_build_id, str(metrics_build_id))
+        self.assertNotEqual(report.metrics_build_id, batch.metrics_build_id)
+        self.assertEqual(report.test_suite_id, batch.test_suite_id)
+        self.assertEqual(report.start_timestamp, start_timestamp)
+        self.assertEqual(report.project_id, batch.project_id)
+
+    async def test_kickoff_report_no_test_suite(self) -> None:
+        # SETUP
+        client = mocks.get_mock_client(make_mock_state())
+        batch = next(iter(client.state.batches.values()))
+        start_timestamp = datetime.now()
+        test_suite = client.state.test_suites[UUID(batch.test_suite_id)]
+        batch.test_suite_id = UNSET
+
+        # ACTION
+        report = await kr.run_report_for_batch(
+            project_id=UUID(batch.project_id),
+            batch_id=UUID(batch.batch_id),
+            client=client,
+            start_timestamp=start_timestamp,
+            test_suite_allowlist={test_suite.name},
+        )
+
+        # VERIFICATION
+        self.assertIs(report, None)
+
+    async def test_kickoff_report_bad_test_suite_return(self) -> None:
+        # SETUP
+        client = mocks.get_mock_client(make_mock_state())
+        batch = next(iter(client.state.batches.values()))
+        start_timestamp = datetime.now()
+        test_suite = client.state.test_suites[UUID(batch.test_suite_id)]
+
+        async def return_none(*_: Any, **__: Any) -> None:
+            return None
+
+        # ACTION / VERIFICATION
+        with patch(GET_TEST_SUITE_FUNCTION, new=return_none), self.assertRaises(
+            RuntimeError
+        ):
+            await kr.run_report_for_batch(
+                project_id=UUID(batch.project_id),
+                batch_id=UUID(batch.batch_id),
+                client=client,
+                start_timestamp=start_timestamp,
+                test_suite_allowlist={test_suite.name},
+            )
+
+    async def test_kickoff_report_bad_create_report(self) -> None:
+        # SETUP
+        client = mocks.get_mock_client(make_mock_state())
+        batch = next(iter(client.state.batches.values()))
+        start_timestamp = datetime.now()
+        test_suite = client.state.test_suites[UUID(batch.test_suite_id)]
+
+        async def return_none(*_: Any, **__: Any) -> None:
+            return None
+
+        # ACTION / VERIFICATION
+        with patch(CREATE_REPORT_FUNCTION, new=return_none), self.assertRaises(
+            RuntimeError
+        ):
+            await kr.run_report_for_batch(
+                project_id=UUID(batch.project_id),
+                batch_id=UUID(batch.batch_id),
+                client=client,
+                start_timestamp=start_timestamp,
+                test_suite_allowlist={test_suite.name},
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/resim/orchestration/kickoff_report_test.py
+++ b/resim/orchestration/kickoff_report_test.py
@@ -21,30 +21,6 @@ from resim_python_client.types import UNSET
 import resim.orchestration.kickoff_report as kr
 import resim.orchestration.resim_python_client_mocks as mocks
 
-
-def make_mock_state() -> mocks.MockState:
-    """Helper to create a MockState containing what we need for this test."""
-    state = mocks.MockState()
-
-    for _ in range(5):
-        p = mocks.random_project(state)
-        state.projects[UUID(p.project_id)] = p
-
-    for _ in range(5):
-        mb = mocks.random_metrics_build(state)
-        state.metrics_builds[UUID(mb.metrics_build_id)] = mb
-
-    for _ in range(5):
-        ts = mocks.random_test_suite(state)
-        state.test_suites[UUID(ts.test_suite_id)] = ts
-
-    for _ in range(5):
-        b = mocks.random_batch(state)
-        state.batches[UUID(b.batch_id)] = b
-
-    return state
-
-
 GET_BATCH_FUNCTION = "resim.orchestration.kickoff_report.get_batch.asyncio"
 GET_TEST_SUITE_FUNCTION = "resim.orchestration.kickoff_report.get_test_suite.asyncio"
 CREATE_REPORT_FUNCTION = "resim.orchestration.kickoff_report.create_report.asyncio"
@@ -56,7 +32,7 @@ CREATE_REPORT_FUNCTION = "resim.orchestration.kickoff_report.create_report.async
 class KickoffReportTest(unittest.IsolatedAsyncioTestCase):
     async def test_kickoff_report(self) -> None:
         # SETUP
-        client = mocks.get_mock_client(make_mock_state())
+        client = mocks.get_mock_client(mocks.make_mock_state())
         batch: Batch = next(iter(client.state.batches.values()))
         start_timestamp = datetime.now(tz=timezone.utc)
 
@@ -77,7 +53,7 @@ class KickoffReportTest(unittest.IsolatedAsyncioTestCase):
 
     async def test_kickoff_report_denied(self) -> None:
         # SETUP
-        client = mocks.get_mock_client(make_mock_state())
+        client = mocks.get_mock_client(mocks.make_mock_state())
         batch = next(iter(client.state.batches.values()))
         start_timestamp = datetime.now(tz=timezone.utc)
 
@@ -95,7 +71,7 @@ class KickoffReportTest(unittest.IsolatedAsyncioTestCase):
 
     async def test_kickoff_report_unlocalized(self) -> None:
         # SETUP
-        client = mocks.get_mock_client(make_mock_state())
+        client = mocks.get_mock_client(mocks.make_mock_state())
         batch = next(iter(client.state.batches.values()))
         start_timestamp = datetime.now()
 
@@ -110,7 +86,7 @@ class KickoffReportTest(unittest.IsolatedAsyncioTestCase):
             )
 
     async def test_kickoff_report_explicit_metrics_build(self) -> None:
-        client = mocks.get_mock_client(make_mock_state())
+        client = mocks.get_mock_client(mocks.make_mock_state())
         batch: Batch = next(iter(client.state.batches.values()))
         metrics_build_id = [
             k
@@ -142,7 +118,7 @@ class KickoffReportTest(unittest.IsolatedAsyncioTestCase):
 
     async def test_kickoff_report_no_test_suite(self) -> None:
         # SETUP
-        client = mocks.get_mock_client(make_mock_state())
+        client = mocks.get_mock_client(mocks.make_mock_state())
         batch = next(iter(client.state.batches.values()))
         start_timestamp = datetime.now(tz=timezone.utc)
         test_suite = client.state.test_suites[UUID(batch.test_suite_id)]
@@ -162,7 +138,7 @@ class KickoffReportTest(unittest.IsolatedAsyncioTestCase):
 
     async def test_kickoff_report_bad_test_suite_return(self) -> None:
         # SETUP
-        client = mocks.get_mock_client(make_mock_state())
+        client = mocks.get_mock_client(mocks.make_mock_state())
         batch = next(iter(client.state.batches.values()))
         start_timestamp = datetime.now(tz=timezone.utc)
         test_suite = client.state.test_suites[UUID(batch.test_suite_id)]
@@ -184,7 +160,7 @@ class KickoffReportTest(unittest.IsolatedAsyncioTestCase):
 
     async def test_kickoff_report_bad_create_report(self) -> None:
         # SETUP
-        client = mocks.get_mock_client(make_mock_state())
+        client = mocks.get_mock_client(mocks.make_mock_state())
         batch = next(iter(client.state.batches.values()))
         start_timestamp = datetime.now(tz=timezone.utc)
         test_suite = client.state.test_suites[UUID(batch.test_suite_id)]

--- a/resim/orchestration/kickoff_report_test.py
+++ b/resim/orchestration/kickoff_report_test.py
@@ -52,7 +52,7 @@ CREATE_REPORT_FUNCTION = "resim.orchestration.kickoff_report.create_report.async
 @patch(GET_BATCH_FUNCTION, new=mocks.get_batch_asyncio)
 @patch(GET_TEST_SUITE_FUNCTION, new=mocks.get_test_suite_asyncio)
 @patch(CREATE_REPORT_FUNCTION, new=mocks.create_report_asyncio)
-class AsyncFetchAllPagesTest(unittest.IsolatedAsyncioTestCase):
+class KickoffReportTest(unittest.IsolatedAsyncioTestCase):
     async def test_kickoff_report(self) -> None:
         # SETUP
         client = mocks.get_mock_client(make_mock_state())

--- a/resim/orchestration/resim_python_client_mocks.py
+++ b/resim/orchestration/resim_python_client_mocks.py
@@ -1,0 +1,166 @@
+# Copyright 2024 ReSim, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+import random
+from dataclasses import dataclass, field
+from datetime import datetime
+from string import ascii_lowercase
+from typing import Any, Optional, TypeVar, Union
+from unittest.mock import MagicMock
+from uuid import UUID, uuid4
+
+from resim_python_client.models import (
+    Batch,
+    MetricsBuild,
+    MetricStatus,
+    Project,
+    Report,
+    ReportInput,
+    ReportStatus,
+    TestSuite,
+)
+
+
+@dataclass
+class MockState:
+    org_id: str = "simbox.tech"
+    projects: dict[UUID, Project] = field(default_factory=dict)
+    metrics_builds: dict[UUID, MetricsBuild] = field(default_factory=dict)
+    batches: dict[UUID, Batch] = field(default_factory=dict)
+    test_suites: dict[UUID, TestSuite] = field(default_factory=dict)
+    reports: dict[UUID, Report] = field(default_factory=dict)
+
+
+K = TypeVar("K")
+V = TypeVar("V")
+
+
+def _random_dict_value(d: dict[K, V]) -> V:
+    k: K = random.choice(list(d.keys()))
+    return d[k]
+
+
+def random_project(state: MockState) -> Project:
+    project_id = uuid4()
+    return Project(
+        creation_timestamp=datetime.now(),
+        description="unit test project",
+        name=f"project {project_id}",
+        org_id=state.org_id,
+        project_id=str(project_id),
+        user_id=f"simbox@{state.org_id}",
+    )
+
+
+def random_batch(state: MockState) -> Batch:
+    batch_id = uuid4()
+    branch_id = uuid4()  # TODO(michael) Once we add builds, get this from there.
+    test_suite = _random_dict_value(state.test_suites)
+    return Batch(
+        associated_account="",
+        project_id=test_suite.project_id,
+        batch_id=str(batch_id),
+        org_id=state.org_id,
+        branch_id=str(branch_id),
+        test_suite_id=test_suite.test_suite_id,
+        metrics_build_id=test_suite.metrics_build_id,
+    )
+
+
+def random_test_suite(state: MockState) -> Batch:
+    test_suite_id = uuid4()
+    metrics_build = _random_dict_value(state.metrics_builds)
+    return TestSuite(
+        creation_timestamp=datetime.now(),
+        description="unit test test suite",
+        experiences=[],
+        name=f"test suite {test_suite_id}",
+        org_id=state.org_id,
+        project_id=metrics_build.project_id,
+        system_id=uuid4(),
+        test_suite_id=str(test_suite_id),
+        test_suite_revision=random.randint(1, 100),
+        user_id=f"simbox@{state.org_id}",
+        metrics_build_id=metrics_build.metrics_build_id,
+    )
+
+
+def random_metrics_build(state: MockState) -> MetricsBuild:
+    project = _random_dict_value(state.projects)
+    metrics_build_id = uuid4()
+    return MetricsBuild(
+        creation_timestamp=datetime.now(),
+        image_uri=str(random.choice(ascii_lowercase) for _ in range(20)),
+        metrics_build_id=str(metrics_build_id),
+        name=f"metrics build {metrics_build_id}",
+        org_id="simbox.tech",
+        project_id=project.project_id,
+        user_id=f"simbox@{state.org_id}",
+        version=str(uuid4()),
+    )
+
+
+def get_mock_client(state: MockState) -> MagicMock:
+    return MagicMock(state=state)
+
+
+async def get_batch_asyncio(
+    project_id: str,
+    batch_id: str,
+    *,
+    client: MagicMock,
+) -> Optional[Union[Any, Batch]]:
+    batch = client.state.batches[UUID(batch_id)]
+    if project_id != batch.project_id:
+        raise ValueError("Project id mismatch!")
+    return batch
+
+
+async def get_test_suite_asyncio(
+    project_id: str,
+    test_suite_id: str,
+    *,
+    client: MagicMock,
+) -> Optional[Union[Any, TestSuite]]:
+    test_suite = client.state.test_suites[UUID(test_suite_id)]
+    if project_id != test_suite.project_id:
+        raise ValueError("Project id mismatch!")
+    return test_suite
+
+
+async def create_report_asyncio(
+    project_id: str,
+    *,
+    client: MagicMock,
+    body: ReportInput,
+) -> Optional[Union[Any, Report]]:
+    report_id = uuid4()
+    if not UUID(project_id) in client.state.projects:
+        raise ValueError("Project not found!")
+    # TODO(michael) Enforce some consistency requirements
+    report = Report(
+        associated_account="",
+        branch_id=body.branch_id,
+        creation_timestamp=datetime.now(),
+        end_timestamp=body.end_timestamp,
+        last_updated_timestamp=datetime.now(),
+        metrics_build_id=body.metrics_build_id,
+        metrics_status=MetricStatus.NO_STATUS_REPORTED,
+        name=body.name,
+        org_id=client.state.org_id,
+        output_location="",
+        project_id=project_id,
+        report_id=str(report_id),
+        respect_revision_boundary=body.respect_revision_boundary,
+        start_timestamp=body.start_timestamp,
+        status=ReportStatus.SUBMITTED,
+        status_history=[],
+        test_suite_id=body.test_suite_id,
+        test_suite_revision=body.test_suite_revision,
+        user_id=f"simbox@{client.state.org_id}",
+    )
+    client.state.reports[report_id] = report
+    return report

--- a/resim/orchestration/resim_python_client_mocks.py
+++ b/resim/orchestration/resim_python_client_mocks.py
@@ -6,7 +6,7 @@
 
 import random
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from string import ascii_lowercase
 from typing import Any, Optional, TypeVar, Union
 from unittest.mock import MagicMock
@@ -43,15 +43,19 @@ def _random_dict_value(d: dict[K, V]) -> V:
     return d[k]
 
 
+def _random_string() -> str:
+    return str(random.choice(ascii_lowercase) for _ in range(20))
+
+
 def random_project(state: MockState) -> Project:
     project_id = uuid4()
     return Project(
-        creation_timestamp=datetime.now(),
-        description="unit test project",
-        name=f"project {project_id}",
+        creation_timestamp=datetime.now(tz=timezone.utc),
+        description=_random_string(),
+        name=_random_string(),
         org_id=state.org_id,
         project_id=str(project_id),
-        user_id=f"simbox@{state.org_id}",
+        user_id=f"{_random_string()}@{state.org_id}",
     )
 
 
@@ -74,16 +78,16 @@ def random_test_suite(state: MockState) -> Batch:
     test_suite_id = uuid4()
     metrics_build = _random_dict_value(state.metrics_builds)
     return TestSuite(
-        creation_timestamp=datetime.now(),
-        description="unit test test suite",
+        creation_timestamp=datetime.now(tz=timezone.utc),
+        description=_random_string(),
         experiences=[],
         name=f"test suite {test_suite_id}",
         org_id=state.org_id,
         project_id=metrics_build.project_id,
-        system_id=uuid4(),
+        system_id=str(uuid4()),
         test_suite_id=str(test_suite_id),
         test_suite_revision=random.randint(1, 100),
-        user_id=f"simbox@{state.org_id}",
+        user_id=f"{_random_string()}@{state.org_id}",
         metrics_build_id=metrics_build.metrics_build_id,
     )
 
@@ -92,13 +96,13 @@ def random_metrics_build(state: MockState) -> MetricsBuild:
     project = _random_dict_value(state.projects)
     metrics_build_id = uuid4()
     return MetricsBuild(
-        creation_timestamp=datetime.now(),
-        image_uri=str(random.choice(ascii_lowercase) for _ in range(20)),
+        creation_timestamp=datetime.now(tz=timezone.utc),
+        image_uri=_random_string(),
         metrics_build_id=str(metrics_build_id),
         name=f"metrics build {metrics_build_id}",
-        org_id="simbox.tech",
+        org_id=state.org_id,
         project_id=project.project_id,
-        user_id=f"simbox@{state.org_id}",
+        user_id=f"{_random_string()}@{state.org_id}",
         version=str(uuid4()),
     )
 
@@ -142,9 +146,9 @@ async def create_report_asyncio(
     report = Report(
         associated_account="",
         branch_id=body.branch_id,
-        creation_timestamp=datetime.now(),
+        creation_timestamp=datetime.now(tz=timezone.utc),
         end_timestamp=body.end_timestamp,
-        last_updated_timestamp=datetime.now(),
+        last_updated_timestamp=datetime.now(tz=timezone.utc),
         metrics_build_id=body.metrics_build_id,
         metrics_status=MetricStatus.NO_STATUS_REPORTED,
         name=body.name,

--- a/resim/orchestration/resim_python_client_mocks.py
+++ b/resim/orchestration/resim_python_client_mocks.py
@@ -4,6 +4,10 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
+"""
+Mocks for the resim python client so we don't have to hit the actual API.
+"""
+
 import random
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -26,6 +30,8 @@ from resim_python_client.models import (
 
 @dataclass
 class MockState:
+    """The state of the mock (i.e. mocking the internal state of the app)."""
+
     org_id: str = "simbox.tech"
     projects: dict[UUID, Project] = field(default_factory=dict)
     metrics_builds: dict[UUID, MetricsBuild] = field(default_factory=dict)
@@ -48,6 +54,7 @@ def _random_string() -> str:
 
 
 def random_project(state: MockState) -> Project:
+    """Get a random project consistent with the current state."""
     project_id = uuid4()
     return Project(
         creation_timestamp=datetime.now(tz=timezone.utc),
@@ -60,6 +67,7 @@ def random_project(state: MockState) -> Project:
 
 
 def random_batch(state: MockState) -> Batch:
+    """Get a random batch consistent with the current state."""
     batch_id = uuid4()
     branch_id = uuid4()  # TODO(michael) Once we add builds, get this from there.
     test_suite = _random_dict_value(state.test_suites)
@@ -75,6 +83,7 @@ def random_batch(state: MockState) -> Batch:
 
 
 def random_test_suite(state: MockState) -> Batch:
+    """Get a random test suite consistent with the current state."""
     test_suite_id = uuid4()
     metrics_build = _random_dict_value(state.metrics_builds)
     return TestSuite(
@@ -93,6 +102,7 @@ def random_test_suite(state: MockState) -> Batch:
 
 
 def random_metrics_build(state: MockState) -> MetricsBuild:
+    """Get a random metrics build consistent with the current state."""
     project = _random_dict_value(state.projects)
     metrics_build_id = uuid4()
     return MetricsBuild(
@@ -109,6 +119,11 @@ def random_metrics_build(state: MockState) -> MetricsBuild:
 
 def get_mock_client(state: MockState) -> MagicMock:
     return MagicMock(state=state)
+
+
+################################################################################
+# ENDPOINT MOCKS:
+################################################################################
 
 
 async def get_batch_asyncio(

--- a/resim/orchestration/resim_python_client_mocks.py
+++ b/resim/orchestration/resim_python_client_mocks.py
@@ -138,8 +138,6 @@ async def create_report_asyncio(
     body: ReportInput,
 ) -> Optional[Union[Any, Report]]:
     report_id = uuid4()
-    if not UUID(project_id) in client.state.projects:
-        raise ValueError("Project not found!")
     # TODO(michael) Enforce some consistency requirements
     report = Report(
         associated_account="",

--- a/resim/orchestration/resim_python_client_mocks.py
+++ b/resim/orchestration/resim_python_client_mocks.py
@@ -181,3 +181,26 @@ async def create_report_asyncio(
     )
     client.state.reports[report_id] = report
     return report
+
+
+def make_mock_state() -> MockState:
+    """Helper to create a MockState containing what we need for our tests."""
+    state = MockState()
+
+    for _ in range(5):
+        p = random_project(state)
+        state.projects[UUID(p.project_id)] = p
+
+    for _ in range(5):
+        mb = random_metrics_build(state)
+        state.metrics_builds[UUID(mb.metrics_build_id)] = mb
+
+    for _ in range(5):
+        ts = random_test_suite(state)
+        state.test_suites[UUID(ts.test_suite_id)] = ts
+
+    for _ in range(5):
+        b = random_batch(state)
+        state.batches[UUID(b.batch_id)] = b
+
+    return state

--- a/resim/orchestration/resim_python_client_mocks_test.py
+++ b/resim/orchestration/resim_python_client_mocks_test.py
@@ -19,6 +19,7 @@ import resim.orchestration.resim_python_client_mocks as mocks
 
 
 def make_mock_state() -> mocks.MockState:
+    """Helper to create a MockState containing what we need for this test."""
     state = mocks.MockState()
 
     for _ in range(5):

--- a/resim/orchestration/resim_python_client_mocks_test.py
+++ b/resim/orchestration/resim_python_client_mocks_test.py
@@ -18,33 +18,10 @@ from resim_python_client.models import Batch, Report, ReportInput, TestSuite
 import resim.orchestration.resim_python_client_mocks as mocks
 
 
-def make_mock_state() -> mocks.MockState:
-    """Helper to create a MockState containing what we need for this test."""
-    state = mocks.MockState()
-
-    for _ in range(5):
-        p = mocks.random_project(state)
-        state.projects[UUID(p.project_id)] = p
-
-    for _ in range(5):
-        mb = mocks.random_metrics_build(state)
-        state.metrics_builds[UUID(mb.metrics_build_id)] = mb
-
-    for _ in range(5):
-        ts = mocks.random_test_suite(state)
-        state.test_suites[UUID(ts.test_suite_id)] = ts
-
-    for _ in range(5):
-        b = mocks.random_batch(state)
-        state.batches[UUID(b.batch_id)] = b
-
-    return state
-
-
 class ReSimPythonClientMocksTest(unittest.IsolatedAsyncioTestCase):
     async def test_get_batch(self) -> None:
         # SETUP
-        client = mocks.get_mock_client(make_mock_state())
+        client = mocks.get_mock_client(mocks.make_mock_state())
         batch: Batch = next(iter(client.state.batches.values()))
 
         # ACTION
@@ -63,7 +40,7 @@ class ReSimPythonClientMocksTest(unittest.IsolatedAsyncioTestCase):
 
     async def test_get_test_suite(self) -> None:
         # SETUP
-        client = mocks.get_mock_client(make_mock_state())
+        client = mocks.get_mock_client(mocks.make_mock_state())
         test_suite: TestSuite = next(iter(client.state.test_suites.values()))
 
         # ACTION
@@ -86,7 +63,7 @@ class ReSimPythonClientMocksTest(unittest.IsolatedAsyncioTestCase):
 
     async def test_create_report(self) -> None:
         # SETUP
-        client = mocks.get_mock_client(make_mock_state())
+        client = mocks.get_mock_client(mocks.make_mock_state())
         batch: Batch = next(iter(client.state.batches.values()))
         start_timestamp = datetime.now()
 

--- a/resim/orchestration/resim_python_client_mocks_test.py
+++ b/resim/orchestration/resim_python_client_mocks_test.py
@@ -1,0 +1,115 @@
+# Copyright 2024 ReSim, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+
+"""
+Test for resim_python_client_mocks
+"""
+
+import unittest
+from datetime import datetime
+from uuid import UUID, uuid4
+
+from resim_python_client.models import Batch, Report, ReportInput, TestSuite
+
+import resim.orchestration.resim_python_client_mocks as mocks
+
+
+def make_mock_state() -> mocks.MockState:
+    state = mocks.MockState()
+
+    for _ in range(5):
+        p = mocks.random_project(state)
+        state.projects[UUID(p.project_id)] = p
+
+    for _ in range(5):
+        mb = mocks.random_metrics_build(state)
+        state.metrics_builds[UUID(mb.metrics_build_id)] = mb
+
+    for _ in range(5):
+        ts = mocks.random_test_suite(state)
+        state.test_suites[UUID(ts.test_suite_id)] = ts
+
+    for _ in range(5):
+        b = mocks.random_batch(state)
+        state.batches[UUID(b.batch_id)] = b
+
+    return state
+
+
+class ReSimPythonClientMocksTest(unittest.IsolatedAsyncioTestCase):
+    async def test_get_batch(self) -> None:
+        # SETUP
+        client = mocks.get_mock_client(make_mock_state())
+        batch: Batch = next(iter(client.state.batches.values()))
+
+        # ACTION
+        received_batch = await mocks.get_batch_asyncio(
+            project_id=batch.project_id, batch_id=batch.batch_id, client=client
+        )
+
+        # VERIFICATION
+        self.assertIs(batch, received_batch)
+
+        # ACTION / VERIFICATION
+        with self.assertRaises(ValueError):
+            await mocks.get_batch_asyncio(
+                project_id=str(uuid4()), batch_id=batch.batch_id, client=client
+            )
+
+    async def test_get_test_suite(self) -> None:
+        # SETUP
+        client = mocks.get_mock_client(make_mock_state())
+        test_suite: TestSuite = next(iter(client.state.test_suites.values()))
+
+        # ACTION
+        received_test_suite = await mocks.get_test_suite_asyncio(
+            project_id=test_suite.project_id,
+            test_suite_id=test_suite.test_suite_id,
+            client=client,
+        )
+
+        # VERIFICATION
+        self.assertIs(test_suite, received_test_suite)
+
+        # ACTION / VERIFICATION
+        with self.assertRaises(ValueError):
+            await mocks.get_test_suite_asyncio(
+                project_id=str(uuid4()),
+                test_suite_id=test_suite.test_suite_id,
+                client=client,
+            )
+
+    async def test_create_report(self) -> None:
+        # SETUP
+        client = mocks.get_mock_client(make_mock_state())
+        batch: Batch = next(iter(client.state.batches.values()))
+        start_timestamp = datetime.now()
+
+        body = ReportInput(
+            branch_id=batch.branch_id,
+            metrics_build_id=batch.metrics_build_id,
+            start_timestamp=start_timestamp,
+            test_suite_id=batch.test_suite_id,
+        )
+
+        # ACTION
+        report: Report = await mocks.create_report_asyncio(
+            project_id=batch.project_id,
+            body=body,
+            client=client,
+        )
+
+        # VERIFICATION
+        self.assertIs(report, client.state.reports[UUID(report.report_id)])
+        self.assertEqual(report.branch_id, batch.branch_id)
+        self.assertEqual(report.metrics_build_id, batch.metrics_build_id)
+        self.assertEqual(report.start_timestamp, start_timestamp)
+        self.assertEqual(report.test_suite_id, batch.test_suite_id)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description of change

Add a helper function which allows us to kickoff a report easily based on a batch id and a test suite allowlist. The idea is we can use this to automatically kick of reports as the last step of batch metrics.

Also add mocks for the API client so we don't have to hit the API to test this. The expectation is that this mocks library will grow as more endpoints require mocking.

## Guide to reproduce test results.

```bash
bazel test //resim/orchestration/...
```

## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
