### PR TITLE
Reduce cache misses with --incompatible_strict_action_env

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -9,3 +9,4 @@ coverage --combined_report=lcov --experimental_generate_llvm_lcov --experimental
 
 common --registry=https://raw.githubusercontent.com/resim-ai/open-core/main/bazel_registry/
 common --registry=https://bcr.bazel.build
+common --incompatible_strict_action_env


### PR DESCRIPTION
## Description of change
Trunk as well as other tools often modify the $PATH when using bazel which causes "costly cache misses". This makes it necessary to rebuild dependencies more frequently than should be required. See [here](https://docs.aspect.build/guides/bazelrc/) for a brief explanation. We should maybe consider some of the other flags from there too.

## Guide to reproduce test results.
```
bazel build //...
```
Change PATH and verify that rebuilds are no longer required.

## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
