### PR TITLE
Sweep metrics collector script

### DIFF
--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -47,6 +47,7 @@ py_package(
         "//resim/metrics:fetch_job_metrics",
         "//resim/metrics:fetch_metrics_urls",
         "//resim/metrics:fetch_report_metrics",
+        "//resim/metrics:fetch_sweep_metrics",
         "//resim/metrics:get_metrics_proto",
         "//resim/metrics/proto:metrics_proto_py",
         "//resim/metrics/proto:validate_metrics_proto",

--- a/resim/metrics/BUILD
+++ b/resim/metrics/BUILD
@@ -248,3 +248,14 @@ pkg_tar(
     include_runfiles = True,
     strip_prefix = "/",
 )
+
+py_binary(
+    name = "fetch_sweep_metrics",
+    srcs = ["fetch_sweep_metrics.py"],
+    deps = [
+        ":fetch_all_pages",
+        "//resim-python-client",
+        "//resim/auth/python:device_code_client",
+        requirement("pandas"),
+    ],
+)

--- a/resim/metrics/BUILD
+++ b/resim/metrics/BUILD
@@ -252,6 +252,7 @@ pkg_tar(
 py_binary(
     name = "fetch_sweep_metrics",
     srcs = ["fetch_sweep_metrics.py"],
+    visibility = ["//visibility:public"],
     deps = [
         ":fetch_all_pages",
         "//resim-python-client",

--- a/resim/metrics/fetch_sweep_metrics.py
+++ b/resim/metrics/fetch_sweep_metrics.py
@@ -1,3 +1,9 @@
+# Copyright 2025 ReSim, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
 import asyncio
 from resim_python_client.client import AuthenticatedClient
 from resim.auth.python.device_code_client import DeviceCodeClient

--- a/resim/metrics/fetch_sweep_metrics.py
+++ b/resim/metrics/fetch_sweep_metrics.py
@@ -5,6 +5,7 @@ from resim_python_client.api.batches import list_jobs, list_metrics_for_job
 from uuid import UUID
 import pandas as pd
 import argparse
+from pathlib import Path
 
 from resim_python_client.models import (
     Job,
@@ -19,6 +20,9 @@ from resim_python_client.api.parameter_sweeps import get_parameter_sweep
 async def _fetch_jobs_for_batch(
     *, client: AuthenticatedClient, batch_id: UUID, project_id: UUID
 ) -> list[Job]:
+    """
+    Fetch all the jobs corresponding to a single batch.
+    """
     job_pages: list[ListJobsOutput] = await async_fetch_all_pages(
         list_jobs.asyncio,
         client=client,
@@ -30,7 +34,11 @@ async def _fetch_jobs_for_batch(
 
 async def _fetch_scalar_metrics_for_job(
     *, client: AuthenticatedClient, job_id: UUID, batch_id: UUID, project_id: UUID
-) -> pd.DataFrame:
+) -> list[tuple]:
+    """
+    Fetch all scalar metrics for a single job.
+    """
+
     job_metrics_pages: ListJobMetricsOutput = await async_fetch_all_pages(
         list_metrics_for_job.asyncio,
         client=client,
@@ -46,33 +54,59 @@ async def _fetch_scalar_metrics_for_job(
     ]
 
 
-async def fetch_sweep_metrics_frame(
-    *, client: AuthenticatedClient, sweep_id: UUID, project_id: UUID
+async def _fetch_sweep_metrics_frame(
+    *, client: AuthenticatedClient, sweep_id: UUID, project_id: UUID, pivot: bool
 ) -> pd.DataFrame:
+    """
+    Compute the sweep metrics frame.
+
+    There are two options, if pivot==false, we just produce a single frame with columns:
+    (batch_id, job_id, sweep_params..., name, value, unit)
+    where each batch id and job id is repeated once for each metric in that job.
+
+    If pivot==true, we produce a single frame with columns:
+    (batch_id, job_id, sweep_params..., metrics_values...)
+
+    where each job now appears only once and units are no longer present.
+    """
     sweep = await get_parameter_sweep.asyncio(
         project_id=str(project_id), sweep_id=str(sweep_id), client=client
     )
     batch_ids = sweep.batches
 
-    jobs = [
+    jobs_per_batch = [
         await _fetch_jobs_for_batch(
             client=client, batch_id=UUID(bid), project_id=project_id
         )
         for bid in batch_ids
     ]
+    jobs = [j for batch in jobs_per_batch for j in batch]
 
     # Could be done more async with a task group
-    jobs_frame = pd.DataFrame(
-        [(j.job_id, j.batch_id) for batch in jobs for j in batch],
-        columns=("job_id", "batch_id"),
+    job_rows = []
+    param_set = set()
+    for j in jobs:
+        param_set.update(j.parameters.additional_properties)
+
+    params = list(param_set)
+    for j in jobs:
+        job_rows.append(
+            (j.job_id, j.batch_id)
+            + tuple((j.parameters.additional_properties[p] for p in params))
+        )
+
+    columns = ("job_id", "batch_id") + tuple(params)
+
+    jobs_frame = pd.DataFrame(job_rows, columns=columns).set_index(
+        ["batch_id", "job_id"]
     )
 
+    # Use a semaphore so we don't try to fetch too many jobs' metrics simultaneously
     sem = asyncio.Semaphore(20)
 
-    async def fetch_metrics(row: pd.DataFrame) -> pd.DataFrame:
+    async def fetch_metrics(idx: pd.DataFrame) -> pd.DataFrame:
         async with sem:
-            job_id = row["job_id"]
-            batch_id = row["batch_id"]
+            batch_id, job_id = idx
             metrics = await _fetch_scalar_metrics_for_job(
                 client=client,
                 job_id=UUID(job_id),
@@ -85,20 +119,46 @@ async def fetch_sweep_metrics_frame(
                     for (name, value, unit) in metrics
                 ],
                 columns=("batch_id", "job_id", "name", "value", "unit"),
-            )
+            ).set_index(["batch_id", "job_id"])
 
     frames = await asyncio.gather(
-        *(fetch_metrics(row) for _, row in jobs_frame.iterrows())
+        *(fetch_metrics(index) for index, _ in jobs_frame.iterrows())
     )
+    metrics_frame = pd.concat(frames)
 
-    metrics_frame = pd.concat(frames, ignore_index=True)
-    metrics_frame.to_csv("/home/ubuntu/job_metrics.csv", index=False)
+    if pivot:
+        metrics_frame = metrics_frame.pivot(columns="name", values="value")
+    return jobs_frame.join(metrics_frame).reset_index()
 
 
 async def main() -> None:
-    parser = argparse.ArgumentParser(prog="fetch_sweep_metrics")
+    parser = argparse.ArgumentParser(
+        prog="fetch_sweep_metrics",
+        description="""
+This program computes a DataFrame containing all *scalar* job metrics data from a parameter sweep.
+    
+There are two options for how this DataFrame can be laid out:
+
+If pivot==false, we just produce a single frame with columns:
+(batch_id, job_id, sweep_params..., name, value, unit)
+where each batch id and job id is repeated once for each metric in that job.
+
+If pivot==true, we produce a single frame with columns:
+(batch_id, job_id, sweep_params..., metrics_values...)
+where each job now appears only once and units are no longer present. Note that
+null entries may result in the case where some jobs produce different metrics
+from others.
+""",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     parser.add_argument("--project-id", type=UUID, required=True)
     parser.add_argument("--sweep-id", type=UUID, required=True)
+    parser.add_argument(
+        "--pivot",
+        action="store_true",
+        help="Pivot the resulting metrics so that each metric gets its own column",
+    )
+    parser.add_argument("--output-path", type=Path, required=True)
 
     args = parser.parse_args()
     device_code_client = DeviceCodeClient()
@@ -107,11 +167,14 @@ async def main() -> None:
         token=device_code_client.get_jwt()["access_token"],
     )
 
-    await fetch_sweep_metrics_frame(
+    metrics_frame = await _fetch_sweep_metrics_frame(
         client=client,
         sweep_id=args.sweep_id,
         project_id=args.project_id,
+        pivot=args.pivot,
     )
+
+    metrics_frame.to_csv(args.output_path, index=False)
 
 
 if __name__ == "__main__":

--- a/resim/metrics/fetch_sweep_metrics.py
+++ b/resim/metrics/fetch_sweep_metrics.py
@@ -16,6 +16,8 @@ from resim_python_client.models import (
 from resim.metrics.fetch_all_pages import async_fetch_all_pages
 from resim_python_client.api.parameter_sweeps import get_parameter_sweep
 
+_PAGE_SIZE = 100
+
 
 async def _fetch_jobs_for_batch(
     *, client: AuthenticatedClient, batch_id: UUID, project_id: UUID
@@ -28,6 +30,7 @@ async def _fetch_jobs_for_batch(
         client=client,
         project_id=str(project_id),
         batch_id=str(batch_id),
+        page_size=_PAGE_SIZE,
     )
     return [j for page in job_pages for j in page.jobs]
 
@@ -45,6 +48,7 @@ async def _fetch_scalar_metrics_for_job(
         project_id=str(project_id),
         batch_id=str(batch_id),
         job_id=str(job_id),
+        page_size=_PAGE_SIZE,
     )
     return [
         (m.name, m.value, m.unit)

--- a/resim/metrics/fetch_sweep_metrics.py
+++ b/resim/metrics/fetch_sweep_metrics.py
@@ -58,7 +58,7 @@ async def _fetch_scalar_metrics_for_job(
     ]
 
 
-async def _fetch_sweep_metrics_frame(
+async def fetch_sweep_metrics_frame(
     *, client: AuthenticatedClient, sweep_id: UUID, project_id: UUID, pivot: bool
 ) -> pd.DataFrame:
     """
@@ -171,7 +171,7 @@ from others.
         token=device_code_client.get_jwt()["access_token"],
     )
 
-    metrics_frame = await _fetch_sweep_metrics_frame(
+    metrics_frame = await fetch_sweep_metrics_frame(
         client=client,
         sweep_id=args.sweep_id,
         project_id=args.project_id,

--- a/resim/metrics/fetch_sweep_metrics.py
+++ b/resim/metrics/fetch_sweep_metrics.py
@@ -1,0 +1,114 @@
+import asyncio
+from resim_python_client.client import AuthenticatedClient
+from resim.auth.python.device_code_client import DeviceCodeClient
+from resim_python_client.api.batches import list_jobs, list_metrics_for_job
+from uuid import UUID
+import pandas as pd
+import argparse
+import asyncio
+
+from resim_python_client.models import Job, MetricType
+from resim.metrics.fetch_all_pages import async_fetch_all_pages
+from resim_python_client.api.parameter_sweeps import get_parameter_sweep
+
+
+async def _fetch_jobs_for_batch(
+    *, client: AuthenticatedClient, batch_id: UUID, project_id: UUID
+) -> list[Job]:
+    job_pages = await async_fetch_all_pages(
+        list_jobs.asyncio,
+        client=client,
+        project_id=str(project_id),
+        batch_id=str(batch_id),
+    )
+    return [j for page in job_pages for j in page.jobs]
+
+
+async def _fetch_scalar_metrics_for_job(
+    *, client: AuthenticatedClient, job_id: UUID, batch_id: UUID, project_id: UUID
+) -> pd.DataFrame:
+    job_metrics_pages = await async_fetch_all_pages(
+        list_metrics_for_job.asyncio,
+        client=client,
+        project_id=str(project_id),
+        batch_id=str(batch_id),
+        job_id=str(job_id),
+    )
+    return [
+        (m.name, m.value, m.unit)
+        for page in job_metrics_pages
+        for m in page.metrics
+        if m.type == MetricType.SCALAR
+    ]
+
+
+async def fetch_sweep_metrics_frame(
+    *, client: AuthenticatedClient, sweep_id: UUID, project_id: UUID
+) -> pd.DataFrame:
+    sweep = await get_parameter_sweep.asyncio(
+        project_id=str(project_id), sweep_id=str(sweep_id), client=client
+    )
+    batch_ids = sweep.batches
+
+    jobs = [
+        await _fetch_jobs_for_batch(
+            client=client, batch_id=UUID(bid), project_id=project_id
+        )
+        for bid in batch_ids
+    ]
+
+    # Could be done more async with a task group
+    jobs_frame = pd.DataFrame(
+        [(j.job_id, j.batch_id) for batch in jobs for j in batch],
+        columns=("job_id", "batch_id"),
+    )
+
+    sem = asyncio.Semaphore(20)
+
+    async def fetch_metrics(row: tuple):
+        async with sem:
+            job_id = row["job_id"]
+            batch_id = row["batch_id"]
+            metrics = await _fetch_scalar_metrics_for_job(
+                client=client,
+                job_id=UUID(job_id),
+                batch_id=UUID(batch_id),
+                project_id=project_id,
+            )
+            return pd.DataFrame(
+                [
+                    (batch_id, job_id, name, value, unit)
+                    for (name, value, unit) in metrics
+                ],
+                columns=("batch_id", "job_id", "name", "value", "unit"),
+            )
+
+    frames = await asyncio.gather(
+        *(fetch_metrics(row) for _, row in jobs_frame.iterrows())
+    )
+
+    metrics_frame = pd.concat(frames, ignore_index=True)
+    metrics_frame.to_csv("/home/ubuntu/job_metrics.csv", index=False)
+
+
+async def main():
+    parser = argparse.ArgumentParser(prog="fetch_sweep_metrics")
+    parser.add_argument("--project-id", type=UUID, required=True)
+    parser.add_argument("--sweep-id", type=UUID, required=True)
+
+    args = parser.parse_args()
+    device_code_client = DeviceCodeClient()
+    client = AuthenticatedClient(
+        base_url="https://api.resim.ai/v1/",
+        token=device_code_client.get_jwt()["access_token"],
+    )
+
+    await fetch_sweep_metrics_frame(
+        client=client,
+        sweep_id=args.sweep_id,
+        project_id=args.project_id,
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Description of change
Add a helper binary to fetch a DataFrame with all scalar job metrics from a parameter sweep.

## Guide to reproduce test results.
```bash
bazel run //resim/metrics:fetch_sweep_metrics -- --project-id <project-id> --sweep-id <sweep-id> --output-path "$(pwd)/metrics.csv"
```

Running against one of our test projects, with pivot:

|batch_id                            |job_id                              |velocity_cost_override|Mean Ego Speed    |TestLength  |
|------------------------------------|------------------------------------|----------------------|------------------|------------|
|24c09aa0-4e78-44cb-922d-7296315427b8|10607d7b-61f3-42aa-a674-65148739a8e8|0.06                  |19.177305066641562|19.915033869|
|7d63821f-8100-4a29-8544-a012ef930f41|508f9572-3764-42aa-ba5c-10bc93bd493d|0.01                  |19.177305066641562|20.936511434|
|8e3b0d51-41ec-4cd3-a793-40cdfdd2215a|896e607a-e2f8-457a-b0cf-e9ae71c1ea54|0.03                  |19.177305066641562|19.896541426|
|a6e20ebc-db1f-45b6-a811-32c43aef7e8b|92800091-6f35-4681-a560-ec67508bb249|0.05                  |19.177305066641562|19.823120796|
|aa20e359-f2e6-4fd2-8556-1fb09221a989|42c76adc-c1a0-4512-b6e9-b01d9c6a48ab|0.02                  |19.177305066641562|20.411389924|
|ac92f51a-f05e-498a-a70d-f6110ee13838|214fff42-1497-41a5-bd0f-68d74650b759|0.04                  |19.177305066641562|21.904813282|

Without pivot:

|batch_id                            |job_id                              |velocity_cost_override|name              |value       |unit|
|------------------------------------|------------------------------------|----------------------|------------------|------------|----|
|24c09aa0-4e78-44cb-922d-7296315427b8|10607d7b-61f3-42aa-a674-65148739a8e8|0.06                  |TestLength        |19.915033869|s   |
|24c09aa0-4e78-44cb-922d-7296315427b8|10607d7b-61f3-42aa-a674-65148739a8e8|0.06                  |Mean Ego Speed    |19.177305066641562|m/s |
|7d63821f-8100-4a29-8544-a012ef930f41|508f9572-3764-42aa-ba5c-10bc93bd493d|0.01                  |Mean Ego Speed    |19.177305066641562|m/s |
|7d63821f-8100-4a29-8544-a012ef930f41|508f9572-3764-42aa-ba5c-10bc93bd493d|0.01                  |TestLength        |20.936511434|s   |
|8e3b0d51-41ec-4cd3-a793-40cdfdd2215a|896e607a-e2f8-457a-b0cf-e9ae71c1ea54|0.03                  |Mean Ego Speed    |19.177305066641562|m/s |
|8e3b0d51-41ec-4cd3-a793-40cdfdd2215a|896e607a-e2f8-457a-b0cf-e9ae71c1ea54|0.03                  |TestLength        |19.896541426|s   |
|a6e20ebc-db1f-45b6-a811-32c43aef7e8b|92800091-6f35-4681-a560-ec67508bb249|0.05                  |TestLength        |19.823120796|s   |
|a6e20ebc-db1f-45b6-a811-32c43aef7e8b|92800091-6f35-4681-a560-ec67508bb249|0.05                  |Mean Ego Speed    |19.177305066641562|m/s |
|aa20e359-f2e6-4fd2-8556-1fb09221a989|42c76adc-c1a0-4512-b6e9-b01d9c6a48ab|0.02                  |Mean Ego Speed    |19.177305066641562|m/s |
|aa20e359-f2e6-4fd2-8556-1fb09221a989|42c76adc-c1a0-4512-b6e9-b01d9c6a48ab|0.02                  |TestLength        |20.411389924|s   |
|ac92f51a-f05e-498a-a70d-f6110ee13838|214fff42-1497-41a5-bd0f-68d74650b759|0.04                  |TestLength        |21.904813282|s   |
|ac92f51a-f05e-498a-a70d-f6110ee13838|214fff42-1497-41a5-bd0f-68d74650b759|0.04                  |Mean Ego Speed    |19.177305066641562|m/s |


## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [ ] This change is covered by tests that are already landed, or in this PR.
