### PR TITLE
Only build stubs on host

### DIFF
--- a/.github/workflows/lint-and-codecov.yml
+++ b/.github/workflows/lint-and-codecov.yml
@@ -20,22 +20,6 @@ jobs:
         with:
           bazel_cache_auth_string: ${{ secrets.BAZEL_CACHE_AUTH_STRING }}
 
-      - name: Build Aarch64 Wheel
-        id: build_aarch64_wheel
-        env:
-          RESIM_VERSION: v420
-          OUTPUT_BASE: "~/.cache/cross_output" # Purposefully avoids the cache
-        run: |
-          bazel --output_base $OUTPUT_BASE \
-            build --platforms //:aarch64_linux //pkg:resim_wheel \
-              --repo_env="RESIM_VERSION=$RESIM_VERSION"
-          OUTPATH=$(bazel --output_base $OUTPUT_BASE info output_path)
-          WHEELPATH=$OUTPATH/../$(bazel --output_base $OUTPUT_BASE \
-            cquery --platforms //:aarch64_linux //pkg:resim_wheel \
-              --repo_env="RESIM_VERSION=$RESIM_VERSION" \
-              --output files)
-          echo "path=$(realpath $WHEELPATH)" >> $GITHUB_OUTPUT
-
       - name: Build `compile_commands.json` database
         run: bazel run @hedron_compile_commands//:refresh_all
 

--- a/.github/workflows/lint-and-codecov.yml
+++ b/.github/workflows/lint-and-codecov.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Build Aarch64 Wheel
         id: build_aarch64_wheel
         env:
-          RESIM_VERSION: ${{ github.event.inputs.tag }}
+          RESIM_VERSION: v420
           OUTPUT_BASE: "~/.cache/cross_output" # Purposefully avoids the cache
         run: |
           bazel --output_base $OUTPUT_BASE \

--- a/.github/workflows/lint-and-codecov.yml
+++ b/.github/workflows/lint-and-codecov.yml
@@ -20,6 +20,22 @@ jobs:
         with:
           bazel_cache_auth_string: ${{ secrets.BAZEL_CACHE_AUTH_STRING }}
 
+      - name: Build Aarch64 Wheel
+        id: build_aarch64_wheel
+        env:
+          RESIM_VERSION: ${{ github.event.inputs.tag }}
+          OUTPUT_BASE: "~/.cache/cross_output" # Purposefully avoids the cache
+        run: |
+          bazel --output_base $OUTPUT_BASE \
+            build --platforms //:aarch64_linux //pkg:resim_wheel \
+              --repo_env="RESIM_VERSION=$RESIM_VERSION"
+          OUTPATH=$(bazel --output_base $OUTPUT_BASE info output_path)
+          WHEELPATH=$OUTPATH/../$(bazel --output_base $OUTPUT_BASE \
+            cquery --platforms //:aarch64_linux //pkg:resim_wheel \
+              --repo_env="RESIM_VERSION=$RESIM_VERSION" \
+              --output files)
+          echo "path=$(realpath $WHEELPATH)" >> $GITHUB_OUTPUT
+
       - name: Build `compile_commands.json` database
         run: bazel run @hedron_compile_commands//:refresh_all
 

--- a/BUILD
+++ b/BUILD
@@ -4,6 +4,8 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
+load("@platforms//host:constraints.bzl", "HOST_CONSTRAINTS")
+
 exports_files(["requirements.txt"])
 
 platform(
@@ -12,4 +14,10 @@ platform(
         "@platforms//os:linux",
         "@platforms//cpu:aarch64",
     ],
+)
+
+config_setting(
+    name = "nocross",
+    constraint_values = HOST_CONSTRAINTS,
+    visibility = ["//visibility:public"],
 )

--- a/bazel/python.bzl
+++ b/bazel/python.bzl
@@ -6,6 +6,7 @@
 
 """Python & PyBind rule customizations."""
 
+load("@platforms//host:constraints.bzl", "HOST_CONSTRAINTS")
 load("@pybind11_bazel//:build_defs.bzl", _pybind_extension = "pybind_extension")
 load("@resim_python_deps//:requirements.bzl", "requirement")
 
@@ -22,6 +23,7 @@ def pybind_extension(
         extension = ":{}".format(name),
         testonly = kwargs.get("testonly"),
         visibility = kwargs.get("visibility"),
+        target_compatible_with = HOST_CONSTRAINTS,
     )
 
 def _get_module_name(pybind_binary_path):

--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -114,8 +114,9 @@ py_wheel(
     version = version,
     deps = [
         ":resim_package",
-        ":resim_package_stubs",
-    ],
+    ] + select({
+        "//:nocross": [":resim_package_stubs"],
+    }),
 )
 
 py_package(
@@ -242,8 +243,9 @@ py_wheel(
     version = version,
     deps = [
         "//resim/ros2:ros2_py_package",
-        "//resim/ros2:ros2_py_package_stubs",
-    ],
+    ] + select({
+        "//:nocross": ["//resim/ros2:ros2_py_package_stubs"],
+    }),
 )
 
 py_console_script_binary(

--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -116,6 +116,7 @@ py_wheel(
         ":resim_package",
     ] + select({
         "//:nocross": [":resim_package_stubs"],
+        "//conditions:default": [],
     }),
 )
 
@@ -245,6 +246,7 @@ py_wheel(
         "//resim/ros2:ros2_py_package",
     ] + select({
         "//:nocross": ["//resim/ros2:ros2_py_package_stubs"],
+        "//conditions:default": [],
     }),
 )
 


### PR DESCRIPTION
## Description of change
Add the needed config settings so that we don't try to generate python stubs from cross-compiled pybindings.


## Guide to reproduce test results.
Splice the cross-compilation step of the release temporarily into the lint and codecov CI run for this branch:
https://github.com/resim-ai/open-core/actions/runs/12838210087/job/35803390912?pr=217

## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [ ] This change is covered by tests that are already landed, or in this PR.
