### PR TITLE
Introduce Metrics Status Override

### DIFF
--- a/docs/resim/metrics/metrics_writer.md
+++ b/docs/resim/metrics/metrics_writer.md
@@ -71,6 +71,17 @@ metrics_writer.add_metrics_data(TIMESTAMPS)
 
 This is useful, because we may want to write data that is not immediately referenced by any metric. Such data may be used by **batch metrics**. The `MetricsData` class also has a simple fluent API to make this easier.
 
+## Overriding the metrics status
+
+By default, the `writer.write()` function constructs a protobuf message that computes an overall job status based on the individual metrics. 
+The logic is fairly simple: 
+- if any metric is a blocking failure (`FAIL_BLOCK_METRIC_STATUS`), the overall job will be considered a blocking failure;
+- otherwise, if any metric is a warning (`FAIL_WARN_METRIC_STATUS`), the overall job will be considered a warning failure;
+- otherwise, the overall job will be considered a pass;
+
+It is, however, possible to override that calculation with `writer.write(metrics_status_override=FAIL_BLOCK_METRIC_STATUS)`, or 
+whatever status you wish. This is particularly useful if you would like to ignore warnings, for example.
+
 ## Validating the metrics writer output
 
 It's important to validate your output, to check it's a valid protobuf message that our system can plot.  We currently provide this through the `validate_job_metrics` function in `resim.metrics.proto.validate_metrics_proto`. Note that this is called on the **output metrics message** of the metrics writer (i.e. `output.metrics_msg`), not the metrics writer itself.

--- a/resim/metrics/proto/validate_metrics_proto.py
+++ b/resim/metrics/proto/validate_metrics_proto.py
@@ -681,36 +681,6 @@ def _validate_metrics_data(
         _metrics_assert(metrics_data.index_data_type == index_data.data_type)
 
 
-def _validate_statuses(job_metrics: mp.JobMetrics) -> None:
-    """
-    Check that the statuses in this JobMetrics are consistent
-
-    This ensures that the status stored in the JobMetrics and the
-    MetricCollection match - e.g. they are PASSED if and only if
-    none of the metrics FAILED.
-
-    Args:
-        job_metrics: The job metrics to validate.
-    """
-
-    expected_status = mp.PASSED_METRIC_STATUS
-    for metric in job_metrics.job_level_metrics.metrics:
-        status = metric.status
-        if status == mp.FAIL_BLOCK_METRIC_STATUS:
-            expected_status = mp.FAIL_BLOCK_METRIC_STATUS
-        elif status == mp.FAIL_WARN_METRIC_STATUS:
-            expected_status = (
-                mp.FAIL_WARN_METRIC_STATUS
-                if (expected_status != mp.FAIL_BLOCK_METRIC_STATUS)
-                else mp.FAIL_BLOCK_METRIC_STATUS
-            )
-
-    _metrics_assert(expected_status == job_metrics.metrics_status)
-    _metrics_assert(
-        job_metrics.job_level_metrics.metrics_status == job_metrics.metrics_status
-    )
-
-
 def _validate_event(event: mp.Event, metrics_map: dict[str, mp.Metric]) -> None:
     """
     Check that the Event is valid.
@@ -847,5 +817,3 @@ def validate_job_metrics(job_metrics: mp.JobMetrics) -> None:
             _metrics_assert(event.timestamp_type == timestamp_type)
             event_names.add(event.name)
             _validate_event(event, metrics_map)
-
-    _validate_statuses(job_metrics)

--- a/resim/metrics/python/metrics_writer.py
+++ b/resim/metrics/python/metrics_writer.py
@@ -150,7 +150,7 @@ class ResimMetricsWriter:
         return metrics_data
 
     def write(
-        self, override_metrics_status: typing.Optional[MetricStatus] = None
+        self, metrics_status_override: typing.Optional[MetricStatus] = None
     ) -> ResimMetricsOutput:
         output = ResimMetricsOutput()
 
@@ -168,8 +168,8 @@ class ResimMetricsWriter:
         packed_job_id = pack_uuid_to_proto(self.job_id)
         output.metrics_msg.job_id.id.CopyFrom(packed_job_id)
 
-        if override_metrics_status is not None:
-            metrics_status = override_metrics_status.value
+        if metrics_status_override is not None:
+            metrics_status = metrics_status_override.value
         else:
             fail_block = any(
                 metric.status == ProtoMetricStatus.Value("FAIL_BLOCK_METRIC_STATUS")

--- a/resim/metrics/python/metrics_writer_test.py
+++ b/resim/metrics/python/metrics_writer_test.py
@@ -710,7 +710,7 @@ class TestMetricsWriter(unittest.TestCase):
                     .with_value(METRIC_VALUE)
                     .with_status(metric_status)
                 )
-                output = self.writer.write(override_metrics_status=override_status)
+                output = self.writer.write(metrics_status_override=override_status)
                 self.assertEqual(
                     output.metrics_msg.metrics_status, override_status.value
                 )

--- a/resim/metrics/python/metrics_writer_test.py
+++ b/resim/metrics/python/metrics_writer_test.py
@@ -699,7 +699,6 @@ class TestMetricsWriter(unittest.TestCase):
             ALL_STATUSES, ALL_STATUSES
         ):
             if override_status != metric_status:
-                print(metric_status, override_status)
                 self.writer = ResimMetricsWriter(self.job_id)
                 METRIC_NAME = (
                     "Scalar metric" + str(metric_status) + str(override_status)
@@ -721,12 +720,6 @@ class TestMetricsWriter(unittest.TestCase):
                 metric_base = output.metrics_msg.job_level_metrics.metrics[0]
                 self.assertEqual(metric_base.status, metric_status.value)
 
-                self.writer = ResimMetricsWriter(self.job_id)
-                (
-                    self.writer.add_scalar_metric(METRIC_NAME)
-                    .with_value(METRIC_VALUE)
-                    .with_status(metric_status)
-                )
                 output = self.writer.write()
                 self.assertEqual(len(output.packed_ids), 1)
                 self.assertEqual(len(output.metrics_msg.job_level_metrics.metrics), 1)


### PR DESCRIPTION
## Description of change

This PR proposes to extend the ReSim Metrics Writer to enable the passing through of a MetricsStatus that would override the default calculation for how an overall test status is calculated. It enables users flexibility to determine exactly how a test would fail based on the metrics it contains. For example, warnings could be ignored, rather than cause the whole test to be considered in a warning status.

## Guide to reproduce test results.

```
bazel test //...
```

## Checklist:
- [X] I have self-reviewed this change.
- [X] I have tested this change.
- [X] This change is covered by tests that are already landed, or in this PR.
