### PR TITLE
Limit number of concurrent endpoint calls in report metrics

### DIFF
--- a/resim/metrics/default_report_metrics.py
+++ b/resim/metrics/default_report_metrics.py
@@ -50,9 +50,11 @@ DEFAULT_OUTPUT_PATH = pathlib.Path("/tmp/resim/outputs/metrics.binproto")
 
 async def dict_gather(coroutine_dict: dict) -> dict:
     """A simple helper function that enables asyncio.gather to be called on dictionaries."""
+    semaphore = asyncio.Semaphore(24)
 
     async def tag(key: Hashable, coroutine: Awaitable) -> tuple:
-        return key, await coroutine
+        async with semaphore:
+            return key, await coroutine
 
     return dict(
         await asyncio.gather(


### PR DESCRIPTION
## Description of change
Use a semaphore to limit the number of concurrent endpoint calls in the default report metrics.

## Guide to reproduce test results.
Run against a large report which is known to be problematic.

## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [ ] This change is covered by tests that are already landed, or in this PR.
