### PR TITLE
Make python dependencies compatible with resim-python-client

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ pandas==2.1.0
 plotly==5.22.0
 polling2==0.5.0
 requests==2.31.0
-httpx==0.27.0
+httpx==0.25.2

--- a/requirements_lock.txt
+++ b/requirements_lock.txt
@@ -19,7 +19,7 @@ h11==0.14.0
     # via httpcore
 httpcore==1.0.5
     # via httpx
-httpx==0.27.0
+httpx==0.25.2
     # via -r requirements.txt
 idna==3.7
     # via


### PR DESCRIPTION
## Description of change
Make sure that our python dependencies are compatible with resim-python-client.

## Guide to reproduce test results.

Build the wheel locally and check that it can be included alongside the latest `resim-python-client` version with `pip-compile`.

## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [ ] This change is covered by tests that are already landed, or in this PR.
