### PR TITLE
Deprecating Rechart in metrics

### DIFF
--- a/docs/resim/metrics/metric_types.md
+++ b/docs/resim/metrics/metric_types.md
@@ -35,7 +35,59 @@ This is a maximally simple metric, with a single double. This is one of only two
 - `failure_definition: DoubleFailureDefinition` - the thresholds (on `value`) for whether the metric fails.
 - `unit: str` - a unit associated with `value`.
 
+## Plotly Metric
+
+In the event that the above metric types are not sufficient, ReSim support displaying an arbitrary plotly chart, via serializing 
+the [plotly JSON model](https://plotly.com/chart-studio-help/json-chart-schema/). This is the second metric to not have any `MetricsData`
+associated. It takes advantage of the ability to serialize a plotly figure as a JSON string:
+
+```python
+figure = px.pie(
+    data_frame=<data_frame>,
+    values=<values>,
+    names=<name>,
+    title=f"Pie chart example",
+    template=<template>,
+)
+plotly_json = figure.to_json()
+```
+
+In this way, charts not yet supported natively can be displayed and have the rest of the metrics framework metadata e.g. importance, status associated.
+
+### Parameters
+
+- `plotly_data: str` - the metric's plotly chart.
+
+## Image Metric
+
+The ReSim metrics framework also supports attaching an arbitrary image as a metric. This could be used to attach images from sensors, or from extremely custom charts previously created. This is simply achieved by storing the image in the `/tmp/resim/outputs` directory and referencing the filename in the metric.
+
+
+### Parameters
+
+- `image_data: ExternalFileMetricsData` - the metric's image, as an external file metrics data, which simply encapsulates the path to the file.
+
+## Text Metric
+
+ReSim supports displaying arbitrary Markdown as a metric. This metric also has no `MetricsData`
+associated. In this way, one can provide textual output from any system, evaluated with metric data. 
+This is commonly used in non-autonomy applications of the ReSim app.
+
+### Parameters
+
+- `text: str` - the metric's text.
+
+## Image List Metric
+
+For situations where you wish to attach a list of images to a single metric, the ReSim metrics framework also supports an `ImageListMetric`. This is achieved by storing the images in the `/tmp/resim/outputs` directory in the metrics build and referencing the filenames in the metric.
+
+### Parameters
+
+- `image_list_data: List[ExternalFileMetricsData]` - the metric's images, as a list of external file metrics data, which simply encapsulates the path to each file.
+
 ## Bar Chart
+
+`Note:` To provide more flexibility in your metrics, we are deprecating Rechart metrics. Please take a look at Plotly with some examples in the sandbox(link to sandbox)
 
 Bar chart provides a stacked or side-by-side bar chart of numerical data. An example would be the precision and recall being plotted as bars, over several different detection categories.
 
@@ -150,53 +202,3 @@ Histograms plot the frequencies with which doubles appear in an array, by bucket
 ### Grouped data support
 
 Grouped data should not currently be provided to histogram metrics.
-
-## Plotly Metric
-
-In the event that the above metric types are not sufficient, ReSim support displaying an arbitrary plotly chart, via serializing 
-the [plotly JSON model](https://plotly.com/chart-studio-help/json-chart-schema/). This is the second metric to not have any `MetricsData`
-associated. It takes advantage of the ability to serialize a plotly figure as a JSON string:
-
-```python
-figure = px.pie(
-    data_frame=<data_frame>,
-    values=<values>,
-    names=<name>,
-    title=f"Pie chart example",
-    template=<template>,
-)
-plotly_json = figure.to_json()
-```
-
-In this way, charts not yet supported natively can be displayed and have the rest of the metrics framework metadata e.g. importance, status associated.
-
-### Parameters
-
-- `plotly_data: str` - the metric's plotly chart.
-
-## Image Metric
-
-The ReSim metrics framework also supports attaching an arbitrary image as a metric. This could be used to attach images from sensors, or from extremely custom charts previously created. This is simply achieved by storing the image in the `/tmp/resim/outputs` directory and referencing the filename in the metric.
-
-
-### Parameters
-
-- `image_data: ExternalFileMetricsData` - the metric's image, as an external file metrics data, which simply encapsulates the path to the file.
-
-## Text Metric
-
-ReSim supports displaying arbitrary Markdown as a metric. This metric also has no `MetricsData`
-associated. In this way, one can provide textual output from any system, evaluated with metric data. 
-This is commonly used in non-autonomy applications of the ReSim app.
-
-### Parameters
-
-- `text: str` - the metric's text.
-
-## Image List Metric
-
-For situations where you wish to attach a list of images to a single metric, the ReSim metrics framework also supports an `ImageListMetric`. This is achieved by storing the images in the `/tmp/resim/outputs` directory in the metrics build and referencing the filenames in the metric.
-
-### Parameters
-
-- `image_list_data: List[ExternalFileMetricsData]` - the metric's images, as a list of external file metrics data, which simply encapsulates the path to each file.

--- a/docs/resim/metrics/metric_types.md
+++ b/docs/resim/metrics/metric_types.md
@@ -88,7 +88,7 @@ For situations where you wish to attach a list of images to a single metric, the
 ## Deprecated Metrics
 
 !!! warning "Deprecation Notice"
-    To provide more flexibility in your metrics, we are deprecating Rechart metrics. Please take a look at Plotly with some examples in the sandbox(link to sandbox)
+    To provide more flexibility in your metrics, we are deprecating Rechart metrics. Please take a look at Plotly with [an example in the sandbox](https://github.com/resim-ai/sandbox/blob/8d10f09ceadea4f929c1a54fd6eeb4b859010529/systems/drone/metrics/batch_metrics.py#L184)
 
 ### Bar Chart
 

--- a/docs/resim/metrics/metric_types.md
+++ b/docs/resim/metrics/metric_types.md
@@ -85,15 +85,18 @@ For situations where you wish to attach a list of images to a single metric, the
 
 - `image_list_data: List[ExternalFileMetricsData]` - the metric's images, as a list of external file metrics data, which simply encapsulates the path to each file.
 
-## Bar Chart
+## Deprecated Metrics
 
-`Note:` To provide more flexibility in your metrics, we are deprecating Rechart metrics. Please take a look at Plotly with some examples in the sandbox(link to sandbox)
+!!! warning "Deprecation Notice"
+    To provide more flexibility in your metrics, we are deprecating Rechart metrics. Please take a look at Plotly with some examples in the sandbox(link to sandbox)
+
+### Bar Chart
 
 Bar chart provides a stacked or side-by-side bar chart of numerical data. An example would be the precision and recall being plotted as bars, over several different detection categories.
 
 ![An example bar chart](./bar_chart.png)
 
-### Parameters
+#### Parameters
 
 - `values_data: List[MetricsData]` - A list of $k$ series of doubles, each indexed by the same series of strings. These are the values to plot, and every series will be plotted on the same bar chart. The index values are the labels on the x-axis.
 - `statuses_data: List[MetricsData]` - A list of $k$ series of MetricStatuses, each indexed by the same series of strings. These are statuses associated with the above values.
@@ -102,17 +105,17 @@ Bar chart provides a stacked or side-by-side bar chart of numerical data. An exa
 - `y_axis_name: str`
 - `stack_bars: bool` - A bool indicating whether to stack the $k$ series. If this is true, a stacked bar chart will be produced, with all the series stacked above the corresponding index. If this is false, the $k$ bars per-index will be placed next to each other, above the corresponding index.
 
-### Grouped data support
+#### Grouped data support
 
 Grouped data should not currently be supplied to bar chart metrics.
 
-## Double over time
+### Double over time
 
 This is a plot of doubles, across timestamps in the simulation/experience. An example would be the distance between a self-driving car and the car in front, over a 30 second experience.
 
 ![An example double over time](./double_over_time.png)
 
-### Parameters
+#### Parameters
 
 - `doubles_over_time_data: List[MetricsData]` - A list of $k$ MetricsData containing series of doubles, indexed by series of timestamps. Each such series will be plotted as a separate line on the same chart.
 - `statuses_over_time_data: List[MetricsData]` - A list of $k$ MetricsData containing series of statuses, indexed by the same timestamps.
@@ -122,36 +125,36 @@ This is a plot of doubles, across timestamps in the simulation/experience. An ex
 - `y_axis_name: str`
 - `legend_series_names: List[str]`: An optional list of $k$ names for the data series - if not provided, the MetricsData names will be used.
 
-### Grouped Data Support
+#### Grouped Data Support
 
 Grouped data should not currently be supplied to double over time metrics.
 
-## Double Summary 
+### Double Summary 
 
 This is a single double summarizing a larger series of data. Currently, it only supports indexing an element from a series - in the future, we will likely add simple operations such as max, min, mean, and median.
 
 ![An example double summary metric](./double_summary.png)
 
-### Parameters
+#### Parameters
 
 - `value_data: MetricsData` - A series of doubles, optionally indexed.
 - `status_data: MetricStatus` - A series of statuses, corresponding to `value_data`.
 - `index_data: Union[int, str, Timestamp, uuid.UUID]` - An optional index $i$, with type corresponding to the index type of `value_data` (or `int` if there is no index). If not provided, then 0 will be used. This "selects" the element with corresponding index from value_data.
 - `failure_definition`: A failure definition for the selected value.
 
-### Grouped data
+#### Grouped data
 
 - Grouped data can be provided, and will be plotted as a key-value table, with key being the group name, and value being the corresponding double.
 
 ![An example grouped double summary metric](./grouped_double_summary.png)
 
-## States over Time
+### States over Time
 
 States-over-time charts visualize a categorical enum which changes over time. An example would be the classifications for an object's type, plotted over time; or a vehicle's attempted maneuver over time.
 
 ![An example states over time chart](./states_over_time.png)
 
-### Parameters 
+#### Parameters 
 
 - `states_over_time_data: List[MetricsData]`: A list of $k$ series, of strings, each indexed by timestamps. The strings here are used as an enum representing "states the system can be in", which are then plotted over time. If more than one series is provided, they will be plotted next to each other in one plot.
 - `statuses_over_time_data: List[MetricsData]`: A list of $k$ series of statuses, each indexed by timestamps. These are the timestamp-level statuses associated with `states_over_time_data`.
@@ -159,12 +162,11 @@ States-over-time charts visualize a categorical enum which changes over time. An
 - `failure_states: Set[str]` - A subset of `states_set`, representing the states in which it should fail.
 - `legend_series_names: List[str]` - A list of $k$ strings, storing the legend names of the series in `states_over_time_data`.
 
-
-### Grouped data support
+#### Grouped data support
 
 Grouped data is supported for StatesOverTime metrics, and will give a dropdown, with one chart per category.
 
-## Line Chart
+### Line Chart
 
 Line charts are classical line charts, plotting a dependent variable against an independent variable, joined by a line. Multiple lines can be placed on one chart.
 
@@ -172,7 +174,7 @@ Line charts are classical line charts, plotting a dependent variable against an 
 
 ![An example line chart](./line_chart.png)
 
-### Parameters
+#### Parameters
 
 - `x_doubles_data: List[MetricsData]` - A list of $k$ series of x-axis values to plot, which are doubles. Each series will be plotted on the same chart.
 - `y_doubles_data: List[MetricsData]` - A list of $k$ series of y-axis values, where the $i$^{th} series corresponds to the $i$^{th} series in `x_doubles_data`.
@@ -181,17 +183,17 @@ Line charts are classical line charts, plotting a dependent variable against an 
 - `y_axis_name: str`
 - `legend_series_names` - A list of $k$ strings, storing the legend names of the series in `x_doubles_data` and `y_doubles_data`.
 
-### Grouped data support
+#### Grouped data support
 
 Grouped data should currently not be provided to line plot.
 
-## Histogram
+### Histogram
 
 Histograms plot the frequencies with which doubles appear in an array, by bucketing them and plotting them as a bar chart. An example would be the frequencies over frames of the probabilities output by a classifier; or the frequencies with which there are a certain number of actors detected.
 
 ![An example histogram](./histogram.png)
 
-### Parameters
+#### Parameters
 
 - `values_data: MetricsData`: A series of doubles, the frequencies of which will be plotted.
 - `statuses_data: MetricsData`: The associated statuses to `values_data`.
@@ -199,6 +201,6 @@ Histograms plot the frequencies with which doubles appear in an array, by bucket
 - `lower_bound`: An optional lower bound on how small values can be.
 - `upper_bound`: An optional upper bound on how big values can be.
 
-### Grouped data support
+#### Grouped data support
 
 Grouped data should not currently be provided to histogram metrics.


### PR DESCRIPTION
## Description of change
We are moving our charting library to Plotly, and are deprecating metrics that used Rechart. This PR does a couple of things: 

- [x] Groups deprecated metrics into a section denoting the metrics are deprecated
- [x] Adds a note at the top of the section saying they are deprecated (possibly add it to each chart individually to make it very obvious?)

## Guide to reproduce test results.

To test you can pull it locally and run it and see if things look good. 

## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
