### PR TITLE
Don't fetch image list metrics in fetch_job_metrics

### DIFF
--- a/resim/metrics/fetch_job_metrics.py
+++ b/resim/metrics/fetch_job_metrics.py
@@ -273,10 +273,11 @@ def _fetch_metrics(
         message_type=message_type, session=session, url=url
     )
 
-    if  (
+    if (
         # these metrics depend on external file metrics, which we do not fetch due to optimize the fetch process. So if we unpack them, it could fail
         message_type == mp.Metric
-        and metrics_proto.type in  [mp.MetricType.IMAGE_METRIC_TYPE, mp.MetricType.IMAGE_LIST_METRIC_TYPE] 
+        and metrics_proto.type
+        in [mp.MetricType.IMAGE_METRIC_TYPE, mp.MetricType.IMAGE_LIST_METRIC_TYPE]
     ):
         return
     protos_lock.acquire()

--- a/resim/metrics/fetch_job_metrics.py
+++ b/resim/metrics/fetch_job_metrics.py
@@ -273,9 +273,10 @@ def _fetch_metrics(
         message_type=message_type, session=session, url=url
     )
 
-    if (
+    if  (
+        # these metrics depend on external file metrics, which we do not fetch due to optimize the fetch process. So if we unpack them, it could fail
         message_type == mp.Metric
-        and metrics_proto.type == mp.MetricType.IMAGE_METRIC_TYPE
+        and metrics_proto.type in  [mp.MetricType.IMAGE_METRIC_TYPE, mp.MetricType.IMAGE_LIST_METRIC_TYPE] 
     ):
         return
     protos_lock.acquire()


### PR DESCRIPTION
## Description of change
This metric references external files which aren't pulled when fetching job metrics, so the function will fail when trying to unpack image list metrics if they aren't exempted.

## Guide to reproduce test results.
```bash
bazel test //resim/metrics:fetch_job_metrics_test
```
## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
