### PR TITLE
Fix fetch fetch job metrics

### DIFF
--- a/resim/metrics/BUILD
+++ b/resim/metrics/BUILD
@@ -177,8 +177,8 @@ py_test(
     name = "fetch_job_metrics_test",
     srcs = ["fetch_job_metrics_test.py"],
     deps = [
-        "//resim/metrics/proto:metrics_proto_py",
         ":fetch_job_metrics",
+        "//resim/metrics/proto:metrics_proto_py",
     ],
 )
 

--- a/resim/metrics/BUILD
+++ b/resim/metrics/BUILD
@@ -177,6 +177,7 @@ py_test(
     name = "fetch_job_metrics_test",
     srcs = ["fetch_job_metrics_test.py"],
     deps = [
+        "//resim/metrics/proto:metrics_prot
         ":fetch_job_metrics",
     ],
 )

--- a/resim/metrics/BUILD
+++ b/resim/metrics/BUILD
@@ -177,7 +177,7 @@ py_test(
     name = "fetch_job_metrics_test",
     srcs = ["fetch_job_metrics_test.py"],
     deps = [
-        "//resim/metrics/proto:metrics_prot
+        "//resim/metrics/proto:metrics_proto_py",
         ":fetch_job_metrics",
     ],
 )

--- a/resim/metrics/fetch_job_metrics.py
+++ b/resim/metrics/fetch_job_metrics.py
@@ -268,8 +268,15 @@ def _fetch_metrics(
     Simple wrapper around get_metrics_proto which locks a mutex
     so we can multithread this.
     """
-    protos_lock.acquire()
-    protos[job_id].append(
-        get_metrics_proto(message_type=message_type, session=session, url=url)
+    metrics_proto = get_metrics_proto(
+        message_type=message_type, session=session, url=url
     )
+
+    if (
+        message_type == mp.Metric
+        and metrics_proto.type == mp.MetricType.IMAGE_METRIC_TYPE
+    ):
+        return
+    protos_lock.acquire()
+    protos[job_id].append(metrics_proto)
     protos_lock.release()


### PR DESCRIPTION
## Description of change
Currently, fetching image metrics fails in fetch_job_metrics since image metrics depend on external file metrics data, which we don't fetch since they don't have a protobuf message.

## Guide to reproduce test results.
Try running fetch_job_metrics_for_batch() on an existing batch.

## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
