### PR TITLE
Add two jet mean function

### DIFF
--- a/resim/curves/learning/BUILD
+++ b/resim/curves/learning/BUILD
@@ -1,0 +1,34 @@
+# Copyright 2025 ReSim, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+cc_library(
+    name = "two_jet_mean",
+    srcs = ["two_jet_mean.cc"],
+    hdrs = ["two_jet_mean.hh"],
+    deps = [
+        "//resim/assert",
+        "//resim/curves:two_jet",
+        "//resim/curves/optimization:two_jet_tangent_space",
+        "//resim/transforms:se3",
+        "//resim/utils:status_value",
+    ],
+)
+
+cc_test(
+    name = "two_jet_mean_test",
+    srcs = ["two_jet_mean_test.cc"],
+    deps = [
+        ":two_jet_mean",
+        "//resim/curves:two_jet_test_helpers",
+        "//resim/curves/optimization:two_jet_tangent_space",
+        "//resim/testing:random_matrix",
+        "//resim/transforms:se3",
+        "//resim/utils:inout",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/resim/curves/learning/BUILD
+++ b/resim/curves/learning/BUILD
@@ -28,6 +28,7 @@ cc_test(
         "//resim/curves/optimization:two_jet_tangent_space",
         "//resim/testing:random_matrix",
         "//resim/transforms:se3",
+        "//resim/transforms:so3",
         "//resim/utils:inout",
         "@com_google_googletest//:gtest_main",
     ],

--- a/resim/curves/learning/two_jet_mean.cc
+++ b/resim/curves/learning/two_jet_mean.cc
@@ -1,0 +1,44 @@
+// Copyright 2025 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include "resim/curves/learning/two_jet_mean.hh"
+
+#include "resim/assert/assert.hh"
+#include "resim/curves/optimization/two_jet_tangent_space.hh"
+#include "resim/curves/two_jet.hh"
+
+namespace resim::curves::learning {
+
+using transforms::SE3;
+using TwoJetL = TwoJetL<SE3>;
+using TangentVector = optimization::TwoJetTangentVector<SE3>;
+
+StatusValue<TwoJetL> two_jet_mean(
+    const std::span<const TwoJetL> &samples,
+    const double tolerance,
+    const int max_iterations) {
+  REASSERT(not samples.empty(), "Sample size must be greater than 1");
+
+  TwoJetL guess = samples.front();
+  TangentVector delta{TangentVector::Zero()};
+  bool converged = false;
+  for (int ii = 0; ii < max_iterations and not converged; ++ii) {
+    for (const auto &sample : samples) {
+      delta += optimization::difference(sample, guess);
+    }
+    delta /= static_cast<double>(samples.size());
+    guess = optimization::accumulate(guess, delta);
+    if (delta.norm() < tolerance) {
+      converged = true;
+    }
+  }
+  if (not converged) {
+    return MAKE_STATUS("Failed to converge!");
+  }
+  return guess;
+}
+
+}  // namespace resim::curves::learning

--- a/resim/curves/learning/two_jet_mean.cc
+++ b/resim/curves/learning/two_jet_mean.cc
@@ -21,6 +21,9 @@ StatusValue<TwoJetL> two_jet_mean(
     const double tolerance,
     const int max_iterations) {
   REASSERT(not samples.empty(), "Sample size must be greater than 1");
+  REASSERT(
+      max_iterations > 0,
+      "Number of iterations must be greater than zero");
 
   TwoJetL guess = samples.front();
   TangentVector delta{TangentVector::Zero()};

--- a/resim/curves/learning/two_jet_mean.hh
+++ b/resim/curves/learning/two_jet_mean.hh
@@ -19,7 +19,7 @@ namespace resim::curves::learning {
 // is defined as the left minus operator as defined in
 // resim/curves/optimization/two_jet_tangent_space.hh. Another way of saying
 // this is that u is the mean of all the samples when they're expressed in u's
-// tangent space. We use iteration to find u  and therefore a tolerance and a
+// tangent space. We use iteration to find u and therefore a tolerance and a
 // maximum number of iterations must be provided.
 // @param[in] samples - The samples to compute the mean of.
 // @param[in] tolerance - The absolute tolerance for computing the mean.

--- a/resim/curves/learning/two_jet_mean.hh
+++ b/resim/curves/learning/two_jet_mean.hh
@@ -14,6 +14,20 @@
 
 namespace resim::curves::learning {
 
+// Compute the mean of a set of two jets. Since two jets exist on a manifold,
+// this function computes the two jet u such that sum_i(x_i (-) u) = 0 where (-)
+// is defined as the left minus operator as defined in
+// resim/curves/optimization/two_jet_tangent_space.hh. Another way of saying
+// this is that u is the mean of all the samples when they're expressed in u's
+// tangent space. We use iteration to find u  and therefore a tolerance and a
+// maximum number of iterations must be provided.
+// @param[in] samples - The samples to compute the mean of.
+// @param[in] tolerance - The absolute tolerance for computing the mean.
+//                        Iteration terminates once updates get smaller in L2
+//                        norm than this.
+// @param[in] max_iterations - The maximum number of iterations allowed before
+//                             terminating unsuccessfully.
+// @returns The mean as described above, or a bad status otherwise.
 StatusValue<TwoJetL<resim::transforms::SE3>> two_jet_mean(
     const std::span<const TwoJetL<resim::transforms::SE3>> &samples,
     double tolerance,

--- a/resim/curves/learning/two_jet_mean.hh
+++ b/resim/curves/learning/two_jet_mean.hh
@@ -1,0 +1,22 @@
+// Copyright 2025 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#pragma once
+
+#include <span>
+
+#include "resim/curves/two_jet.hh"
+#include "resim/transforms/se3.hh"
+#include "resim/utils/status_value.hh"
+
+namespace resim::curves::learning {
+
+StatusValue<TwoJetL<resim::transforms::SE3>> two_jet_mean(
+    const std::span<const TwoJetL<resim::transforms::SE3>> &samples,
+    double tolerance,
+    int max_iterations);
+
+}  // namespace resim::curves::learning

--- a/resim/curves/learning/two_jet_mean_test.cc
+++ b/resim/curves/learning/two_jet_mean_test.cc
@@ -1,0 +1,128 @@
+// Copyright 2025 ReSim, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include "resim/curves/learning/two_jet_mean.hh"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <random>
+
+#include "resim/curves/optimization/two_jet_tangent_space.hh"
+#include "resim/curves/two_jet_test_helpers.hh"
+#include "resim/testing/random_matrix.hh"
+#include "resim/transforms/se3.hh"
+#include "resim/utils/inout.hh"
+
+namespace resim::curves::learning {
+
+using transforms::SE3;
+using TwoJetL = TwoJetL<SE3>;
+using TangentVector = optimization::TwoJetTangentVector<SE3>;
+
+// Simple helper to create random sets of TwoJets drawn from a normal
+// distribution.
+template <typename Rng>
+std::vector<TwoJetL> random_samples(
+    const int num_samples,
+    const TwoJetL &dist_mean,
+    const double stddev,
+    InOut<Rng> rng) {
+  std::vector<TwoJetL> samples;
+  samples.reserve(num_samples);
+
+  std::normal_distribution<double> dist{0.0, stddev};
+  const auto generator = [&]() -> TwoJetL {
+    return optimization::accumulate(
+        dist_mean,
+        testing::random_matrix<TangentVector>(*rng, dist));
+  };
+
+  std::generate_n(std::back_inserter(samples), num_samples, generator);
+
+  return samples;
+}
+
+TEST(TwoJetMeanTest, TestTwoJetMean) {
+  // SETUP
+  constexpr std::size_t NUM_SAMPLES = 50;
+  constexpr int SEED = 8932;
+  constexpr double STDDEV = 0.1;
+  constexpr int MAX_ITERATIONS = NUM_SAMPLES;
+  constexpr int NUM_TESTS = 10;
+  constexpr double TOLERANCE = 1e-8;
+  constexpr double MEAN_TOLERANCE = 5e-2;
+
+  TwoJetTestHelper<TwoJetL> helper;
+  std::mt19937 rng{SEED};
+
+  for (int ii = 0; ii < NUM_TESTS; ++ii) {
+    auto dist_mean = helper.make_test_two_jet();
+    const auto samples =
+        random_samples(NUM_SAMPLES, dist_mean, STDDEV, InOut{rng});
+
+    // ACTION
+    const auto sample_mean_sv =
+        two_jet_mean(samples, TOLERANCE, MAX_ITERATIONS);
+
+    // VERIFICATION
+    ASSERT_TRUE(sample_mean_sv.ok());
+    const TwoJetL &sample_mean = sample_mean_sv.value();
+
+    EXPECT_TRUE(sample_mean.is_approx(dist_mean, MEAN_TOLERANCE));
+  }
+}
+
+TEST(TwoJetMeanTest, TestTwoJetMeanSingleSample) {
+  // SETUP
+  constexpr int SEED = 8932;
+  constexpr int MAX_ITERATIONS = 10;
+  constexpr int NUM_TESTS = 10;
+  constexpr double TOLERANCE = 1e-8;
+  constexpr double MEAN_TOLERANCE = 1e-12;
+
+  TwoJetTestHelper<TwoJetL> helper;
+  std::mt19937 rng{SEED};
+
+  for (int ii = 0; ii < NUM_TESTS; ++ii) {
+    auto dist_mean = helper.make_test_two_jet();
+    const std::vector<TwoJetL> samples = {dist_mean};
+
+    // ACTION
+    const auto sample_mean_sv =
+        two_jet_mean(samples, TOLERANCE, MAX_ITERATIONS);
+
+    // VERIFICATION
+    ASSERT_TRUE(sample_mean_sv.ok());
+    const TwoJetL &sample_mean = sample_mean_sv.value();
+
+    EXPECT_TRUE(sample_mean.is_approx(dist_mean, MEAN_TOLERANCE));
+  }
+}
+
+TEST(TwoJetMeanTest, TestTwoJetNoConverge) {
+  // SETUP
+  constexpr std::size_t NUM_SAMPLES = 50;
+  constexpr int SEED = 8932;
+  constexpr double STDDEV = 0.1;
+  constexpr int MAX_ITERATIONS = 1;
+  constexpr double TOLERANCE = 1e-8;
+
+  TwoJetTestHelper<TwoJetL> helper;
+  std::mt19937 rng{SEED};
+  auto dist_mean = helper.make_test_two_jet();
+  const auto samples =
+      random_samples(NUM_SAMPLES, dist_mean, STDDEV, InOut{rng});
+
+  // ACTION
+  const auto sample_mean_sv = two_jet_mean(samples, TOLERANCE, MAX_ITERATIONS);
+
+  // VERIFICATION
+  // Shouldn't converge because MAX_ITERATIONS is 1
+  EXPECT_FALSE(sample_mean_sv.ok());
+}
+
+}  // namespace resim::curves::learning

--- a/resim/curves/optimization/BUILD
+++ b/resim/curves/optimization/BUILD
@@ -10,6 +10,7 @@ cc_library(
     name = "two_jet_tangent_space",
     srcs = ["two_jet_tangent_space.cc"],
     hdrs = ["two_jet_tangent_space.hh"],
+    visibility = ["//resim/curves:__subpackages__"],
     deps = [
         "//resim/curves:two_jet",
         "//resim/math:vector_partition",


### PR DESCRIPTION
## Description of change
Two Jets exist on a manifold so their mean $\mu$ is computed iteratively such that:

$$
\sum_i (x_i \ominus \mu) = 0
$$

In our case $\ominus$ is defined by the difference in [two_jet_tangent_space](https://github.com/resim-ai/open-core/blob/main/resim/curves/optimization/two_jet_tangent_space.hh).

## Guide to reproduce test results.
```bash
bazel test //resim/curves/learning/...
```
## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
