### PR TITLE
Add box-box distance function

### DIFF
--- a/resim/geometry/BUILD
+++ b/resim/geometry/BUILD
@@ -94,6 +94,19 @@ cc_library(
     ],
 )
 
+cc_test(
+    name = "box_box_distance_test",
+    srcs = ["box_box_distance_test.cc"],
+    deps = [
+        ":boxes_collide",
+        "//resim/assert",
+        "//resim/transforms:se3",
+        "//resim/transforms:so3",
+        "@com_google_googletest//:gtest_main",
+        "@libeigen//:eigen",
+    ],
+)
+
 cc_library(
     name = "boxes_collide",
     srcs = ["boxes_collide.cc"],

--- a/resim/geometry/BUILD
+++ b/resim/geometry/BUILD
@@ -80,10 +80,26 @@ cc_test(
 )
 
 cc_library(
+    name = "box_box_distance",
+    srcs = ["box_box_distance.cc"],
+    hdrs = ["box_box_distance.hh"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gjk_algorithm",
+        ":oriented_box",
+        "//resim/assert",
+        "//resim/transforms:liegroup_concepts",
+        "//resim/transforms:se3",
+        "@libeigen//:eigen",
+    ],
+)
+
+cc_library(
     name = "boxes_collide",
     srcs = ["boxes_collide.cc"],
     hdrs = ["boxes_collide.hh"],
     deps = [
+        ":box_box_distance",
         ":gjk_algorithm",
         ":oriented_box",
         "//resim/assert",

--- a/resim/geometry/box_box_distance.cc
+++ b/resim/geometry/box_box_distance.cc
@@ -1,0 +1,74 @@
+
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include <Eigen/Dense>
+
+#include "resim/assert/assert.hh"
+#include "resim/geometry/box_box_distance.hh"
+#include "resim/geometry/gjk_algorithm.hh"
+#include "resim/transforms/se3.hh"
+
+namespace resim::geometry {
+
+namespace {
+using Vec3 = Eigen::Vector3d;
+using transforms::LieGroupType;
+
+// This helper represents the support function for a simple oriented box
+template <LieGroupType Group>
+Vec3 box_support(const OrientedBox<Group> &box, const Vec3 &direction) {
+  REASSERT(not direction.isZero(), "Zero direction detected!");
+  const Vec3 direction_in_box_coordinates{
+      box.reference_from_box().rotation().inverse() * direction};
+
+  const Vec3 support_in_box_coordinates{direction.binaryExpr(
+      box.extents(),
+      [](const double direction_element, const double extents_element) {
+        constexpr double HALF = 0.5;
+        constexpr double ZERO = 0.;
+        return extents_element *
+               (direction_element > 0.
+                    ? HALF
+                    : (direction_element < 0. ? -HALF : ZERO));
+      })};
+
+  Vec3 support_in_ref_coordinates{
+      box.reference_from_box() * support_in_box_coordinates};
+  return support_in_ref_coordinates;
+}
+
+}  // namespace
+
+template <transforms::LieGroupType Group>
+double box_box_distance(
+    const OrientedBox<Group> &box_1,
+    const OrientedBox<Group> &box_2) {
+  const bool frames_match =
+      box_1.reference_from_box().into() == box_2.reference_from_box().into();
+  REASSERT(frames_match, "Box frames don't match!");
+
+  constexpr int DIM = 3;
+  const SupportFunction<DIM> support_1{[&](const Vec3 &direction) -> Vec3 {
+    return box_support(box_1, direction);
+  }};
+  const SupportFunction<DIM> support_2{[&](const Vec3 &direction) -> Vec3 {
+    return box_support(box_2, direction);
+  }};
+
+  const std::optional<double> maybe_box_box_distance =
+      gjk_algorithm(support_1, support_2);
+
+  REASSERT(maybe_box_box_distance.has_value(), "GJK Algorithm Failed!");
+
+  return *maybe_box_box_distance;
+}
+
+template double box_box_distance(
+    const OrientedBox<transforms::SE3> &box_1,
+    const OrientedBox<transforms::SE3> &box_2);
+
+}  // namespace resim::geometry

--- a/resim/geometry/box_box_distance.cc
+++ b/resim/geometry/box_box_distance.cc
@@ -25,7 +25,7 @@ Vec3 box_support(const OrientedBox<Group> &box, const Vec3 &direction) {
   const Vec3 direction_in_box_coordinates{
       box.reference_from_box().rotation().inverse() * direction};
 
-  const Vec3 support_in_box_coordinates{direction.binaryExpr(
+  const Vec3 support_in_box_coordinates{direction_in_box_coordinates.binaryExpr(
       box.extents(),
       [](const double direction_element, const double extents_element) {
         constexpr double HALF = 0.5;

--- a/resim/geometry/box_box_distance.cc
+++ b/resim/geometry/box_box_distance.cc
@@ -1,5 +1,4 @@
-
-// Copyright 2023 ReSim, Inc.
+// Copyright 2025 ReSim, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/resim/geometry/box_box_distance.cc
+++ b/resim/geometry/box_box_distance.cc
@@ -5,10 +5,11 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+#include "resim/geometry/box_box_distance.hh"
+
 #include <Eigen/Dense>
 
 #include "resim/assert/assert.hh"
-#include "resim/geometry/box_box_distance.hh"
 #include "resim/geometry/gjk_algorithm.hh"
 #include "resim/transforms/se3.hh"
 

--- a/resim/geometry/box_box_distance.hh
+++ b/resim/geometry/box_box_distance.hh
@@ -1,0 +1,23 @@
+// Copyright 2023 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#pragma once
+
+#include "resim/geometry/oriented_box.hh"
+#include "resim/transforms/liegroup_concepts.hh"
+
+namespace resim::geometry {
+
+// This function determines the distance between two oriented boxes
+// @param[in] box_1 - The first box.
+// @param[in] box_2 - The second box.
+// @returns The distance between the boxes.
+template <transforms::LieGroupType Group>
+double box_box_distance(
+    const OrientedBox<Group> &box_1,
+    const OrientedBox<Group> &box_2);
+
+}  // namespace resim::geometry

--- a/resim/geometry/box_box_distance.hh
+++ b/resim/geometry/box_box_distance.hh
@@ -1,4 +1,4 @@
-// Copyright 2023 ReSim, Inc.
+// Copyright 2025 ReSim, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/resim/geometry/box_box_distance_test.cc
+++ b/resim/geometry/box_box_distance_test.cc
@@ -1,0 +1,145 @@
+// Copyright 2025 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include <gtest/gtest.h>
+
+#include <Eigen/Dense>
+
+#include "oriented_box.hh"
+#include "resim/assert/assert.hh"
+#include "resim/geometry/box_box_distance.hh"
+#include "resim/transforms/se3.hh"
+#include "resim/transforms/so3.hh"
+namespace resim::geometry {
+
+using Vec3 = Eigen::Vector3d;
+using transforms::LieGroupType;
+using transforms::SE3;
+using transforms::SO3;
+using Frame = transforms::Frame<transforms::SE3::DIMS>;
+
+class BoxBoxDistanceTest : public ::testing::Test {};
+
+TEST_F(BoxBoxDistanceTest, TestFaceFaceDistance) {
+  // SETUP
+  const Vec3 extents_a{Vec3{1.0, 2.0, 3.0}};
+  const Vec3 extents_b{Vec3{3.0, 2.0, 1.0}};
+
+  const SE3 scene_from_box_a{SE3::identity()};
+  const SE3 scene_from_box_b{3.0 * Vec3::UnitY()};
+
+  const OrientedBox<SE3> box_a{scene_from_box_a, extents_a};
+  const OrientedBox<SE3> box_b{scene_from_box_b, extents_b};
+
+  // ACTION
+  const double distance_ab = box_box_distance(box_a, box_b);
+  const double distance_ba = box_box_distance(box_b, box_a);
+
+  // VERIFICATION
+  constexpr double TOLERANCE = 1e-8;
+  EXPECT_NEAR(
+      distance_ab,
+      scene_from_box_b.translation().y() - extents_a.y() / 2.0 -
+          extents_b.y() / 2.0,
+      TOLERANCE);
+  EXPECT_NEAR(distance_ab, distance_ba, TOLERANCE);
+}
+
+TEST_F(BoxBoxDistanceTest, TestFaceEdgeDistance) {
+  // SETUP
+  const Vec3 extents_a{Vec3{1.0, 2.0, 3.0}};
+  const Vec3 extents_b{Vec3{2.0, 2.0, 1.0}};
+
+  const SE3 scene_from_box_a{SE3::identity()};
+  constexpr double THETA = M_PI_4;
+  const SE3 scene_from_box_b{
+      SO3::exp(THETA * Vec3::UnitZ()),
+      3.0 * Vec3::UnitY()};
+
+  const OrientedBox<SE3> box_a{scene_from_box_a, extents_a};
+  const OrientedBox<SE3> box_b{scene_from_box_b, extents_b};
+
+  // ACTION
+  const double distance_ab = box_box_distance(box_a, box_b);
+  const double distance_ba = box_box_distance(box_b, box_a);
+
+  // VERIFICATION
+  constexpr double TOLERANCE = 1e-8;
+  EXPECT_NEAR(
+      distance_ab,
+      scene_from_box_b.translation().y() - extents_a.y() / 2.0 -
+          (extents_b.y() * std::cos(THETA) + extents_b.x() * std::sin(THETA)) /
+              2.0,
+      TOLERANCE);
+  EXPECT_NEAR(distance_ab, distance_ba, TOLERANCE);
+}
+
+TEST_F(BoxBoxDistanceTest, TestFaceVertexDistance) {
+  // SETUP
+  const Vec3 extents_a{Vec3{1.0, 2.0, 3.0}};
+  const Vec3 extents_b{Vec3{2.0, 2.0, 2.0}};
+
+  // The idea is to find a rotation that maps a corner of our cube (for b) to be
+  // as close to box a as possible. Find the rotation that maps (1, 1,
+  // 1)/sqrt(3) to (0, -1, 0):
+  const Vec3 source{Vec3::Ones() / std::sqrt(3.0)};
+  const Vec3 dest{-Vec3::UnitY()};
+  const Vec3 rot_angle_axis{
+      source.cross(dest).normalized() * std::asin(source.cross(dest).norm())};
+
+  const SE3 scene_from_box_a{SE3::identity()};
+  const SE3 scene_from_box_b{SO3::exp(rot_angle_axis), 3.0 * Vec3::UnitY()};
+
+  const OrientedBox<SE3> box_a{scene_from_box_a, extents_a};
+  const OrientedBox<SE3> box_b{scene_from_box_b, extents_b};
+
+  // ACTION
+  const double distance_ab = box_box_distance(box_a, box_b);
+  const double distance_ba = box_box_distance(box_b, box_a);
+
+  // VERIFICATION
+  // Based on the specific rotation we set up for b above and its extents:
+  const double expected_distance =
+      scene_from_box_b.translation().y() - extents_a.y() / 2.0 - std::sqrt(3.0);
+  constexpr double TOLERANCE = 1e-8;
+  EXPECT_NEAR(distance_ab, expected_distance, TOLERANCE);
+  EXPECT_NEAR(distance_ab, distance_ba, TOLERANCE);
+}
+
+TEST_F(BoxBoxDistanceTest, TestEdgeEdgeDistance) {
+  // SETUP
+  const Vec3 extents_a{Vec3{2.0, 2.0, 3.0}};
+  const Vec3 extents_b{Vec3{2.0, 2.0, 1.0}};
+
+  constexpr double THETA = M_PI_4;
+  const SE3 scene_from_box_a{
+      SO3::exp(THETA * Vec3::UnitZ()),
+  };
+  const SE3 scene_from_box_b{
+      SO3::exp(M_PI_2 * Vec3::UnitY()) * SO3::exp(THETA * Vec3::UnitZ()),
+      3.0 * Vec3::UnitY()};
+
+  const OrientedBox<SE3> box_a{scene_from_box_a, extents_a};
+  const OrientedBox<SE3> box_b{scene_from_box_b, extents_b};
+
+  // ACTION
+  const double distance_ab = box_box_distance(box_a, box_b);
+  const double distance_ba = box_box_distance(box_b, box_a);
+
+  // VERIFICATION
+  constexpr double TOLERANCE = 1e-8;
+  EXPECT_NEAR(
+      distance_ab,
+      scene_from_box_b.translation().y() -
+          (extents_a.y() * std::cos(THETA) + extents_a.x() * std::sin(THETA)) /
+              2.0 -
+          (extents_b.y() * std::cos(THETA) + extents_b.x() * std::sin(THETA)) /
+              2.0,
+      TOLERANCE);
+  EXPECT_NEAR(distance_ab, distance_ba, TOLERANCE);
+}
+
+}  // namespace resim::geometry

--- a/resim/geometry/box_box_distance_test.cc
+++ b/resim/geometry/box_box_distance_test.cc
@@ -4,13 +4,14 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+#include "resim/geometry/box_box_distance.hh"
+
 #include <gtest/gtest.h>
 
 #include <Eigen/Dense>
 
 #include "oriented_box.hh"
 #include "resim/assert/assert.hh"
-#include "resim/geometry/box_box_distance.hh"
 #include "resim/transforms/se3.hh"
 #include "resim/transforms/so3.hh"
 namespace resim::geometry {

--- a/resim/geometry/boxes_collide.cc
+++ b/resim/geometry/boxes_collide.cc
@@ -4,11 +4,11 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-#include "resim/geometry/boxes_collide.hh"
-
 #include <Eigen/Dense>
 
 #include "resim/assert/assert.hh"
+#include "resim/geometry/box_box_distance.hh"
+#include "resim/geometry/boxes_collide.hh"
 #include "resim/geometry/gjk_algorithm.hh"
 #include "resim/transforms/se3.hh"
 
@@ -17,29 +17,6 @@ namespace resim::geometry {
 namespace {
 using Vec3 = Eigen::Vector3d;
 using transforms::LieGroupType;
-
-// This helper represents the support function for a simple oriented box
-template <LieGroupType Group>
-Vec3 box_support(const OrientedBox<Group> &box, const Vec3 &direction) {
-  REASSERT(not direction.isZero(), "Zero direction detected!");
-  const Vec3 direction_in_box_coordinates{
-      box.reference_from_box().rotation().inverse() * direction};
-
-  const Vec3 support_in_box_coordinates{direction.binaryExpr(
-      box.extents(),
-      [](const double direction_element, const double extents_element) {
-        constexpr double HALF = 0.5;
-        constexpr double ZERO = 0.;
-        return extents_element *
-               (direction_element > 0.
-                    ? HALF
-                    : (direction_element < 0. ? -HALF : ZERO));
-      })};
-
-  Vec3 support_in_ref_coordinates{
-      box.reference_from_box() * support_in_box_coordinates};
-  return support_in_ref_coordinates;
-}
 
 // This simple helper detects whether the bounding spheres of the
 // given bounding boxes collide within the given collision tolerance.
@@ -76,20 +53,7 @@ bool boxes_collide(
   if (not bounding_spheres_collide(box_1, box_2, collision_tolerance)) {
     return false;
   }
-  constexpr int DIM = 3;
-  const SupportFunction<DIM> support_1{[&](const Vec3 &direction) -> Vec3 {
-    return box_support(box_1, direction);
-  }};
-  const SupportFunction<DIM> support_2{[&](const Vec3 &direction) -> Vec3 {
-    return box_support(box_2, direction);
-  }};
-
-  const std::optional<double> maybe_box_box_distance =
-      gjk_algorithm(support_1, support_2);
-
-  REASSERT(maybe_box_box_distance.has_value(), "GJK Algorithm Failed!");
-
-  return *maybe_box_box_distance < collision_tolerance;
+  return box_box_distance(box_1, box_2) < collision_tolerance;
 }
 
 template bool boxes_collide(

--- a/resim/geometry/boxes_collide.cc
+++ b/resim/geometry/boxes_collide.cc
@@ -4,11 +4,12 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+#include "resim/geometry/boxes_collide.hh"
+
 #include <Eigen/Dense>
 
 #include "resim/assert/assert.hh"
 #include "resim/geometry/box_box_distance.hh"
-#include "resim/geometry/boxes_collide.hh"
 #include "resim/geometry/gjk_algorithm.hh"
 #include "resim/transforms/se3.hh"
 

--- a/resim/geometry/boxes_collide.hh
+++ b/resim/geometry/boxes_collide.hh
@@ -27,6 +27,5 @@ bool boxes_collide(
     const OrientedBox<Group> &box_1,
     const OrientedBox<Group> &box_2,
     double collision_tolerance = 1e-4);
-;
 
 }  // namespace resim::geometry


### PR DESCRIPTION
## Description of change
Factor out parts of the box collision check into a distance function for two oriented boxes. Also fix a bug in that function relating to how distances are handled.

## Guide to reproduce test results.
```
bazel test //resim/geometry:box_box_distance_test
```
## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
