### PR TITLE
WOB-4023 | Support syncing custom metrics templates

### DIFF
--- a/resim/metrics/python/metrics_test.py
+++ b/resim/metrics/python/metrics_test.py
@@ -2078,7 +2078,7 @@ class MetricsTest(unittest.TestCase):
         )
 
         with self.assertRaises(ValueError):
-            event.with_tags("only_a_single_tag")  # type: ignore
+            event.with_tags("only_a_single_tag")
 
         self.assertEqual(event, event.with_description(description))
         self.assertEqual(event, event.with_tags(tags))

--- a/resim/sdk/batch.py
+++ b/resim/sdk/batch.py
@@ -28,7 +28,10 @@ class Batch(AbstractContextManager):
         name: str | None = None,
         version: str | None = None,
         metrics_set_name: str | None = None,
-        metrics_config_path: Union[str, Sequence[str], None] = None,
+        metrics_config_path: Union[
+            str, Sequence[str], None
+        ] = ".resim/metrics/config.resim.yml",
+        templates_path: str | None = ".resim/metrics/templates",
         system: str | None = None,
         test_suite: str | None = None,
         test_suite_revision: int | None = None,
@@ -46,7 +49,10 @@ class Batch(AbstractContextManager):
             name: Optional display name for the batch.
             version: Optional version string to associate with the batch, such as a commit SHA or semver.
             metrics_set_name: Optional name of the metrics set to use, from your config file.
-            metrics_config_path: Optional path to a metrics config file to sync before creating the batch.
+            metrics_config_path: Path to a metrics config file (or directory) to sync before creating the batch.
+                Defaults to ``".resim/metrics/config.resim.yml"``. Pass ``None`` to disable syncing.
+            templates_path: Path to a directory of custom metric ``.liquid`` template files to sync alongside
+                the metrics config. Defaults to ``".resim/metrics/templates"``.
             system: Optional name of the system to use for the build.
             test_suite: Optional name of the test suite to attach the batch to.
             test_suite_revision: Optional revision of the test suite to pin to. Requires test_suite.
@@ -66,6 +72,7 @@ class Batch(AbstractContextManager):
         self._branch = branch
         self._metrics_set_name = metrics_set_name
         self.metrics_config_path = metrics_config_path
+        self._templates_path = templates_path
         self._system = system
         self._test_suite = test_suite
         self._test_suite_revision = test_suite_revision
@@ -80,6 +87,7 @@ class Batch(AbstractContextManager):
                 self.project_id,
                 self._branch,
                 config_path=self.metrics_config_path,
+                templates_path=self._templates_path,
             )
 
         self._branch_id = self.__get_branch_id(self._branch)

--- a/resim/sdk/batch_test.py
+++ b/resim/sdk/batch_test.py
@@ -39,11 +39,16 @@ class BatchTest(unittest.TestCase):
         mock_close_response.status_code = 204
         mock_close_batch.sync_detailed.return_value = mock_close_response
 
+    @patch("resim.sdk.batch.metrics")
     @patch("resim.sdk.batch.close_batch")
     @patch("resim.sdk.batch.create_light_batch")
     @patch("resim.sdk.batch.list_branches_for_project")
     def test_batch(
-        self, mock_list_branches: Any, mock_create_batch: Any, mock_close_batch: Any
+        self,
+        mock_list_branches: Any,
+        mock_create_batch: Any,
+        mock_close_batch: Any,
+        _mock_metrics: Any,
     ) -> None:
         mock_client = MagicMock()
 
@@ -91,6 +96,7 @@ class BatchTest(unittest.TestCase):
             PROJECT_ID, BATCH_ID, client=mock_client
         )
 
+    @patch("resim.sdk.batch.metrics")
     @patch("resim.sdk.batch.close_batch")
     @patch("resim.sdk.batch.create_light_batch")
     @patch("resim.sdk.batch.list_branches_for_project")
@@ -101,6 +107,7 @@ class BatchTest(unittest.TestCase):
         mock_list_branches: Any,
         mock_create_batch: Any,
         mock_close_batch: Any,
+        _mock_metrics: Any,
     ) -> None:
         mock_client = MagicMock()
 
@@ -136,6 +143,7 @@ class BatchTest(unittest.TestCase):
 
         mock_list_projects.sync.assert_called_once_with(client=mock_client)
 
