### PR TITLE
Add project id to BatchwiseBarChartMetric

### DIFF
--- a/resim/metrics/proto/generate_test_metrics.py
+++ b/resim/metrics/proto/generate_test_metrics.py
@@ -470,6 +470,7 @@ def _add_batchwise_bar_chart_metric(
     values = metric.metric_values.batchwise_bar_chart_metric_values
     values.categories.extend(["PASSED", "FAILED"])
     values.colors.extend(["#46ffd4", "#220050"])
+    values.project_id.data = _get_uuid_str()
 
     length = 10
 

--- a/resim/metrics/proto/metrics.proto
+++ b/resim/metrics/proto/metrics.proto
@@ -410,6 +410,8 @@ message BatchwiseBarChartMetricValues {
 
     optional bool stack_bars = 8;  // Whether series should be stacked, as
                                    // opposed to next to each other
+
+    optional resim.proto.UUID project_id = 9;  // The project id for the batches
 }
 
 message StatesOverTimeMetricValues {

--- a/resim/metrics/proto/validate_metrics_proto.py
+++ b/resim/metrics/proto/validate_metrics_proto.py
@@ -386,6 +386,8 @@ def _validate_batchwise_bar_chart_metric_values(
     for color in values.colors:
         _validate_hex_color(color)
 
+    _validate_uuid(values.project_id)
+
     for i in range(length):
         _validate_values_and_statuses(
             values.values_data_id[i],

--- a/resim/metrics/python/metrics.py
+++ b/resim/metrics/python/metrics.py
@@ -996,6 +996,7 @@ class BatchwiseBarChartMetric(Metric["BatchwiseBarChartMetric"]):
     statuses_data: List[MetricsData] = dataclasses.field(default_factory=list)
     categories: List[str] = dataclasses.field(default_factory=list)
     colors: List[str] = dataclasses.field(default_factory=list)
+    project_id: Optional[uuid.UUID]
     x_axis_name: str
     y_axis_name: str
     stack_bars: bool
@@ -1017,6 +1018,7 @@ class BatchwiseBarChartMetric(Metric["BatchwiseBarChartMetric"]):
         statuses_data: Optional[List[MetricsData]] = None,
         categories: Optional[List[str]] = None,
         colors: Optional[List[str]] = None,
+        project_id: Optional[uuid.UUID] = None,
         x_axis_name: str = "",
         y_axis_name: str = "",
         stack_bars: bool = False,
@@ -1053,6 +1055,7 @@ class BatchwiseBarChartMetric(Metric["BatchwiseBarChartMetric"]):
             self.colors = colors
         else:
             self.colors = []
+        self.project_id = project_id
         self.x_axis_name = x_axis_name
         self.y_axis_name = y_axis_name
         self.stack_bars = stack_bars
@@ -1093,10 +1096,16 @@ class BatchwiseBarChartMetric(Metric["BatchwiseBarChartMetric"]):
         self.stack_bars = stack_bars
         return self
 
+    def with_project_id(self, project_id: uuid.UUID) -> BatchwiseBarChartMetric:
+        self.project_id = project_id
+        return self
+
     def pack(self: BatchwiseBarChartMetric) -> metrics_proto.Metric:
         msg = super().pack()
         msg.type = metrics_proto.MetricType.Value("BATCHWISE_BAR_CHART_METRIC_TYPE")
         metric_values = msg.metric_values.batchwise_bar_chart_metric_values
+
+        assert self.project_id is not None
 
         if self.times_data is not None:
             for times_data in self.times_data:
@@ -1122,6 +1131,7 @@ class BatchwiseBarChartMetric(Metric["BatchwiseBarChartMetric"]):
         if self.colors is not None:
             metric_values.colors.extend(self.colors)
 
+        metric_values.project_id.data = str(self.project_id)
         metric_values.x_axis_name = self.x_axis_name
         metric_values.y_axis_name = self.y_axis_name
         metric_values.stack_bars = self.stack_bars

--- a/resim/metrics/python/metrics_test.py
+++ b/resim/metrics/python/metrics_test.py
@@ -1045,6 +1045,10 @@ class MetricsTest(unittest.TestCase):
         self.assertEqual(metric, metric.with_stack_bars(new_stack_bars))
         self.assertEqual(metric.stack_bars, new_stack_bars)
 
+        new_project_id = uuid.uuid4()
+        self.assertEqual(metric, metric.with_project_id(new_project_id))
+        self.assertEqual(metric.project_id, new_project_id)
+
     def test_batchwise_bar_chart_metric_pack(self) -> None:
         job_id = uuid.uuid4()
 
@@ -1074,6 +1078,7 @@ class MetricsTest(unittest.TestCase):
         )
 
         category = "passed"
+        project_id = uuid.uuid4()
         color = "#fa8072"
 
         # Use the constructor to initialize the data this time, in contrast with
@@ -1093,6 +1098,7 @@ class MetricsTest(unittest.TestCase):
             statuses_data=[status_data],
             categories=[category],
             colors=[color],
+            project_id=project_id,
             x_axis_name="my x axis",
             y_axis_name="my y axis",
             stack_bars=True,
@@ -1117,7 +1123,7 @@ class MetricsTest(unittest.TestCase):
         )
         self.assertEqual(set(values.categories), {category})
         self.assertEqual(set(values.colors), {color})
-
+        self.assertEqual(uuid.UUID(values.project_id.data), metric.project_id)
         for attr in ("x_axis_name", "y_axis_name", "stack_bars"):
             self.assertEqual(getattr(values, attr), getattr(metric, attr))
 

--- a/resim/metrics/python/unpack_metrics.py
+++ b/resim/metrics/python/unpack_metrics.py
@@ -358,7 +358,9 @@ def _unpack_batchwise_bar_chart_metric(
 
     unpacked.with_x_axis_name(values.x_axis_name).with_y_axis_name(
         values.y_axis_name
-    ).with_stack_bars(values.stack_bars).with_colors(values.colors)
+    ).with_stack_bars(values.stack_bars).with_colors(values.colors).with_project_id(
+        uuid.UUID(values.project_id.data)
+    )
 
 
 def _unpack_states_over_time_metric(


### PR DESCRIPTION
## Description of change
Add a project id to the batchwise bar chart metric to make rendering easier.

## Guide to reproduce test results.
```
bazel test //resim/metrics/...
```
## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
