### PR TITLE
PRO-225: Relax validation on duplicate metric names

### DIFF
--- a/resim/metrics/python/metrics.py
+++ b/resim/metrics/python/metrics.py
@@ -2133,6 +2133,10 @@ class Event:
         return self
 
     def with_metrics(self: Event, metrics: List[Metric]) -> Event:
+        # ensure all event metrics have unique names
+        assert len(metrics) == len(set(m.name for m in metrics)), (
+            "Event metrics must have unique names."
+        )
         self.metrics = metrics
         return self
 

--- a/resim/metrics/python/metrics_test.py
+++ b/resim/metrics/python/metrics_test.py
@@ -2101,6 +2101,22 @@ class MetricsTest(unittest.TestCase):
         self.assertTrue(event.timestamp == timestamp)
         self.assertTrue(event.timestamp_type == TimestampType.ABSOLUTE_TIMESTAMP)
 
+    def test_event_duplicate_metric_names(self) -> None:
+        """Test that Event.with_metrics() fails when metrics have duplicate names"""
+        event = metrics.Event(name="test_event")
+
+        # Create two metrics with the same name
+        metric1 = metrics.ScalarMetric(
+            name="duplicate_name", parent_job_id=uuid.uuid4()
+        )
+        metric2 = metrics.ScalarMetric(
+            name="duplicate_name", parent_job_id=uuid.uuid4()
+        )
+
+        with self.assertRaises(AssertionError) as context:
+            event.with_metrics([metric1, metric2])
+        self.assertIn("Event metrics must have unique names", str(context.exception))
+
     def test_event_pack(self) -> None:
         name = "my_event"
         description = "event description"

--- a/resim/metrics/python/metrics_writer.py
+++ b/resim/metrics/python/metrics_writer.py
@@ -44,25 +44,24 @@ class ResimMetricsWriter:
     metrics: Dict[uuid.UUID, Metric]
     metrics_data: Dict[uuid.UUID, BaseMetricsData]
     events: Dict[uuid.UUID, Event]
-
-    names: Set[str]
+    metrics_data_names: Set[str]
+    event_names: Set[str]
 
     def __init__(self, job_id: uuid.UUID):
         self.job_id = job_id
         self.metrics = {}
         self.metrics_data = {}
         self.events = {}
-        self.names = set()
+        self.metrics_data_names = set()
+        self.event_names = set()
 
     def add_metrics_data(self, data: BaseMetricsDataT) -> BaseMetricsDataT:
-        assert data.name not in self.names
-        self.names.add(data.name)
+        assert data.name not in self.metrics_data_names
+        self.metrics_data_names.add(data.name)
         self.metrics_data[data.id] = data
         return data
 
     def add_metric(self, metric: MetricT) -> MetricT:
-        assert metric.name not in self.names
-        self.names.add(metric.name)
         self.metrics[metric.id] = metric
         return metric
 
@@ -75,8 +74,8 @@ class ResimMetricsWriter:
         Returns:
             Event: the added event, for chaining
         """
-        assert event.name not in self.names
-        self.names.add(event.name)
+        assert event.name not in self.event_names
+        self.event_names.add(event.name)
         self.events[event.id] = event
         return event
 

--- a/resim/metrics/python/metrics_writer_test.py
+++ b/resim/metrics/python/metrics_writer_test.py
@@ -546,7 +546,7 @@ class TestMetricsWriter(unittest.TestCase):
         metrics_data = self.writer.add_grouped_metrics_data(name=NAME)
         self.assertEqual(type(metrics_data), GroupedMetricsData)
         self.assertEqual(metrics_data.name, NAME)
-        self.assertIn(NAME, self.writer.names)
+        self.assertIn(NAME, self.writer.metrics_data_names)
         self.assertIn(metrics_data.id, self.writer.metrics_data)
         self.assertEqual(self.writer.metrics_data[metrics_data.id], metrics_data)
 
@@ -780,7 +780,7 @@ class TestMetricsWriter(unittest.TestCase):
         metrics_data = self.writer.add_external_file_metrics_data(name=NAME)
         self.assertEqual(type(metrics_data), ExternalFileMetricsData)
         self.assertEqual(metrics_data.name, NAME)
-        self.assertIn(NAME, self.writer.names)
+        self.assertIn(NAME, self.writer.metrics_data_names)
         self.assertIn(metrics_data.id, self.writer.metrics_data)
         self.assertEqual(self.writer.metrics_data[metrics_data.id], metrics_data)
 


### PR DESCRIPTION
## Description of change
- Allow duplicate metric names if they are in different event metrics

## Guide to reproduce test results.
<!-- 
    Please help reviewers by including instructions 
    on how to test this change
-->
## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