+    @patch("resim.sdk.batch.metrics")
     @patch("resim.sdk.batch.close_batch")
     @patch("resim.sdk.batch.create_light_batch")
     @patch("resim.sdk.batch.list_branches_for_project")
@@ -146,6 +154,7 @@ class BatchTest(unittest.TestCase):
         mock_list_branches: Any,
         mock_create_batch: Any,
         mock_close_batch: Any,
+        _mock_metrics: Any,
     ) -> None:
         mock_client = MagicMock()
 
@@ -254,6 +263,7 @@ class BatchTest(unittest.TestCase):
             PROJECT_ID,
             BRANCH_NAME,
             config_path=config_path,
+            templates_path=".resim/metrics/templates",
         )
 
     @patch("resim.sdk.batch.metrics")
@@ -298,6 +308,7 @@ class BatchTest(unittest.TestCase):
             PROJECT_ID,
             BRANCH_NAME,
             config_path=config_paths,
+            templates_path=".resim/metrics/templates",
         )
 
     @patch("resim.sdk.batch.metrics")
@@ -327,13 +338,18 @@ class BatchTest(unittest.TestCase):
         mock_close_response.status_code = 204
         mock_close_batch.sync_detailed.return_value = mock_close_response
 
-        with Batch(mock_client, BRANCH_NAME, project_id=PROJECT_ID):
+        with Batch(
+            mock_client, BRANCH_NAME, project_id=PROJECT_ID, metrics_config_path=None
+        ):
             pass
 
         mock_metrics.sync_config.assert_not_called()
 
+    @patch("resim.sdk.batch.metrics")
     @patch("resim.sdk.batch.list_branches_for_project")
-    def test_batch_raises_if_branch_is_missing(self, mock_list_branches: Any) -> None:
+    def test_batch_raises_if_branch_is_missing(
+        self, mock_list_branches: Any, _mock_metrics: Any
+    ) -> None:
         mock_client = MagicMock()
         mock_list_branches.sync.return_value = MagicMock(branches=[])
 
@@ -341,6 +357,7 @@ class BatchTest(unittest.TestCase):
             with Batch(mock_client, BRANCH_NAME, project_id=PROJECT_ID):
                 pass
 
+    @patch("resim.sdk.batch.metrics")
     @patch("resim.sdk.batch.close_batch")
     @patch("resim.sdk.batch.create_light_batch")
     @patch("resim.sdk.batch.list_systems")
@@ -351,6 +368,7 @@ class BatchTest(unittest.TestCase):
         mock_list_systems: Any,
         mock_create_batch: Any,
         mock_close_batch: Any,
+        _mock_metrics: Any,
     ) -> None:
         mock_client = MagicMock()
         self._make_standard_mocks(
@@ -371,6 +389,7 @@ class BatchTest(unittest.TestCase):
         body = mock_create_batch.sync_detailed.call_args.kwargs["body"]
         self.assertEqual(body.system_id, SYSTEM_ID)
 
+    @patch("resim.sdk.batch.metrics")
     @patch("resim.sdk.batch.close_batch")
     @patch("resim.sdk.batch.create_light_batch")
     @patch("resim.sdk.batch.list_test_suites")
@@ -381,6 +400,7 @@ class BatchTest(unittest.TestCase):
         mock_list_test_suites: Any,
         mock_create_batch: Any,
         mock_close_batch: Any,
+        _mock_metrics: Any,
     ) -> None:
         mock_client = MagicMock()
         self._make_standard_mocks(
@@ -403,6 +423,7 @@ class BatchTest(unittest.TestCase):
         body = mock_create_batch.sync_detailed.call_args.kwargs["body"]
         self.assertEqual(body.test_suite_id, TEST_SUITE_ID)
 
+    @patch("resim.sdk.batch.metrics")
     @patch("resim.sdk.batch.close_batch")
     @patch("resim.sdk.batch.create_light_batch")
     @patch("resim.sdk.batch.list_test_suites")
@@ -413,6 +434,7 @@ class BatchTest(unittest.TestCase):
         mock_list_test_suites: Any,
         mock_create_batch: Any,
         mock_close_batch: Any,
+        _mock_metrics: Any,
     ) -> None:
         mock_client = MagicMock()
         self._make_standard_mocks(
@@ -437,6 +459,7 @@ class BatchTest(unittest.TestCase):
         self.assertEqual(body.test_suite_id, TEST_SUITE_ID)
         self.assertEqual(body.test_suite_revision, TEST_SUITE_REVISION)
 
+    @patch("resim.sdk.batch.metrics")
     @patch("resim.sdk.batch.close_batch")
     @patch("resim.sdk.batch.create_light_batch")
     @patch("resim.sdk.batch.list_systems")
@@ -449,6 +472,7 @@ class BatchTest(unittest.TestCase):
         mock_list_systems: Any,
         mock_create_batch: Any,
         mock_close_batch: Any,
+        _mock_metrics: Any,
     ) -> None:
         mock_client = MagicMock()
         self._make_standard_mocks(
@@ -478,10 +502,11 @@ class BatchTest(unittest.TestCase):
         self.assertEqual(body.system_id, SYSTEM_ID)
         self.assertEqual(body.test_suite_id, TEST_SUITE_ID)
 
+    @patch("resim.sdk.batch.metrics")
     @patch("resim.sdk.batch.list_systems")
     @patch("resim.sdk.batch.list_branches_for_project")
     def test_batch_raises_if_system_not_found(
-        self, mock_list_branches: Any, mock_list_systems: Any
+        self, mock_list_branches: Any, mock_list_systems: Any, _mock_metrics: Any
     ) -> None:
         mock_client = MagicMock()
         mock_branch = MagicMock()
@@ -499,10 +524,11 @@ class BatchTest(unittest.TestCase):
             ):
                 pass
 
