### PR TITLE
WOB-4328 | Change default for log type

### DIFF
--- a/resim/sdk/client_generator/customerapi.yaml
+++ b/resim/sdk/client_generator/customerapi.yaml
@@ -4562,7 +4562,7 @@ paths:
         "404":
           $ref: "#/components/responses/notFound"
     post:
-      description: Creates a log entry for a job and returns a presigned S3 upload URL. The batch must be of type LIGHT and the job must be in EXPERIENCE_RUNNING status.
+      description: Creates a log entry for a job and returns a presigned S3 upload URL. The batch must be of type LIGHT and the job must be in EXPERIENCE_RUNNING status. When logType is omitted, it is inferred from the file name.
       operationId: createJobLog
       security:
         - OAuth:
@@ -7262,7 +7262,6 @@ components:
         - fileName
         - fileSize
         - checksum
-        - logType
       properties:
         fileName:
           $ref: "#/components/schemas/fileName"

--- a/resim/sdk/test.py
+++ b/resim/sdk/test.py
@@ -9,7 +9,7 @@ from typing import Optional
 from pathlib import Path
 from resim.sdk.batch import Batch
 from resim.sdk.client import AuthenticatedClient
-from resim.sdk.client.types import Unset
+from resim.sdk.client.types import UNSET, Unset
 from resim.sdk.metrics.emissions import Emitter
 from resim.sdk.client.api.light_batches import (
     create_job_for_batch,
@@ -53,14 +53,15 @@ class Test(Emitter):
     def attach_log(
         self,
         file_path: str,
-        log_type: LogType = LogType.OTHER_LOG,
+        log_type: Optional[LogType] = None,
         file_name: Optional[str] = None,
     ) -> None:
         """Upload a local file as a log attachment for this test.
 
         Args:
             file_path: Path to the local file to upload.
-            log_type: The log type classification. Defaults to LogType.OTHER_LOG.
+            log_type: The log type classification. Defaults to None, which lets
+                ReSim infer the log type from the file name.
             file_name: Override the filename used when uploading. Defaults to
                 the basename of file_path.
         """
@@ -76,7 +77,7 @@ class Test(Emitter):
             file_name=file_name,
             file_size=os.path.getsize(file_path),
             checksum=h.hexdigest(),
-            log_type=log_type,
+            log_type=log_type if log_type is not None else UNSET,
         )
         response = create_job_log.sync_detailed(
             self._batch.project_id,
@@ -104,6 +105,20 @@ class Test(Emitter):
             raise Exception(
                 f"failed to upload log {file_name}. Got response {r.status_code}: {r.content}"
             )
+
+    def attach_system_log(
+        self,
+        file_path: str,
+        file_name: Optional[str] = None,
+    ) -> None:
+        """Upload a local file as a system log for this test.
+
+        Args:
+            file_path: Path to the local file to upload.
+            file_name: Override the filename used when uploading. Defaults to
+                the basename of file_path.
+        """
+        self.attach_log(file_path, log_type=LogType.SYSTEM_LOG, file_name=file_name)
 
     def __enter__(self) -> "Test":
         return self

--- a/resim/sdk/test_test.py
+++ b/resim/sdk/test_test.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch, mock_open
 
 from resim.sdk.test import Test, LogType
 from resim.sdk.client.models.light_job_status import LightJobStatus
+from resim.sdk.client.types import Unset
 
 PROJECT_ID = "project-123"
 BATCH_ID = "batch-789"
@@ -132,6 +133,123 @@ class TestTest(unittest.TestCase):
 
         first_call_body = mock_create_log.sync_detailed.call_args_list[0].kwargs["body"]
         self.assertEqual(first_call_body.log_type, LogType.MP4_LOG)
+
+    @patch("resim.sdk.test.httpx")
+    @patch("resim.sdk.test.close_job")
+    @patch("resim.sdk.test.create_job_log")
+    @patch("resim.sdk.test.create_job_for_batch")
+    def test_attach_log_without_log_type(
+        self,
+        mock_create_job: Any,
+        mock_create_log: Any,
+        mock_close_job: Any,
+        mock_httpx: Any,
+    ) -> None:
+        mock_client = MagicMock()
+
+        mock_batch = MagicMock()
+        mock_batch.project_id = PROJECT_ID
+        mock_batch.id = BATCH_ID
+        mock_batch.metrics_config_path = CONFIG_PATH
+
+        mock_create_response = MagicMock()
+        mock_create_response.status_code = 201
+        mock_create_response.parsed.job_id = JOB_ID
+        mock_create_job.sync_detailed.return_value = mock_create_response
+
+        mock_log_response = MagicMock()
+        mock_log_response.status_code = 201
+        mock_log_response.parsed.upload_url = UPLOAD_URL
+        mock_create_log.sync_detailed.return_value = mock_log_response
+
+        mock_httpx.put.return_value = MagicMock(status_code=200)
+
+        mock_close_response = MagicMock()
+        mock_close_response.status_code = 204
+        mock_close_job.sync_detailed.return_value = mock_close_response
+
+        emissions_content = b"fake emissions data"
+        extra_log_content = b"fake image data"
+        m = mock_open(read_data=emissions_content)
+        m.return_value.__enter__.return_value.read.side_effect = [
+            extra_log_content,
+            b"",  # SHA256 for extra log
+            extra_log_content,  # httpx.put upload for extra log
+            emissions_content,
+            b"",  # SHA256 for emissions
+            emissions_content,  # httpx.put upload for emissions
+        ]
+        with (
+            patch("builtins.open", m),
+            patch("os.path.getsize", return_value=len(emissions_content)),
+        ):
+            with Test(mock_client, mock_batch, TEST_NAME) as test:
+                test.attach_log("some_image.jpeg")
+
+        # Omitting log_type leaves it off the request body so the server can
+        # infer it from the file name.
+        first_call_body = mock_create_log.sync_detailed.call_args_list[0].kwargs["body"]
+        self.assertIsInstance(first_call_body.log_type, Unset)
+        self.assertNotIn("logType", first_call_body.to_dict())
+
+    @patch("resim.sdk.test.httpx")
+    @patch("resim.sdk.test.close_job")
+    @patch("resim.sdk.test.create_job_log")
+    @patch("resim.sdk.test.create_job_for_batch")
+    def test_attach_system_log(
+        self,
+        mock_create_job: Any,
+        mock_create_log: Any,
+        mock_close_job: Any,
+        mock_httpx: Any,
+    ) -> None:
+        mock_client = MagicMock()
+
+        mock_batch = MagicMock()
+        mock_batch.project_id = PROJECT_ID
+        mock_batch.id = BATCH_ID
+        mock_batch.metrics_config_path = CONFIG_PATH
+
+        mock_create_response = MagicMock()
+        mock_create_response.status_code = 201
+        mock_create_response.parsed.job_id = JOB_ID
+        mock_create_job.sync_detailed.return_value = mock_create_response
+
+        mock_log_response = MagicMock()
+        mock_log_response.status_code = 201
+        mock_log_response.parsed.upload_url = UPLOAD_URL
+        mock_create_log.sync_detailed.return_value = mock_log_response
+
+        mock_httpx.put.return_value = MagicMock(status_code=200)
+
+        mock_close_response = MagicMock()
+        mock_close_response.status_code = 204
+        mock_close_job.sync_detailed.return_value = mock_close_response
+
+        emissions_content = b"fake emissions data"
+        system_log_content = b"fake system log data"
+        m = mock_open(read_data=emissions_content)
+        m.return_value.__enter__.return_value.read.side_effect = [
+            system_log_content,
+            b"",  # SHA256 for system log
+            system_log_content,  # httpx.put upload for system log
+            emissions_content,
+            b"",  # SHA256 for emissions
+            emissions_content,  # httpx.put upload for emissions
+        ]
+        with (
+            patch("builtins.open", m),
+            patch("os.path.getsize", return_value=len(system_log_content)),
+        ):
+            with Test(mock_client, mock_batch, TEST_NAME) as test:
+                test.attach_system_log("logs/run.log", file_name="robot.log")
+
+        # System logs are always uploaded as SYSTEM_LOG, and the file_name
+        # override is passed through.
+        self.assertEqual(mock_create_log.sync_detailed.call_count, 2)
+        first_call_body = mock_create_log.sync_detailed.call_args_list[0].kwargs["body"]
+        self.assertEqual(first_call_body.log_type, LogType.SYSTEM_LOG)
+        self.assertEqual(first_call_body.file_name, "robot.log")
 
     @patch("resim.sdk.test.os.unlink")
     @patch("resim.sdk.test.tempfile.NamedTemporaryFile")


### PR DESCRIPTION
## Description of change

Default logtype to null, which lets the server categorize it instead. Also adds an `add_system_log` helper.

## Guide to reproduce test results.
<!-- 
    Please help reviewers by including instructions 
    on how to test this change
-->
## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
