### PR TITLE
Text Metrics

### DIFF
--- a/resim/metrics/proto/generate_test_metrics.py
+++ b/resim/metrics/proto/generate_test_metrics.py
@@ -930,6 +930,7 @@ def generate_test_metrics(block_fail: bool = False) -> mp.JobMetrics:
     _add_subsystem_states(job_metrics)
     _add_string_and_uuid_summary_metrics(job_metrics)
     _add_plotly_metric(job_metrics)
+    _add_text_metric(job_metrics)
     _add_image_metric(job_metrics)
     _populate_metrics_statuses(job_metrics)
     # Test events:

--- a/resim/metrics/proto/generate_test_metrics.py
+++ b/resim/metrics/proto/generate_test_metrics.py
@@ -827,6 +827,21 @@ def _add_image_metric(job_metrics: mp.JobMetrics) -> None:
     image_metric_values.image_data_id.CopyFrom(metrics_data.metrics_data_id)
 
 
+def _add_text_metric(job_metrics: mp.JobMetrics) -> None:
+    metric = job_metrics.job_level_metrics.metrics.add()
+    metric.metric_id.id.data = _get_uuid_str()
+    metric.name = "A text metric"
+    metric.type = mp.TEXT_METRIC_TYPE
+    metric.description = "A textual metric, using markdown"
+    metric.status = mp.NOT_APPLICABLE_METRIC_STATUS
+    metric.should_display = True
+    metric.blocking = False
+    metric.importance = mp.ZERO_IMPORTANCE
+    metric.order = 13.0
+    metric.job_id.CopyFrom(job_metrics.job_id)
+    metric.metric_values.text_metric_values.text = "Hello, world!"
+
+
 def _add_event_scalar_metric(
     job_metrics: mp.JobMetrics, tag_as_event: bool
 ) -> mp.MetricId:

--- a/resim/metrics/proto/metrics.proto
+++ b/resim/metrics/proto/metrics.proto
@@ -156,6 +156,7 @@ enum MetricType {
     PLOTLY_METRIC_TYPE              = 8;
     IMAGE_METRIC_TYPE               = 9;
     BATCHWISE_BAR_CHART_METRIC_TYPE = 10;
+    TEXT_METRIC_TYPE                = 11;
 }
 
 message MetricId {
@@ -297,6 +298,7 @@ message MetricValues {
         PlotlyMetricValues            plotly_metric_values              = 8;
         ImageMetricValues             image_metric_values               = 9;
         BatchwiseBarChartMetricValues batchwise_bar_chart_metric_values = 10;
+        TextMetricValues              text_metric_values                = 11;
     }
 }
 