+    @patch("resim.sdk.batch.metrics")
     @patch("resim.sdk.batch.list_test_suites")
     @patch("resim.sdk.batch.list_branches_for_project")
     def test_batch_raises_if_test_suite_not_found(
-        self, mock_list_branches: Any, mock_list_test_suites: Any
+        self, mock_list_branches: Any, mock_list_test_suites: Any, _mock_metrics: Any
     ) -> None:
         mock_client = MagicMock()
         mock_branch = MagicMock()
@@ -535,10 +561,11 @@ class BatchTest(unittest.TestCase):
                 test_suite_revision=TEST_SUITE_REVISION,
             )
 
+    @patch("resim.sdk.batch.metrics")
     @patch("resim.sdk.batch.create_light_batch")
     @patch("resim.sdk.batch.list_branches_for_project")
     def test_batch_raises_if_create_fails(
-        self, mock_list_branches: Any, mock_create_batch: Any
+        self, mock_list_branches: Any, mock_create_batch: Any, _mock_metrics: Any
     ) -> None:
         mock_client = MagicMock()
         mock_branch = MagicMock()
@@ -554,11 +581,16 @@ class BatchTest(unittest.TestCase):
             with Batch(mock_client, BRANCH_NAME, project_id=PROJECT_ID):
                 pass
 
+    @patch("resim.sdk.batch.metrics")
     @patch("resim.sdk.batch.close_batch")
     @patch("resim.sdk.batch.create_light_batch")
     @patch("resim.sdk.batch.list_branches_for_project")
     def test_batch_raises_if_close_fails(
-        self, mock_list_branches: Any, mock_create_batch: Any, mock_close_batch: Any
+        self,
+        mock_list_branches: Any,
+        mock_create_batch: Any,
+        mock_close_batch: Any,
+        _mock_metrics: Any,
     ) -> None:
         mock_client = MagicMock()
         mock_branch = MagicMock()

--- a/resim/sdk/bff_client/metrics.py
+++ b/resim/sdk/bff_client/metrics.py
@@ -1,5 +1,6 @@
 import base64
 from collections.abc import Sequence
+from pathlib import Path
 from typing import Union
 
 import yaml
