### PR TITLE
Add UsernamePasswordClient and document usage of client

### DIFF
--- a/.trunk/.gitignore
+++ b/.trunk/.gitignore
@@ -2,8 +2,8 @@
 *logs
 *actions
 *notifications
+*tools
 plugins
 user_trunk.yaml
 user.yaml
-shims
-tools
+tmp

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,10 +1,10 @@
 version: 0.1
 cli:
-  version: 1.17.2
+  version: 1.22.10
 plugins:
   sources:
     - id: trunk
-      ref: v0.0.16
+      ref: v1.6.7
       uri: https://github.com/trunk-io/plugins
 lint:
   definitions:
@@ -38,23 +38,24 @@ lint:
         - types-requests
         - types-protobuf
   enabled:
-    - isort@5.13.2
-    - black@24.4.2
-    - buildifier@6.1.0
-    - clang-tidy@15.0.6
-    - clang-format@14.0.0
-    - pylint@2.17.5
-    - mypy@1.5.1
+    - ruff@0.9.7:
+        commands:
+          - lint
+          - format
+    - buildifier@8.0.3
+    - clang-tidy@16.0.3
+    - clang-format@16.0.3
+    - mypy@1.15.0
 runtimes:
 # These runtimes do not influence anything running in our development
 # docker container, or our bazel environment. These runtimes set the 
 # version of a language which will be used by trunk while they execute
 # their tools. The defaults recommended by Trunk are used for this reason.
   enabled:
-    - go@1.19.5
-    - node@18.12.1
+    - go@1.21.0
+    - node@18.20.5
     - python@3.10.8
-    - ruby@3.1.0
+    - ruby@3.1.4
 actions:
   enabled:
     - trunk-announce

