### PR TITLE
Display test_status_over_time as a categorical bar chart

### DIFF
--- a/resim/metrics/default_report_metrics.py
+++ b/resim/metrics/default_report_metrics.py
@@ -422,6 +422,7 @@ def test_status_over_time_metric(
         .value_counts()
         .unstack(fill_value=0)
         .join(builds_frame)
+        .sort_values(by=["build_creation_timestamp"])
     )
 
     for status in (
@@ -435,13 +436,15 @@ def test_status_over_time_metric(
             continue
         fig.add_trace(
             go.Bar(
-                x=status_counts_frame.build_creation_timestamp,
+                x=status_counts_frame.build_creation_timestamp.dt.strftime(
+                    "%Y-%m-%d %H:%M"
+                ),
                 y=status_counts_frame[status],
                 name=status,
                 marker_color=resim_status_color_map[status],
             )
         )
-
+    fig.update_xaxes(type="category")
     resim_plotly_style(
         fig,
         barmode="stack",


### PR DESCRIPTION
## Description of change
To help with the issue of the status bar charts becoming unreadable when there are high numbers of batches, display it as a categorical bar chart instead.

## Guide to reproduce test results.
Generate a metrics.binproto with this locally and try it in the metrics debugger.

## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
