### PR TITLE
Add aarch64 toolchain

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,11 +10,11 @@ bazel_dep(name = "bazel_skylib", version = "1.6.1")
 bazel_dep(name = "com_github_mvukov_rules_ros2", version = "14b75cb377784f21d709663df6c599056a512c18")
 bazel_dep(name = "cpr", version = "1.10.5")
 bazel_dep(name = "cxxopts", version = "3.2.1")
-bazel_dep(name = "eigen", repo_name = "libeigen", version = "3.4.0")
+bazel_dep(name = "eigen", version = "3.4.0", repo_name = "libeigen")
 bazel_dep(name = "fmt", version = "10.2.1")
 bazel_dep(name = "foxglove_schemas", version = "0.7.1")
-bazel_dep(name = "glog", repo_name = "com_github_google_glog", version = "0.7.0")
-bazel_dep(name = "googletest", repo_name = "com_google_googletest", version = "1.14.0")
+bazel_dep(name = "glog", version = "0.7.0", repo_name = "com_github_google_glog")
+bazel_dep(name = "googletest", version = "1.14.0", repo_name = "com_google_googletest")
 bazel_dep(name = "hedron_compile_commands", version = "a14ad3a64e7bf398ab48105aaa0348e032ac87f8")
 bazel_dep(name = "httplib", version = "0.15.3")
 bazel_dep(name = "indicators", version = "2.3.0")
@@ -22,7 +22,7 @@ bazel_dep(name = "libuuid", version = "2.39.3")
 bazel_dep(name = "mcap", version = "1.2.1")
 bazel_dep(name = "nlohmann_json", version = "3.11.3")
 bazel_dep(name = "platforms", version = "0.0.10")
-bazel_dep(name = "protobuf", repo_name = "com_google_protobuf", version = "26.0")
+bazel_dep(name = "protobuf", version = "26.0", repo_name = "com_google_protobuf")
 bazel_dep(name = "pybind11_bazel", version = "2.12.0")
 bazel_dep(name = "resim-python-client", version = "185d9c00b3d7903150a3149fd7e258d9ceae12f5")
 bazel_dep(name = "ros2_common_interfaces", version = "4.2.3")
@@ -38,9 +38,9 @@ bazel_dep(name = "rules_pkg", version = "0.10.1")
 bazel_dep(name = "rules_proto", version = "6.0.0")
 bazel_dep(name = "rules_python", version = "0.35.0")
 bazel_dep(name = "vision_msgs", version = "4.1.0")
+bazel_dep(name = "rules_foreign_cc", version = "0.12.0")
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
-
 python.toolchain(
     configure_coverage_tool = True,
     ignore_root_user_error = True,
@@ -48,50 +48,46 @@ python.toolchain(
 )
 
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
-
 pip.parse(
     hub_name = "resim_python_deps",
     python_version = "3.10",
     requirements_lock = "@resim_open_core//:requirements_lock.txt",
 )
-
 use_repo(pip, "resim_python_deps")
-
 pip.parse(
     hub_name = "resim_pkg_deps",
     python_version = "3.10",
     requirements_lock = "@resim_open_core//pkg:requirements_lock.txt",
 )
-
 use_repo(pip, "resim_pkg_deps")
 
 register_toolchains(
     "@resim_open_core//resim/toolchain:cc_toolchain_for_k8",
     "@resim_open_core//resim/toolchain:aarch64_cross_toolchain_for_amd64",
+    "@resim_open_core//resim/toolchain:cc_toolchain_for_aarch64",
 )
 
 resim_version_extension = use_extension("@resim_open_core//:version.bzl", "resim_version_extension")
-
 use_repo(resim_version_extension, "resim_version")
 
 oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
-
 oci.pull(
     name = "debian_slim",
     image = "debian",
     platforms = [
         "linux/amd64",
+        "linux/arm64/v8",
     ],
     tag = "bookworm-slim",
 )
-
 oci.pull(
     name = "python_image",
     image = "python",
-    platforms = ["linux/amd64"],
+    platforms = [
+        "linux/amd64",
+        "linux/arm64/v8",
+    ],
     tag = "3.11-slim",
 )
-
 use_repo(oci, "debian_slim")
-
 use_repo(oci, "python_image")

--- a/resim/toolchain/BUILD
+++ b/resim/toolchain/BUILD
@@ -6,21 +6,15 @@
 
 # Copied from https://bazel.build/tutorials/cc-toolchain-config
 
-load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test", "cc_toolchain", "cc_toolchain_suite")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test", "cc_toolchain")
 load("@rules_python//python:defs.bzl", "py_test")
 load(":cc_toolchain_config.bzl", "cc_toolchain_config", "cc_toolchain_config_amd64_aarch64_cross")
 
 cc_toolchain_config(name = "k8_toolchain_config")
 
-cc_toolchain_config_amd64_aarch64_cross(name = "amd64_aarch64_cross_toolchain_config")
+cc_toolchain_config(name = "aarch64_toolchain_config")
 
-cc_toolchain_suite(
-    name = "clang_suite",
-    toolchains = {
-        "k8": ":k8_toolchain",
-    },
-    visibility = ["//visibility:public"],
-)
+cc_toolchain_config_amd64_aarch64_cross(name = "amd64_aarch64_cross_toolchain_config")
 
 filegroup(name = "empty")
 
@@ -35,6 +29,20 @@ cc_toolchain(
     supports_param_files = 0,
     toolchain_config = ":k8_toolchain_config",
     toolchain_identifier = "k8-toolchain",
+    visibility = ["//visibility:public"],
+)
+
+cc_toolchain(
+    name = "aarch64_toolchain",
+    all_files = ":empty",
+    compiler_files = ":empty",
+    dwp_files = ":empty",
+    linker_files = ":empty",
+    objcopy_files = ":empty",
+    strip_files = ":empty",
+    supports_param_files = 0,
+    toolchain_config = ":aarch64_toolchain_config",
+    toolchain_identifier = "aarch64-toolchain",
     visibility = ["//visibility:public"],
 )
 
@@ -63,6 +71,20 @@ toolchain(
         "@platforms//os:linux",
     ],
     toolchain = ":k8_toolchain",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+)
+
+toolchain(
+    name = "cc_toolchain_for_aarch64",
+    exec_compatible_with = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
+    target_compatible_with = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
+    toolchain = ":aarch64_toolchain",
     toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
 )
 

--- a/resim/toolchain/cc_toolchain_config.bzl
+++ b/resim/toolchain/cc_toolchain_config.bzl
@@ -173,6 +173,15 @@ def _impl(ctx):
         ],
     )
 
+def _aarch64_impl(ctx):
+    return _toolchain_config_helper(
+        ctx,
+        [
+            "/usr/lib/llvm-14/lib/clang/14.0.0/include",
+            "/usr/include",
+        ],
+    )
+
 def _amd64_aarch64_cross_impl(ctx):
     return _toolchain_config_helper(
         ctx,
@@ -186,6 +195,12 @@ def _amd64_aarch64_cross_impl(ctx):
 
 cc_toolchain_config = rule(
     implementation = _impl,
+    attrs = {},
+    provides = [CcToolchainConfigInfo],
+)
+
+cc_toolchain_config_aarch64 = rule(
+    implementation = _aarch64_impl,
     attrs = {},
     provides = [CcToolchainConfigInfo],
 )


### PR DESCRIPTION
## Description of change
Add an aarch64 toolchain for use on ubuntu.

## Guide to reproduce test results.
On a mac (in an ubuntu docker container):
```
bazel test //...
```

## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [ ] This change is covered by tests that are already landed, or in this PR.