--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -38,6 +38,7 @@ py_package(
     deps = [
         "//resim/actor/state/proto:observable_state_proto_py",
         "//resim/auth/python:device_code_client",
+        "//resim/auth/python:username_password_client",
         "//resim/experiences/proto:experience_proto_py",
         "//resim/geometry/python:polygon_distance_python.so",
         "//resim/metrics:default_report_metrics",

--- a/resim-python-client/README.md
+++ b/resim-python-client/README.md
@@ -1,0 +1,117 @@
+# resim-python-client
+A client library for accessing the ReSim Customer API
+
+## Usage
+First, create a client:
+
+```python
+from resim_python_client import AuthenticatedClient
+from resim.auth.python.device_code_client import DeviceCodeClient, UsernamePasswordClient
+
+# If you're using your local machine, you can use the device code flow to get a token
+device_code_client = DeviceCodeClient()
+client = AuthenticatedClient(base_url="https://api.resim.ai/v1/", token=device_code_client.get_jwt())
+
+# OR
+
+# If you're running in CI, ReSim will provide you with a username & password to auth with
+client = UsernamePasswordClient(
+    username="your_username", # or set the `RESIM_USERNAME` environment variable
+    password="your_password"  # or set the `RESIM_PASSWORD` environment variable
+)
+```
+
+Now call your endpoint and use the generated models:
+
+```python
+from resim_python_client.models import Batch
+from resim_python_client.api.batches import get_batch
+from resim_python_client.types import Response
+
+with client as client:
+    my_data = get_batch.sync(client=client)
+    assert my_data != None, "Failed to get batch"
+    # or if you need more info (e.g. status_code)
+    response: Response[Batch] = get_batch.sync_detailed(client=client)
+    assert response.status_code == 200, "Failed to get batch"
+```
+
+Or do the same thing with an async version:
+
+```python
+from resim_python_client.models import Batch
+from resim_python_client.api.batches import get_batch
+from resim_python_client.types import Response
+
+async with client as client:
+    my_data: Batch = await get_batch.asyncio(client=client)
+    assert my_data != None, "Failed to get batch"
+    # or if you need more info (e.g. status_code)
+    response: Response[Batch] = await get_batch.asyncio_detailed(client=client)
+    assert response.status_code == 200, "Failed to get batch"
+```
+
+To discover more endpoints, check out our [Swagger Docs](https://redocly.github.io/redoc/?url=https://api.resim.ai). 
+
+Things to know:
+1. Every path/method combo becomes a Python module with four functions:
+    1. `sync`: Blocking request that returns parsed data (if successful) or `None`. This may be omitted if there is no data to parse.
+    1. `sync_detailed`: Blocking request that always returns a `Request`, optionally with `parsed` set if the request was successful.
+    1. `asyncio`: Like `sync` but async instead of blocking. 
+    1. `asyncio_detailed`: Like `sync_detailed` but async instead of blocking.
+
+1. All path/query params, and bodies become method arguments.
+1. If your endpoint had any tags on it, the first tag will be used as a module name for the function (`batches` above)
+1. Any endpoint which did not have a tag is in `resim_python_client.api.default`
+
+### Example: updating an experience
+
+If you are looking to update an experience, browse to the [updateExperience endpoint](https://redocly.github.io/redoc/?url=https://api.resim.ai#tag/experiences/operation/updateExperience) and you'll see that it has a tag of `experiences`. This means that the generated module will be `resim_python_client.api.experiences.update_experience`. A quick usage example:
+
+```python
+from resim_python_client.models import UpdateExperienceInput, Experience
+from resim_python_client.api.experiences import update_experience
+
+with client as client:
+    updated_experience: Experience = update_experience.sync(
+        project_id="ca3b7ce3-0242-4da7-bf51-1eb1945c7de3", experience_id="bf6806c7-aa15-464d-8b2c-387d12c732da", 
+        client=client, body=UpdateExperienceInput(name="Better Experience")
+    )
+    assert updated_experience != None, "Failed to update experience"
+    assert updated_experience.name == "Better Experience", "Experience name was not updated"
+```
+
+## Advanced customizations
+
+There are more settings on the generated `Client` class which let you control more runtime behavior, check out the docstring on that class for more info. You can also customize the underlying `httpx.Client` or `httpx.AsyncClient` (depending on your use-case):
+
+```python
+from resim_python_client import Client
+
+def log_request(request):
+    print(f"Request event hook: {request.method} {request.url} - Waiting for response")
+
+def log_response(response):
+    request = response.request
+    print(f"Response event hook: {request.method} {request.url} - Status {response.status_code}")
+
+client = Client(
+    base_url="https://api.example.com",
+    httpx_args={"event_hooks": {"request": [log_request], "response": [log_response]}},
+)
+
+# Or get the underlying httpx client to modify directly with client.get_httpx_client() or client.get_async_httpx_client()
+```
+
+You can even set the httpx client directly, but beware that this will override any existing settings (e.g., base_url):
+
+```python
+import httpx
+from resim_python_client import Client
+
+client = Client(
+    base_url="https://api.example.com",
+)
+# Note that base_url needs to be re-set, as would any shared cookies, headers, etc.
+client.set_httpx_client(httpx.Client(base_url="https://api.example.com", proxies="http://localhost:8030"))
+```

--- a/resim/auth/python/BUILD
+++ b/resim/auth/python/BUILD
@@ -8,6 +8,12 @@ load("@resim_python_deps//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_library", "py_test")
 
 py_library(
+    name = "const",
+    srcs = ["const.py"],
+    visibility = ["//visibility:public"],
+)
+
+py_library(
     name = "device_code_client",
     srcs = ["device_code_client.py"],
     visibility = ["//visibility:public"],
@@ -15,6 +21,7 @@ py_library(
         requirement("polling2"),
         requirement("requests"),
         ":check_expiration",
+        ":const",
     ],
 )
 
@@ -23,6 +30,26 @@ py_test(
     srcs = ["device_code_client_test.py"],
     deps = [
         ":device_code_client",
+    ],
+)
+
+py_library(
+    name = "username_password_client",
+    srcs = ["username_password_client.py"],
+    visibility = ["//visibility:public"],
+    deps = [
+        requirement("httpx"),
+        ":check_expiration",
+        ":const",
+        "//resim-python-client",
+    ],
+)
+
+py_test(
+    name = "username_password_client_test",
+    srcs = ["username_password_client_test.py"],
+    deps = [
+        ":username_password_client",
     ],
 )
 

--- a/resim/auth/python/const.py
+++ b/resim/auth/python/const.py
@@ -1,0 +1,7 @@
+import pathlib
+
+DEFAULT_BASE_URL = "https://api.resim.ai/v1"
+DEFAULT_DOMAIN = "https://resim.us.auth0.com"
+DEFAULT_SCOPE = "offline_access"
+DEFAULT_AUDIENCE = "https://api.resim.ai"
+DEFAULT_CACHE_LOCATION = pathlib.Path.home() / ".resim" / "token.json"

--- a/resim/auth/python/device_code_client.py
+++ b/resim/auth/python/device_code_client.py
@@ -53,9 +53,9 @@ class DeviceCodeClient:
 
     def refresh(self) -> None:
         """Clear the local token cache and the internal token."""
+        self._token = None
         if self._cache_location.exists():
             self._cache_location.unlink()
-        self._token = None
 
     def get_jwt(self) -> dict[str, typing.Any]:
         """Get the current token, fetching if necessary."""

--- a/resim/auth/python/device_code_client.py
+++ b/resim/auth/python/device_code_client.py
@@ -7,7 +7,7 @@
 """
 This file contains a Client class used to communicate with an OAuth
 2 authentication server to procure a JSON Web Token (jwt) for use with
-ReSim's API (https://api.resim.ai).
+ReSim's API (https://api.resim.ai) via the device code flow.
 """
 
 import json
@@ -19,11 +19,14 @@ import polling2
 import requests
 
 import resim.auth.python.check_expiration as check_exp
+from resim.auth.python.const import (
+    DEFAULT_AUDIENCE,
+    DEFAULT_CACHE_LOCATION,
+    DEFAULT_DOMAIN,
+    DEFAULT_SCOPE,
+)
 
-DEFAULT_SCOPE = "offline_access"
-DEFAULT_AUDIENCE = "https://api.resim.ai"
-DEFAULT_CACHE_LOCATION = pathlib.Path.home() / ".resim" / "token.json"
-DEFAULT_CLIENT_ID = "gTp1Y0kOyQ7QzIo2lZm0auGM6FJZZVvy"
+DEVICE_CODE_CLIENT_ID = "gTp1Y0kOyQ7QzIo2lZm0auGM6FJZZVvy"
 
 
 class DeviceCodeClient:
@@ -35,8 +38,8 @@ class DeviceCodeClient:
     def __init__(
         self,
         *,
-        domain: str,
-        client_id: str = DEFAULT_CLIENT_ID,
+        domain: str = DEFAULT_DOMAIN,
+        client_id: str = DEVICE_CODE_CLIENT_ID,
         scope: str = DEFAULT_SCOPE,
         audience: str = DEFAULT_AUDIENCE,
         cache_location: pathlib.Path = DEFAULT_CACHE_LOCATION,
@@ -57,9 +60,9 @@ class DeviceCodeClient:
     def get_jwt(self) -> dict[str, typing.Any]:
         """Get the current token, fetching if necessary."""
         if self._token is None and self._cache_location.exists():
-            assert (
-                self._cache_location.is_file()
-            ), "Directory detected in cache location!"
+            assert self._cache_location.is_file(), (
+                "Directory detected in cache location!"
+            )
             with open(self._cache_location, "r", encoding="utf-8") as cache:
                 self._token = json.load(cache)
 

--- a/resim/auth/python/device_code_client_test.py
+++ b/resim/auth/python/device_code_client_test.py
@@ -142,9 +142,10 @@ class DeviceCodeClientTest(unittest.TestCase):
         """
         Test that we can get the expected token with the expected queries to the server.
         """
-        with unittest.mock.patch(
-            "requests.post"
-        ) as mock, tempfile.TemporaryDirectory() as tmpdir:
+        with (
+            unittest.mock.patch("requests.post") as mock,
+            tempfile.TemporaryDirectory() as tmpdir,
+        ):
 
             def side_effect(
                 uri: str, *, data: dict[str, typing.Any]
@@ -180,7 +181,6 @@ class DeviceCodeClientTest(unittest.TestCase):
             # Test refreshing
             server = MockServer(testcase=self)
             client.refresh()
-            client.refresh()  # Called intentionally for coverage
             token = client.get_jwt()
             self.assertEqual(token, client.get_jwt())
             self.assertEqual(token["access_token"], TOKEN)
@@ -202,9 +202,10 @@ class DeviceCodeClientTest(unittest.TestCase):
         """
         Verify that we raise on 404.
         """
-        with unittest.mock.patch(
-            "requests.post"
-        ) as mock, tempfile.TemporaryDirectory() as tmpdir:
+        with (
+            unittest.mock.patch("requests.post") as mock,
+            tempfile.TemporaryDirectory() as tmpdir,
+        ):
 
             def side_effect(
                 uri: str, *, data: dict[str, typing.Any]

--- a/resim/auth/python/username_password_client.py
+++ b/resim/auth/python/username_password_client.py
@@ -1,0 +1,135 @@
+# Copyright 2025 ReSim, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+"""
+This file contains a Client class used to communicate with an OAuth
+2 authentication server to procure a JSON Web Token (jwt) for use with
+ReSim's API (https://api.resim.ai) given a username and password.
+"""
+
+import json
+import os
+import pathlib
+from typing import Any, Optional
+
+import httpx
+from resim_python_client import AuthenticatedClient
+
+import resim.auth.python.check_expiration as check_exp
+from resim.auth.python.const import (
+    DEFAULT_AUDIENCE,
+    DEFAULT_BASE_URL,
+    DEFAULT_CACHE_LOCATION,
+    DEFAULT_DOMAIN,
+    DEFAULT_SCOPE,
+)
+
+PASSWORD_AUTH_CLIENT_ID = "0Ip56H1LLAo6Dc6IfePaNzgpUxbJGyVI"
+
+
+class UsernamePasswordClient(AuthenticatedClient):
+    """
+    The client class which manages the token as well as other
+    configuration data for authentication.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str = DEFAULT_BASE_URL,
+        domain: str = DEFAULT_DOMAIN,
+        client_id: str = PASSWORD_AUTH_CLIENT_ID,
+        scope: str = DEFAULT_SCOPE,
+        audience: str = DEFAULT_AUDIENCE,
+        cache_location: pathlib.Path = DEFAULT_CACHE_LOCATION,
+        username: Optional[str] = os.getenv("RESIM_USERNAME"),
+        password: Optional[str] = os.getenv("RESIM_PASSWORD"),
+        **kwargs: Any,
+    ):
+        self._token: Optional[dict[str, Any]] = None
+        self._client_id = client_id
+        self._cache_location = cache_location
+        self._domain = domain
+        self._scope = scope
+        self._audience = audience
+
+        assert username is not None, "Username is required"
+        assert password is not None, "Password is required"
+        self._username = username
+        self._password = password
+
+        super().__init__(
+            token=self.get_jwt()["access_token"],
+            base_url=base_url,
+            **kwargs,
+        )
+
+    def reset(self) -> None:
+        """Clear the local token cache and the internal token."""
+        if self._cache_location.exists():
+            self._cache_location.unlink()
+        self._token = None
+
+    def get_jwt(self) -> dict[str, Any]:
+        """Get the current token, fetching if necessary."""
+        if self._token is None and self._cache_location.exists():
+            assert self._cache_location.is_file(), (
+                "Directory detected in cache location!"
+            )
+            try:
+                with open(self._cache_location, "r", encoding="utf-8") as cache:
+                    self._token = json.load(cache)
+            except json.JSONDecodeError as _:
+                self._token = None
+
+        if self._token is None or check_exp.is_expired(token_data=self._token):
+            self._token = _get_new_token(
+                domain=self._domain,
+                client_id=self._client_id,
+                scope=self._scope,
+                audience=self._audience,
+                username=self._username,
+                password=self._password,
+            )
+            self._cache_location.parent.mkdir(parents=True, exist_ok=True)
+            with open(self._cache_location, "w", encoding="utf-8") as cache:
+                cache.write(json.dumps(self._token, indent=4))
+        return self._token
+
+
+def _get_new_token(
+    *,
+    domain: str,
+    client_id: str,
+    scope: str,
+    audience: str,
+    username: str,
+    password: str,
+) -> dict[str, Any]:
+    token_url = domain + "/oauth/token"
+
+    payload = {
+        "grant_type": "http://auth0.com/oauth/grant-type/password-realm",
+        "realm": "cli-users",
+        "client_id": client_id,
+        "username": username,
+        "password": password,
+        "audience": audience,
+        "scope": scope,
+    }
+
+    resp = httpx.post(
+        token_url,
+        headers={"content-type": "application/x-www-form-urlencoded"},
+        data=payload,
+        timeout=10.0,
+    )
+    assert resp.status_code == 200, f"Failed to get token: {resp.text}"
+    token: dict[str, Any] = resp.json()
+
+    check_exp.add_expiration_time(token_data=token)
+
+    return token

--- a/resim/auth/python/username_password_client.py
+++ b/resim/auth/python/username_password_client.py
@@ -69,9 +69,9 @@ class UsernamePasswordClient(AuthenticatedClient):
 
     def reset(self) -> None:
         """Clear the local token cache and the internal token."""
+        self._token = None
         if self._cache_location.exists():
             self._cache_location.unlink()
-        self._token = None
 
     def get_jwt(self) -> dict[str, Any]:
         """Get the current token, fetching if necessary."""

--- a/resim/auth/python/username_password_client_test.py
+++ b/resim/auth/python/username_password_client_test.py
@@ -1,0 +1,157 @@
+# Copyright 2025 ReSim, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+import unittest
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from unittest.mock import ANY, patch
+
+import httpx
+
+from resim.auth.python.username_password_client import UsernamePasswordClient
+
+
+class UsernamePasswordClientTest(unittest.TestCase):
+    """
+    Tests for the UsernamePasswordClient class.
+    """
+
+    def test_username_password_client(self) -> None:
+        """
+        Test that the username/password token exchange works as expected.
+        """
+        # Given
+        with (
+            NamedTemporaryFile() as temp_file,
+            patch("httpx.Client.get", autospec=True) as get_all_projects_mock,
+            patch("httpx.post", autospec=True) as post_mock,
+        ):
+            post_mock.return_value = httpx.Response(
+                status_code=200,
+                json={
+                    "access_token": "test_access_token",
+                    "refresh_token": "test_refresh_token",
+                    "id_token": "test_id_token",
+                    "token_type": "Bearer",
+                    "expires_in": 36000,
+                },
+            )
+            get_all_projects_mock.return_value = httpx.Response(
+                status_code=200,
+                json={"projects": []},
+            )
+            # When
+            client = UsernamePasswordClient(
+                username="test_username",
+                password="test_password",
+                client_id="test_client_id",
+                audience="test_audience",
+                scope="test_scope",
+                cache_location=Path(temp_file.name),
+            )
+            client.get_httpx_client().get("https://api.resim.ai/v1/projects").json()
+            # Then
+            post_mock.assert_called_once_with(
+                "https://resim.us.auth0.com/oauth/token",
+                headers={"content-type": "application/x-www-form-urlencoded"},
+                data={
+                    "grant_type": "http://auth0.com/oauth/grant-type/password-realm",
+                    "realm": "cli-users",
+                    "client_id": "test_client_id",
+                    "username": "test_username",
+                    "password": "test_password",
+                    "audience": "test_audience",
+                    "scope": "test_scope",
+                },
+                timeout=10.0,
+            )
+            # Check that the get all projects call was made with the correct headers
+            get_all_projects_mock.assert_called_once_with(
+                ANY, "https://api.resim.ai/v1/projects"
+            )
+            self.assertTrue(
+                get_all_projects_mock.call_args[0][0].headers["Authorization"]
+                == "Bearer test_access_token"
+            )
+
+    def test_username_password_client_cache(self) -> None:
+        """
+        Test that the token is not refetched if it is still valid.
+        """
+        # Given
+        with (
+            NamedTemporaryFile() as temp_file,
+            patch("httpx.post", autospec=True) as post_mock,
+        ):
+            post_mock.return_value = httpx.Response(
+                status_code=200,
+                json={
+                    "access_token": "test_access_token",
+                    "refresh_token": "test_refresh_token",
+                    "id_token": "test_id_token",
+                    "token_type": "Bearer",
+                    "expires_in": 36000,
+                },
+            )
+            # When
+            client = UsernamePasswordClient(
+                username="test_username",
+                password="test_password",
+                cache_location=Path(temp_file.name),
+            )
+            #   get the current JWT
+            first_jwt = client.get_jwt()
+            #   update the mock to return a new JWT
+            post_mock.return_value = httpx.Response(
+                status_code=200,
+                json={
+                    "access_token": "test_access_token_2",
+                    "refresh_token": "test_refresh_token_2",
+                    "id_token": "test_id_token_2",
+                    "token_type": "Bearer",
+                    "expires_in": 36000,
+                },
+            )
+            #   get the new JWT
+            second_jwt = client.get_jwt()
+            # Then
+            assert first_jwt is not None
+            assert second_jwt == first_jwt
+            #   reset the jwt
+            client.reset()
+            third_jwt = client.get_jwt()
+            assert third_jwt != first_jwt
+
+    def test_username_password_client_failure(self) -> None:
+        """
+        Test that the username/password token exchange fails if the token is invalid.
+        """
+        # Given
+        with (
+            NamedTemporaryFile() as temp_file,
+            patch("httpx.post", autospec=True) as post_mock,
+            self.assertRaises(Exception) as context,
+        ):
+            post_mock.return_value = httpx.Response(
+                status_code=401,
+                json={
+                    "error": "login_bad",
+                    "error_description": "lorem ipsum",
+                },
+            )
+            # When
+            client = UsernamePasswordClient(
+                username="test_username",
+                password="test_password",
+                cache_location=Path(temp_file.name),
+            )
+            client.get_httpx_client().get("https://api.resim.ai/v1/projects")
+        # Then
+        self.assertIn("Failed to get token", str(context.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/resim/auth/python/username_password_client_test.py
+++ b/resim/auth/python/username_password_client_test.py
@@ -103,7 +103,7 @@ class UsernamePasswordClientTest(unittest.TestCase):
                 cache_location=Path(temp_file.name),
             )
             #   get the current JWT
-            first_jwt = client.get_jwt()
+            first_jwt = client._token
             #   update the mock to return a new JWT
             post_mock.return_value = httpx.Response(
                 status_code=200,
@@ -115,14 +115,25 @@ class UsernamePasswordClientTest(unittest.TestCase):
                     "expires_in": 36000,
                 },
             )
-            #   get the new JWT
-            second_jwt = client.get_jwt()
+            # get the new JWT
+            client2 = UsernamePasswordClient(
+                username="test_username",
+                password="test_password",
+                cache_location=Path(temp_file.name),
+            )
+            second_jwt = client2._token
             # Then
             assert first_jwt is not None
             assert second_jwt == first_jwt
             #   reset the jwt
-            client.reset()
-            third_jwt = client.get_jwt()
+            client2.reset()
+            # client2.reset() # coverage needed help
+            client3 = UsernamePasswordClient(
+                username="test_username",
+                password="test_password",
+                cache_location=Path(temp_file.name),
+            )
+            third_jwt = client3.get_jwt()
             assert third_jwt != first_jwt
 
     def test_username_password_client_failure(self) -> None:


### PR DESCRIPTION
## Description of change
- Adds a UsernamePasswordClient for authenticating in CI
- Adds a readme for the Python client to help users get to using it.

## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
