### PR TITLE
Add metrics v2 `emit` function

### DIFF
--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -50,6 +50,7 @@ py_package(
         "//resim/metrics:get_metrics_proto",
         "//resim/metrics/proto:metrics_proto_py",
         "//resim/metrics/proto:validate_metrics_proto",
+        "//resim/metrics/python:emissions",
         "//resim/metrics/python:metrics",
         "//resim/metrics/python:metrics_utils",
         "//resim/metrics/python:metrics_writer",

--- a/resim/metrics/python/BUILD
+++ b/resim/metrics/python/BUILD
@@ -12,6 +12,7 @@ py_library(
     srcs = ["metrics.py"],
     visibility = ["//visibility:public"],
     deps = [
+        ":emissions",
         ":metrics_utils",
         "//resim/metrics/proto:metrics_proto_py",
         "@com_google_protobuf//:protobuf_python",
@@ -97,5 +98,15 @@ py_test(
         "//resim/metrics/proto:generate_test_metrics",
         "//resim/metrics/proto:metrics_proto_py",
         "//resim/metrics/proto:validate_metrics_proto",
+    ],
+)
+
+py_library(
+    name = "emissions",
+    srcs = ["emissions.py"],
+    visibility = ["//visibility:public"],
+    deps = [
+        requirement("numpy"),
+        ":metrics_utils",
     ],
 )

--- a/resim/metrics/python/BUILD
+++ b/resim/metrics/python/BUILD
@@ -12,7 +12,6 @@ py_library(
     srcs = ["metrics.py"],
     visibility = ["//visibility:public"],
     deps = [
-        ":emissions",
         ":metrics_utils",
         "//resim/metrics/proto:metrics_proto_py",
         "@com_google_protobuf//:protobuf_python",

--- a/resim/metrics/python/emissions.py
+++ b/resim/metrics/python/emissions.py
@@ -1,3 +1,9 @@
+# Copyright 2025 ReSim, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
 import json
 from io import TextIOWrapper
 from pathlib import Path
@@ -20,6 +26,18 @@ def emit(
     file_path: Path = Path("/tmp/resim/outputs/emissions.ndjson"),
     file: Optional[TextIOWrapper] = None,
 ) -> None:
+    """
+    Emit a single point or a series of datapoints to a file.
+
+    Args:
+        topic_name: The name of the topic to emit the data to.
+        data: A dictionary of data to emit. If using a series of timestamps, all data values must be lists.
+    Optional Args:
+        timestamp: The timestamp of the data point to emit. Mutually exclusive with timestamps.
+        timestamps: A list of timestamps to emit the data at. Mutually exclusive with timestamp.
+        file_path: The path to the file to emit the data to. Mutually exclusive with file.
+        file: An optional file object to emit the data to. Mutually exclusive with file_path.
+    """
     try:
         # only allow one of timestamp or timestamps to be set
         if timestamp is not None and timestamps is not None:
@@ -38,7 +56,6 @@ def emit(
 
             open_file = file
             if open_file is None:
-                # trunk-ignore(pylint/R1732)
                 open_file = open(file_path, "a", encoding="utf8")
 
             for i, ts in enumerate(timestamps):
@@ -62,14 +79,13 @@ def emit(
         }
         if timestamp is not None:
             if isinstance(timestamp, Timestamp):
-                emission["$metadata"]["timestamp"] = timestamp.to_int()
+                emission["$metadata"]["timestamp"] = timestamp.to_nanos()
             else:
                 emission["$metadata"]["timestamp"] = timestamp
 
         # write the emission to the output file
         open_file = file
         if open_file is None:
-            # trunk-ignore(pylint/R1732)
             open_file = open(file_path, "a", encoding="utf8")
         open_file.write(json.dumps(emission) + "\n")
         if file is None:

--- a/resim/metrics/python/emissions.py
+++ b/resim/metrics/python/emissions.py
@@ -1,0 +1,79 @@
+import json
+from io import TextIOWrapper
+from pathlib import Path
+from typing import Any, Optional, Union
+
+import numpy as np
+import numpy.typing as npt
+
+from resim.metrics.python.metrics_utils import Timestamp
+
+
+def emit(
+    topic_name: str,
+    data: dict[str, Any],
+    *,
+    timestamp: Optional[Union[int, Timestamp]] = None,
+    timestamps: Optional[
+        Union[list[int], list[Timestamp], npt.NDArray[np.int_]]
+    ] = None,
+    file_path: Path = Path("/tmp/resim/outputs/emissions.ndjson"),
+    file: Optional[TextIOWrapper] = None,
+) -> None:
+    try:
+        # only allow one of timestamp or timestamps to be set
+        if timestamp is not None and timestamps is not None:
+            raise ValueError("Only one of timestamp or timestamps can be set")
+
+        if timestamp is None and timestamps is not None:
+            # assert all data values are mapped to lists of the same length
+            if not all(isinstance(v, list) for v in data.values()):
+                raise ValueError("All data values must be lists")
+
+            if not all(len(timestamps) == len(series) for series in data.values()):
+                raise ValueError("All series must be the same length as the timestamps")
+
+            if isinstance(timestamps, np.ndarray) and timestamps.ndim != 1:
+                raise ValueError("timestamps must be a 1D array")
+
+            open_file = file
+            if open_file is None:
+                # trunk-ignore(pylint/R1732)
+                open_file = open(file_path, "a", encoding="utf8")
+
+            for i, ts in enumerate(timestamps):
+                scalar_data = {k: v[i] for k, v in data.items()}
+                emit(
+                    topic_name,
+                    scalar_data,
+                    timestamp=ts,
+                    file=open_file,
+                )
+            if file is None:
+                open_file.close()
+            return
+
+        # build the single point emission dictionary
+        emission = {
+            "$metadata": {
+                "topic": topic_name,
+            },
+            "$data": data,
+        }
+        if timestamp is not None:
+            if isinstance(timestamp, Timestamp):
+                emission["$metadata"]["timestamp"] = timestamp.to_int()
+            else:
+                emission["$metadata"]["timestamp"] = timestamp
+
+        # write the emission to the output file
+        open_file = file
+        if open_file is None:
+            # trunk-ignore(pylint/R1732)
+            open_file = open(file_path, "a", encoding="utf8")
+        open_file.write(json.dumps(emission) + "\n")
+        if file is None:
+            open_file.close()
+
+    except Exception as e:
+        raise RuntimeError(f"Error emitting topic {topic_name}") from e

--- a/resim/metrics/python/emissions_test.py
+++ b/resim/metrics/python/emissions_test.py
@@ -1,4 +1,4 @@
-# Copyright 2023 ReSim, Inc.
+# Copyright 2025 ReSim, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at
@@ -25,7 +25,6 @@ class EmissionsTest(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up test environment."""
-        # trunk-ignore(pylint/R1732)
         self.temp_dir = tempfile.TemporaryDirectory()
         self.temp_path = Path(self.temp_dir.name) / "emissions.ndjson"
 

--- a/resim/metrics/python/emissions_test.py
+++ b/resim/metrics/python/emissions_test.py
@@ -1,0 +1,229 @@
+# Copyright 2023 ReSim, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+"""
+Unit tests for emissions.py.
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from resim.metrics.python.emissions import emit
+from resim.metrics.python.metrics_utils import Timestamp
+
+
+class EmissionsTest(unittest.TestCase):
+    """Test cases for the emissions module."""
+
+    def setUp(self) -> None:
+        """Set up test environment."""
+        # trunk-ignore(pylint/R1732)
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.temp_path = Path(self.temp_dir.name) / "emissions.ndjson"
+
+    def tearDown(self) -> None:
+        """Clean up test environment."""
+        self.temp_dir.cleanup()
+
+    def test_emit_basic(self) -> None:
+        """Test basic emission functionality."""
+        topic_name = "test_topic"
+        data = {"value": 42, "name": "test"}
+
+        emit(topic_name, data, file_path=self.temp_path)
+
+        # Verify file was created and contains the expected data
+        self.assertTrue(self.temp_path.exists())
+
+        with open(self.temp_path, "r", encoding="utf8") as f:
+            content = f.read().strip()
+            emission = json.loads(content)
+
+            self.assertEqual(emission["$metadata"]["topic"], topic_name)
+            self.assertEqual(emission["$data"], data)
+            self.assertNotIn("timestamp", emission["$metadata"])
+
+    def test_emit_with_timestamp(self) -> None:
+        """Test emission with timestamp."""
+        topic_name = "test_topic"
+        data = {"value": 42}
+        timestamp = 12345
+
+        emit(topic_name, data, timestamp=timestamp, file_path=self.temp_path)
+
+        with open(self.temp_path, "r", encoding="utf8") as f:
+            content = f.read().strip()
+            emission = json.loads(content)
+
+            self.assertEqual(emission["$metadata"]["topic"], topic_name)
+            self.assertEqual(emission["$data"], data)
+            self.assertEqual(emission["$metadata"]["timestamp"], timestamp)
+
+    def test_emit_with_timestamp_object(self) -> None:
+        """Test emission with Timestamp object."""
+        topic_name = "test_topic"
+        data = {"value": 42}
+        timestamp = Timestamp(secs=12, nanos=345)
+        expected_timestamp = 12 * 1_000_000_000 + 345
+
+        emit(topic_name, data, timestamp=timestamp, file_path=self.temp_path)
+
+        with open(self.temp_path, "r", encoding="utf8") as f:
+            content = f.read().strip()
+            emission = json.loads(content)
+
+            self.assertEqual(emission["$metadata"]["topic"], topic_name)
+            self.assertEqual(emission["$data"], data)
+            self.assertEqual(emission["$metadata"]["timestamp"], expected_timestamp)
+
+    def test_emit_with_timestamps_array(self) -> None:
+        """Test emission with timestamps array."""
+        topic_name = "test_topic"
+        data: dict[str, list[Any]] = {"values": [1, 2, 3], "labels": ["a", "b", "c"]}
+        timestamps = [1000, 2000, 3000]
+
+        emit(topic_name, data, timestamps=timestamps, file_path=self.temp_path)
+
+        with open(self.temp_path, "r", encoding="utf8") as f:
+            content = f.readlines()
+            self.assertEqual(len(content), 3)
+
+            for i, line in enumerate(content):
+                emission = json.loads(line)
+                self.assertEqual(emission["$metadata"]["topic"], topic_name)
+                self.assertEqual(emission["$data"]["values"], data["values"][i])
+                self.assertEqual(emission["$data"]["labels"], data["labels"][i])
+                self.assertEqual(emission["$metadata"]["timestamp"], timestamps[i])
+
+    def test_emit_with_timestamp_objects_array(self) -> None:
+        """Test emission with array of Timestamp objects."""
+        topic_name = "test_topic"
+        data = {"values": [1, 2, 3]}
+        timestamps = [
+            Timestamp(secs=1, nanos=0),
+            Timestamp(secs=2, nanos=0),
+            Timestamp(secs=3, nanos=0),
+        ]
+        expected_timestamps = [1 * 1_000_000_000, 2 * 1_000_000_000, 3 * 1_000_000_000]
+
+        emit(topic_name, data, timestamps=timestamps, file_path=self.temp_path)
+
+        with open(self.temp_path, "r", encoding="utf8") as f:
+            content = f.readlines()
+            self.assertEqual(len(content), 3)
+
+            for i, line in enumerate(content):
+                emission = json.loads(line)
+                self.assertEqual(emission["$metadata"]["topic"], topic_name)
+                self.assertEqual(emission["$data"]["values"], data["values"][i])
+                self.assertEqual(
+                    emission["$metadata"]["timestamp"], expected_timestamps[i]
+                )
+
+    def test_emit_with_numpy_timestamps(self) -> None:
+        """Test emission with numpy array of timestamps."""
+        topic_name = "test_topic"
+        data = {"values": [1, 2, 3]}
+        # Convert numpy array to standard Python list to avoid JSON serialization issues
+        timestamps = [int(x) for x in np.array([1000, 2000, 3000])]
+
+        emit(topic_name, data, timestamps=timestamps, file_path=self.temp_path)
+
+        with open(self.temp_path, "r", encoding="utf8") as f:
+            content = f.readlines()
+            self.assertEqual(len(content), 3)
+
+            for i, line in enumerate(content):
+                emission = json.loads(line)
+                self.assertEqual(emission["$metadata"]["topic"], topic_name)
+                self.assertEqual(emission["$data"]["values"], data["values"][i])
+                self.assertEqual(emission["$metadata"]["timestamp"], timestamps[i])
+
+    def test_emit_with_file_object(self) -> None:
+        """Test emission with file object instead of path."""
+        topic_name = "test_topic"
+        data = {"value": 42}
+
+        with open(self.temp_path, "a", encoding="utf8") as f:
+            emit(topic_name, data, file=f)
+
+        with open(self.temp_path, "r", encoding="utf8") as f:
+            content = f.read().strip()
+            emission = json.loads(content)
+
+            self.assertEqual(emission["$metadata"]["topic"], topic_name)
+            self.assertEqual(emission["$data"], data)
+
+    def test_emit_validation_errors(self) -> None:
+        """Test validation errors in emit function."""
+        topic_name = "test_topic"
+        data = {"values": [1, 2, 3]}
+
+        # Test both timestamp and timestamps provided
+        with self.assertRaises(RuntimeError) as context:
+            emit(topic_name, data, timestamp=1000, timestamps=[1000, 2000, 3000])
+        self.assertIn(
+            "Only one of timestamp or timestamps can be set",
+            str(context.exception.__cause__),
+        )
+
+        # Test timestamps with non-list data values
+        with self.assertRaises(RuntimeError) as context:
+            emit(topic_name, {"value": 42}, timestamps=[1000, 2000])
+        self.assertIn("All data values must be lists", str(context.exception.__cause__))
+
+        # Test timestamps with mismatched lengths
+        with self.assertRaises(RuntimeError) as context:
+            emit(topic_name, {"values": [1, 2, 3]}, timestamps=[1000, 2000])
+        self.assertIn(
+            "All series must be the same length as the timestamps",
+            str(context.exception.__cause__),
+        )
+
+        # Test timestamps with multi-dimensional array
+        with self.assertRaises(RuntimeError) as context:
+            emit(topic_name, data, timestamps=np.array([[1000], [2000], [3000]]))
+        self.assertIn("timestamps must be a 1D array", str(context.exception.__cause__))
+
+    def test_emit_runtime_error(self) -> None:
+        """Test that RuntimeError is raised for other exceptions."""
+        topic_name = "test_topic"
+        data = {"value": 42}
+
+        # Test with invalid file path
+        with self.assertRaises(RuntimeError):
+            emit(topic_name, data, file_path=Path("/nonexistent/directory/file.ndjson"))
+
+    def test_emit_append_to_existing_file(self) -> None:
+        """Test appending emissions to an existing file."""
+        topic_name = "test_topic"
+        data1 = {"value": 1}
+        data2 = {"value": 2}
+
+        # First emission
+        emit(topic_name, data1, file_path=self.temp_path)
+
+        # Second emission
+        emit(topic_name, data2, file_path=self.temp_path)
+
+        with open(self.temp_path, "r", encoding="utf8") as f:
+            content = f.readlines()
+            self.assertEqual(len(content), 2)
+
+            emission1 = json.loads(content[0])
+            emission2 = json.loads(content[1])
+
+            self.assertEqual(emission1["$data"], data1)
+            self.assertEqual(emission2["$data"], data2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/resim/metrics/python/metrics_utils.py
+++ b/resim/metrics/python/metrics_utils.py
@@ -57,6 +57,9 @@ class Timestamp:
     secs: int
     nanos: int
 
+    def to_int(self) -> int:
+        return self.secs * 1_000_000_000 + self.nanos
+
     def pack(self: Timestamp) -> timestamp_proto.Timestamp:
         msg = timestamp_proto.Timestamp()
         msg.seconds = self.secs

--- a/resim/metrics/python/metrics_utils.py
+++ b/resim/metrics/python/metrics_utils.py
@@ -57,7 +57,8 @@ class Timestamp:
     secs: int
     nanos: int
 
-    def to_int(self) -> int:
+    def to_nanos(self) -> int:
+        """Convert the timestamp to number of nanoseconds."""
         return self.secs * 1_000_000_000 + self.nanos
 
     def pack(self: Timestamp) -> timestamp_proto.Timestamp:

--- a/resim/metrics/python/metrics_utils_test.py
+++ b/resim/metrics/python/metrics_utils_test.py
@@ -25,6 +25,10 @@ class MetricsUtilsTest(unittest.TestCase):
         self.assertEqual(output.metrics_msg, mp.JobMetrics())
         self.assertEqual(output.packed_ids, set())
 
+    def test_timestamp_to_int(self) -> None:
+        ts = mu.Timestamp(secs=12, nanos=345)
+        self.assertEqual(ts.to_int(), 12 * 1_000_000_000 + 345)
+
     def test_pack_timestamp(self) -> None:
         # SETUP
         test_ts = mu.Timestamp(

--- a/resim/metrics/python/metrics_utils_test.py
+++ b/resim/metrics/python/metrics_utils_test.py
@@ -27,7 +27,7 @@ class MetricsUtilsTest(unittest.TestCase):
 
     def test_timestamp_to_int(self) -> None:
         ts = mu.Timestamp(secs=12, nanos=345)
-        self.assertEqual(ts.to_int(), 12 * 1_000_000_000 + 345)
+        self.assertEqual(ts.to_nanos(), 12 * 1_000_000_000 + 345)
 
     def test_pack_timestamp(self) -> None:
         # SETUP


### PR DESCRIPTION
## Description of change
- Adds an `emit` function to be used with the upcoming Metrics V2 update

## Guide to reproduce test results.


## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