@@ -460,4 +462,8 @@ message PlotlyMetricValues {
 
 message ImageMetricValues {
     MetricsDataId image_data_id = 1;
+}
+
+message TextMetricValues {
+    string text = 1;
 }

--- a/resim/metrics/proto/validate_metrics_proto.py
+++ b/resim/metrics/proto/validate_metrics_proto.py
@@ -513,6 +513,16 @@ def _validate_plotly_metric_values(plotly_metric_values: mp.PlotlyMetricValues) 
     _metrics_assert(plotly_metric_values.HasField("json"))
 
 
+def _validate_text_metric_values(text_metric_values: mp.TextMetricValues) -> None:
+    """
+    Check that a TextMetricValues is valid.
+
+    Args:
+        text_metric_values: The metric values to check.
+    """
+    _metrics_assert(text_metric_values.HasField("text"))
+
+
 def _validate_image_metric_values(
     image_metric_values: mp.ImageMetricValues,
     metrics_data_map: dict[str, mp.MetricsData],
@@ -576,6 +586,8 @@ def _validate_metric_values(
         _validate_scalar_metric_values(metric_values.scalar_metric_values)
     elif metric_values.HasField("plotly_metric_values"):
         _validate_plotly_metric_values(metric_values.plotly_metric_values)
+    elif metric_values.HasField("text_metric_values"):
+        _validate_text_metric_values(metric_values.text_metric_values)
     else:  # metric_values.HasField("image_metric_values")
         _validate_image_metric_values(
             metric_values.image_metric_values, metrics_data_map
@@ -648,6 +660,8 @@ def _validate_metric(
         _metrics_assert(metric.metric_values.HasField("scalar_metric_values"))
     elif metric.type == mp.PLOTLY_METRIC_TYPE:
         _metrics_assert(metric.metric_values.HasField("plotly_metric_values"))
+    elif metric.type == mp.TEXT_METRIC_TYPE:
+        _metrics_assert(metric.metric_values.HasField("text_metric_values"))
     else:  # mp.IMAGE_METRIC_TYPE
         _metrics_assert(metric.metric_values.HasField("image_metric_values"))
 

--- a/resim/metrics/proto/validate_metrics_proto.py
+++ b/resim/metrics/proto/validate_metrics_proto.py
@@ -520,7 +520,7 @@ def _validate_text_metric_values(text_metric_values: mp.TextMetricValues) -> Non
     Args:
         text_metric_values: The metric values to check.
     """
-    _metrics_assert(text_metric_values.HasField("text"))
+    _metrics_assert(text_metric_values.text != "")
 
 
 def _validate_image_metric_values(

--- a/resim/metrics/python/metrics_writer.py
+++ b/resim/metrics/python/metrics_writer.py
@@ -31,6 +31,7 @@ from resim.metrics.python.metrics import (
     ScalarMetric,
     SeriesMetricsData,
     StatesOverTimeMetric,
+    TextMetric,
 )
 from resim.metrics.python.metrics_utils import ResimMetricsOutput, pack_uuid_to_proto
 
@@ -141,6 +142,11 @@ class ResimMetricsWriter:
 
     def add_image_metric(self, name: str) -> ImageMetric:
         metric = ImageMetric(name=name, parent_job_id=self.job_id)
+        self.add_metric(metric)
+        return metric
+
+    def add_text_metric(self, name: str) -> TextMetric:
+        metric = TextMetric(name=name, parent_job_id=self.job_id)
         self.add_metric(metric)
         return metric
 

--- a/resim/metrics/python/metrics_writer_test.py
+++ b/resim/metrics/python/metrics_writer_test.py
@@ -586,6 +586,42 @@ class TestMetricsWriter(unittest.TestCase):
         self.assertEqual(metric_base.name, METRIC_NAME)
         self.assertEqual(MessageToDict(metric_values.json), json.loads(METRIC_DATA))
 
+    def test_text_metric(self) -> None:
+        METRIC_NAME = "Text metric"
+        METRIC_DESCRIPTION = "Description"
+        METRIC_BLOCKING = True
+        METRIC_DISPLAY = True
+        METRIC_IMPORTANCE = MetricImportance.HIGH_IMPORTANCE
+        METRIC_STATUS = MetricStatus.PASSED_METRIC_STATUS
+        METRIC_DATA = "*Hello* **world**"
+
+        (
+            self.writer.add_text_metric(METRIC_NAME)
+            .with_text(METRIC_DATA)
+            .with_description(METRIC_DESCRIPTION)
+            .with_blocking(METRIC_BLOCKING)
+            .with_should_display(METRIC_DISPLAY)
+            .with_importance(METRIC_IMPORTANCE)
+            .with_status(METRIC_STATUS)
+            .is_event_metric()
+        )
+
+        output = self.writer.write()
+        self.assertEqual(len(output.packed_ids), 1)
+        self.assertEqual(len(output.metrics_msg.job_level_metrics.metrics), 1)
+        self.assertEqual(len(output.metrics_msg.metrics_data), 0)
+
+        metric_base = output.metrics_msg.job_level_metrics.metrics[0]
+        metric_values = metric_base.metric_values.text_metric_values
+
+        self.assertEqual(metric_base.description, METRIC_DESCRIPTION)
+        self.assertEqual(metric_base.blocking, METRIC_BLOCKING)
+        self.assertEqual(metric_base.should_display, METRIC_DISPLAY)
+        self.assertEqual(metric_base.importance, METRIC_IMPORTANCE.value)
+        self.assertEqual(metric_base.status, METRIC_STATUS.value)
+        self.assertEqual(metric_base.name, METRIC_NAME)
+        self.assertEqual(metric_values.text, METRIC_DATA)
+
     def test_image_metric(self) -> None:
         METRIC_NAME = "Image metric"
         METRIC_DESCRIPTION = "Description"

--- a/resim/metrics/python/unpack_metrics.py
+++ b/resim/metrics/python/unpack_metrics.py
@@ -38,6 +38,7 @@ from resim.metrics.python.metrics import (
     ScalarMetric,
     SeriesMetricsData,
     StatesOverTimeMetric,
+    TextMetric,
 )
 from resim.metrics.python.metrics_utils import (
     DoubleFailureDefinition,
@@ -221,6 +222,7 @@ def _unpack_metric(
         ScalarMetric: _unpack_scalar_metric,
         PlotlyMetric: _unpack_plotly_metric,
         ImageMetric: _unpack_image_metric,
+        TextMetric: _unpack_text_metric,
         BatchwiseBarChartMetric: _unpack_batchwise_bar_chart_metric,
     }
     unpacker: Callable = unpackers[type(unpacked)]
@@ -430,6 +432,13 @@ def _unpack_image_metric(
         id_to_unpacked_metrics_data[_unpack_uuid(image_data.image_data_id.id)],
     )
     unpacked.with_image_data(data)
+
+
+def _unpack_text_metric(
+    metric: mp.Metric, unpacked: TextMetric, _: dict[uuid.UUID, MetricsData]
+) -> None:
+    text_metric_text = metric.metric_values.text_metric_values.text
+    unpacked.with_text(text_metric_text)
 
 
 def _unpack_event(


### PR DESCRIPTION
## Description of change

Extends the ReSim Metrics SDK with a 'Text Metric', which aims solely to display markdown as a metric.

## Guide to reproduce test results.

```
bazel test //...
```
## Checklist:
- [X] I have self-reviewed this change.
- [X] I have tested this change.
- [X] This change is covered by tests that are already landed, or in this PR.