@@ -17,7 +18,7 @@ def sync_config(
     project_id: str,
     branch_name: str,
     config_path: Union[str, Sequence[str]] = ".resim/metrics/config.resim.yml",
-    templates: list[dict[str, str]] = [],
+    templates_path: Union[str, Path, None] = ".resim/metrics/templates",
 ) -> None:
     """
     Syncs your metrics config with ReSim.
@@ -30,8 +31,10 @@ def sync_config(
             Multiple files are merged (each topic must appear in only one file);
             the combined YAML is uploaded. Defaults to
             ".resim/metrics/config.resim.yml".
-        templates: Optional list of template files to include, each a dict
-            with string keys and values.
+        templates_path: Path to a directory of custom metric ``.liquid`` template
+            files to sync alongside the config. Defaults to
+            ``".resim/metrics/templates"``. If the directory does not exist,
+            no templates are uploaded. Pass ``None`` to disable template syncing.
 
     Raises:
         FileNotFoundError: If a config path does not exist (when multiple paths are given).
@@ -57,7 +60,12 @@ def sync_config(
     if not paths:
         raise ValueError("config_path must not be empty")
     if len(paths) == 1:
-        config_bytes = paths[0].read_bytes()
+        try:
+            config_bytes = paths[0].read_bytes()
+        except FileNotFoundError as e:
+            raise FileNotFoundError(
+                f"Metrics config not found at '{paths[0]}'. "
+            ) from e
     else:
         merged = merge_metrics_config_files(paths)
         config_bytes = yaml.safe_dump(
@@ -70,7 +78,7 @@ def sync_config(
         "variables": {
             "projectId": project_id,
             "config": base64.b64encode(config_bytes).decode(),
-            "templateFiles": templates,
+            "templateFiles": read_templates(templates_path),
             "branch": branch_name,
         },
     }
@@ -84,6 +92,38 @@ def sync_config(
         )
     if "errors" in response.json():
         raise Exception(response.json()["errors"])
+
+
+def read_templates(path: Union[str, Path, None]) -> list[dict[str, str]]:
+    """Read Liquid template files from a directory for use with sync_config.
+
+    Scans the given directory for ``*.liquid`` files and returns them as a list
+    of dicts with ``name`` (filename) and ``contents`` (base64-encoded bytes),
+    matching the format expected by the ``UpdateMetricsConfig`` mutation.
+
+    Args:
+        path: Directory containing ``.liquid`` template files. If ``None`` or
+            the directory does not exist, an empty list is returned.
+
+    Returns:
+        A list of ``{"name": str, "contents": str}`` dicts, one per ``.liquid``
+        file found, sorted by filename for deterministic ordering.
+    """
+    if path is None:
+        return []
+    directory = Path(path)
+    if not directory.is_dir():
+        return []
+    templates = []
+    for entry in sorted(directory.iterdir()):
+        if entry.is_file() and entry.suffix.lower() == ".liquid":
+            templates.append(
+                {
+                    "name": entry.name,
+                    "contents": base64.b64encode(entry.read_bytes()).decode(),
+                }
+            )
+    return templates
 
 
 def _get_bff_url(api_base_url: URL) -> str:

--- a/resim/sdk/bff_client/metrics_test.py
+++ b/resim/sdk/bff_client/metrics_test.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock
 import yaml
 from httpx import URL
 
-from resim.sdk.bff_client.metrics import sync_config
+from resim.sdk.bff_client.metrics import read_templates, sync_config
 
 
 class SyncConfigTest(unittest.TestCase):
@@ -57,7 +57,9 @@ class SyncConfigTest(unittest.TestCase):
         variables = body["variables"]
         self.assertEqual(variables["projectId"], "proj-123")
         self.assertEqual(variables["branch"], "main")
-        self.assertEqual(variables["templateFiles"], [])
+        self.assertEqual(
+            variables["templateFiles"], []
+        )  # default templates dir doesn't exist → empty
         self.assertEqual(
             variables["config"],
             base64.b64encode(self.config_contents).decode(),
@@ -104,6 +106,19 @@ class SyncConfigTest(unittest.TestCase):
 
         self.assertIn("403", str(ctx.exception))
 
+    def test_raises_on_missing_config_file(self) -> None:
+        missing = str(Path(self.temp_dir.name) / "nonexistent.yml")
+
+        with self.assertRaises(FileNotFoundError) as ctx:
+            sync_config(
+                client=self.mock_client,
+                project_id="proj-123",
+                branch_name="main",
+                config_path=missing,
+            )
+
+        self.assertIn("nonexistent.yml", str(ctx.exception))
+
     def test_raises_on_graphql_errors(self) -> None:
         self.mock_response.json.return_value = {"errors": ["something went wrong"]}
 
@@ -116,6 +131,117 @@ class SyncConfigTest(unittest.TestCase):
             )
 
         self.assertEqual(ctx.exception.args[0], ["something went wrong"])
+
+
+class ReadTemplatesTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.templates_dir = Path(self.temp_dir.name)
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def test_none_path_returns_empty(self) -> None:
+        self.assertEqual(read_templates(None), [])
+
+    def test_missing_directory_returns_empty(self) -> None:
+        self.assertEqual(read_templates(self.templates_dir / "nonexistent"), [])
+
+    def test_empty_directory_returns_empty(self) -> None:
+        self.assertEqual(read_templates(self.templates_dir), [])
+
+    def test_liquid_files_are_read(self) -> None:
+        (self.templates_dir / "a.liquid").write_bytes(b"template a")
+        (self.templates_dir / "b.liquid").write_bytes(b"template b")
+
+        result = read_templates(self.templates_dir)
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["name"], "a.liquid")
+        self.assertEqual(
+            result[0]["contents"], base64.b64encode(b"template a").decode()
+        )
+        self.assertEqual(result[1]["name"], "b.liquid")
+        self.assertEqual(
+            result[1]["contents"], base64.b64encode(b"template b").decode()
+        )
+
+    def test_non_liquid_files_are_ignored(self) -> None:
+        (self.templates_dir / "template.liquid").write_bytes(b"liquid")
+        (self.templates_dir / "readme.md").write_bytes(b"docs")
+        (self.templates_dir / "data.yaml").write_bytes(b"yaml")
+
+        result = read_templates(self.templates_dir)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["name"], "template.liquid")
+
+    def test_accepts_string_path(self) -> None:
+        (self.templates_dir / "t.liquid").write_bytes(b"content")
+        result = read_templates(str(self.templates_dir))
+        self.assertEqual(len(result), 1)
+
+    def test_sorted_by_filename(self) -> None:
+        for name in ["c.liquid", "a.liquid", "b.liquid"]:
+            (self.templates_dir / name).write_bytes(b"x")
+        result = read_templates(self.templates_dir)
+        self.assertEqual(
+            [r["name"] for r in result], ["a.liquid", "b.liquid", "c.liquid"]
+        )
+
+
+class SyncConfigWithTemplatesTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.config_path = Path(self.temp_dir.name) / "config.resim.yml"
+        self.config_path.write_bytes(b"metrics_config: true\n")
+        self.templates_dir = Path(self.temp_dir.name) / "templates"
+        self.templates_dir.mkdir()
+
+        self.mock_response = MagicMock()
+        self.mock_response.status_code = 200
+        self.mock_response.json.return_value = {"data": {"updateMetricsConfig": None}}
+
+        self.mock_httpx = MagicMock()
+        self.mock_httpx._base_url = URL("https://api.resim.ai/v1/")
+        self.mock_httpx.post.return_value = self.mock_response
+
+        self.mock_client = MagicMock()
+        self.mock_client.get_httpx_client.return_value = self.mock_httpx
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def test_templates_path_read_and_passed_to_mutation(self) -> None:
+        (self.templates_dir / "dashboard.liquid").write_bytes(b"hello {{ name }}")
+
+        sync_config(
+            client=self.mock_client,
+            project_id="proj-123",
+            branch_name="main",
+            config_path=str(self.config_path),
+            templates_path=self.templates_dir,
+        )
+
+        body = self.mock_httpx.post.call_args.kwargs["json"]
+        template_files = body["variables"]["templateFiles"]
+        self.assertEqual(len(template_files), 1)
+        self.assertEqual(template_files[0]["name"], "dashboard.liquid")
+        self.assertEqual(
+            template_files[0]["contents"],
+            base64.b64encode(b"hello {{ name }}").decode(),
+        )
+
+    def test_no_templates_path_sends_empty_list(self) -> None:
+        sync_config(
+            client=self.mock_client,
+            project_id="proj-123",
+            branch_name="main",
+            config_path=str(self.config_path),
+        )
+
+        body = self.mock_httpx.post.call_args.kwargs["json"]
+        self.assertEqual(body["variables"]["templateFiles"], [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description of change

Allow users to provide a path for custom metrics liquid templates, which will sync them via the graphQL mutation:

```python
    with Batch(
        client=client,
        project_name=PROJECT_NAME,
        branch=branch_name,
        metrics_set_name="cool metrics",
        metrics_config_path="resim/config.resim.yml",
        templates_path="resim/templates", # <-------- new
    ) as batch:
```

## Guide to reproduce test results.

See example above. You'll need to setup an config via BUILD files to actually run and test it.

## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
