### PR TITLE
Make packing/unpacking rigid body state deltas more explicit

### DIFF
--- a/resim/dynamics/rigid_body/BUILD
+++ b/resim/dynamics/rigid_body/BUILD
@@ -12,6 +12,7 @@ cc_library(
     hdrs = ["state.hh"],
     visibility = ["//visibility:public"],
     deps = [
+        "//resim/math:vector_partition",
         "//resim/transforms:se3",
     ],
 )
@@ -59,6 +60,7 @@ cc_library(
         ":state",
         "//resim/assert",
         "//resim/dynamics",
+        "//resim/math:vector_partition",
         "//resim/time:timestamp",
         "//resim/transforms:se3",
         "@libeigen//:eigen",

--- a/resim/dynamics/rigid_body/state.cc
+++ b/resim/dynamics/rigid_body/state.cc
@@ -12,12 +12,33 @@ namespace resim::dynamics::rigid_body {
 
 using transforms::SE3;
 
+Eigen::VectorBlock<State::Delta, transforms::SE3::DOF>
+State::delta_vector_pose_part(Delta &delta) {
+  return math::get_block<DeltaPartition, State::POSE>(delta);
+}
+
+Eigen::VectorBlock<const State::Delta, transforms::SE3::DOF>
+State::delta_vector_pose_part(const Delta &delta) {
+  return math::get_block<DeltaPartition, State::POSE>(delta);
+}
+
+Eigen::VectorBlock<State::Delta, transforms::SE3::DOF>
+State::delta_vector_velocity_part(Delta &delta) {
+  return math::get_block<DeltaPartition, State::VELOCITY>(delta);
+}
+
+Eigen::VectorBlock<const State::Delta, transforms::SE3::DOF>
+State::delta_vector_velocity_part(const Delta &delta) {
+  return math::get_block<DeltaPartition, State::VELOCITY>(delta);
+}
+
 State operator+(const State &state, const State::Delta &delta) {
   const auto from = state.reference_from_body.from();
   State result{state};
   result.reference_from_body =
-      state.reference_from_body * SE3::exp(delta.head<SE3::DOF>(), from, from);
-  result.d_reference_from_body += delta.tail<SE3::DOF>();
+      state.reference_from_body *
+      SE3::exp(State::delta_vector_pose_part(delta), from, from);
+  result.d_reference_from_body += State::delta_vector_velocity_part(delta);
   return result;
 }
 
@@ -28,10 +49,10 @@ State operator+(const State::Delta &delta, const State &state) {
 
 State::Delta operator-(const State &state_a, const State &state_b) {
   State::Delta result;
-  result.head<SE3::DOF>() =
+  State::delta_vector_pose_part(result) =
       (state_b.reference_from_body.inverse() * state_a.reference_from_body)
           .log();
-  result.tail<SE3::DOF>() =
+  State::delta_vector_velocity_part(result) =
       state_a.d_reference_from_body - state_b.d_reference_from_body;
   return result;
 }

--- a/resim/dynamics/rigid_body/state_test.cc
+++ b/resim/dynamics/rigid_body/state_test.cc
@@ -61,7 +61,7 @@ TEST(StateTest, TestAdd) {
         State::delta_vector_pose_part(delta)));
     EXPECT_TRUE(math::is_approx(
         sum.d_reference_from_body - state.d_reference_from_body,
-        State::delta_vector_pose_part(delta)));
+        State::delta_vector_velocity_part(delta)));
 
     EXPECT_EQ(state.reference_from_body.into(), sum.reference_from_body.into());
     EXPECT_EQ(state.reference_from_body.from(), sum.reference_from_body.from());

--- a/resim/dynamics/rigid_body/state_test.cc
+++ b/resim/dynamics/rigid_body/state_test.cc
@@ -56,10 +56,12 @@ TEST(StateTest, TestAdd) {
     const SE3 prev_from_next{
         state.reference_from_body.inverse() * sum.reference_from_body};
 
-    EXPECT_TRUE(math::is_approx(prev_from_next.log(), delta.head<SE3::DOF>()));
+    EXPECT_TRUE(math::is_approx(
+        prev_from_next.log(),
+        State::delta_vector_pose_part(delta)));
     EXPECT_TRUE(math::is_approx(
         sum.d_reference_from_body - state.d_reference_from_body,
-        delta.tail<SE3::DOF>()));
+        State::delta_vector_pose_part(delta)));
 
     EXPECT_EQ(state.reference_from_body.into(), sum.reference_from_body.into());
     EXPECT_EQ(state.reference_from_body.from(), sum.reference_from_body.from());


### PR DESCRIPTION
## Description of change
This is a ReSurrection of an old PR on a previous version of this repo.

Add getters which allow packing and unpacking of rigid body state deltas to be accomplished more explicitly without having to use head and tail frequently.

## Guide to reproduce test results.
```bash
bazel test //resim/dynamics/rigid_body/...
```
## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
