### PR TITLE
Add a MuJoCo demo, and a --demo flag to choose between them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ MODULE.bazel.lock
 /compile_commands.json
 # Directory where clangd puts its indexing work
 /.cache/
+# Python bytecode caches
+__pycache__/
+*.py[cod]

--- a/docs/plans/WOB-4405-mujoco-demo.md
+++ b/docs/plans/WOB-4405-mujoco-demo.md
@@ -1,0 +1,125 @@
+# A second demo, and a `--demo` flag to choose between them
+
+Stacked on the SDK demo PR.
+
+## Context
+
+The demo replays one fixed dataset: a hospital navigation suite. That is a good
+tour of what the platform renders, because the source data is dense telemetry
+and the config can chart nearly every template ReSim ships.
+
+It is not, however, representative of every prospect. A second demo built from
+MuJoCo policy evaluations shows the platform against a different shape of data
+and a different question — did this policy build get better or worse than the
+last one — without pretending the two datasets look alike.
+
+## The data
+
+Two runs of the same 20 seeds against consecutive policy builds, so the A/B
+comparison has a real difference to show:
+
+| | baseline | candidate |
+| --- | --- | --- |
+| Passed / warned | 7 / 13 | 12 / 8 |
+| Mean success rate | 35% | 60% |
+| Mean sum reward | 264 | 325 |
+| Mean evaluation time | 10.4s | 9.2s |
+
+Seeds are identical on both sides, so every test pairs by name in the A/B view
+with no positional alignment.
+
+## What this data does and does not support
+
+Each MuJoCo test emits four summary numbers and a recording. That is all the
+replayable data there is: the rich charts in the source project come from
+`metrics.binproto`, which a light batch does not reproduce, and the two
+remaining emissions files carry `container_performance` and
+`test_length_seconds`, whose names are reserved so a light batch cannot emit
+them.
+
+So this config covers scalar, table, bar, histogram, video and image, and does
+not cover line, state_timeline or pie. There is no time series and no
+categorical state in the data, and inventing one to fill the template list
+would make the demo less honest, not more complete. The default demo remains
+the full tour.
+
+`config_test.py` reflects that: the checks mirroring the platform's validator
+now run against every shipped demo config, while the three that assert the full
+template sweep stay scoped to the default demo.
+
+## Design
+
+A demo is a registry entry plus a config file. `run()` is unchanged in shape —
+resolve project, sync config, two batches, print links — so a third demo is
+data, not code.
+
+```python
+DEMOS = {
+    "navigation": Demo(project_name=…, branch=…, config_file="config.resim.yml",
+                       metrics_set=…, dashboard_name=…, bundle=BundleSource(…)),
+    "mujoco":     Demo(… "mujoco.resim.yml" …),
+}
+```
+
+Values are spelled out per demo rather than derived from a naming convention,
+so what gets downloaded is greppable and a bundle can be republished under any
+name.
+
+### Changes
+
+- `run.py` — `Demo`, `DEMOS`, `get_demo`, and `run(demo=...)`, required rather
+  than defaulted for the same reason. `config_path` and `templates_path` take a
+  demo too, so a reader of either learns demos exist.
+- `bundle.py` — `BundleSource` (url, sha256, cache key); `ensure` and
+  `cache_dir` take one. Each demo caches under its own key, so switching demos
+  does not evict the other's data.
+- `__main__.py` — `--demo`, with no default. The demos are peers, so running one
+  the caller did not ask for is a surprise and a bare argparse error does not
+  say what is on offer; `resim-demo` with no arguments prints the demos and
+  exits 0. `--project-name` and `--branch` default to the chosen demo's own
+  values.
+- `data/mujoco.resim.yml` — 15 metrics over three topics.
+
+## Artifacts
+
+Each file goes up with the log type ReSim can do the most with, following the
+pattern in rerobot's `eval/resim_ingest.py`. An `.mcap` sent as
+`FOXGLOVE_MCAP_LOG` opens in the viewer; the same bytes typed otherwise are only
+a download, so the bundle records the type rather than leaving it to be guessed
+from the filename. Per batch that is 112 attachments where there were 24.
+
+Carrying everything was not viable. All the files both runs produced come to
+271MB, downloaded on first run against a 4.8MB bundle: mcap 91.9MB, mp4 77.9MB,
+`videos.zip` 77.0MB, gif 19.5MB, logs ~5MB. `videos.zip` holds the same footage
+as the mp4 beside it and is dropped; the `.mcap` rides along only for jobs that
+already carry media. The bundle lands at 24MB and still puts a real recording in
+the viewer. An `.mcap` on all forty tests would take it to roughly 110MB.
+
+`_log_type` falls back to inference on a type this SDK does not know, so a
+bundle naming one added later degrades rather than failing the run, and a file
+listed in both `artifacts` and `media` uploads once.
+
+## Verification
+
+- `bazel test //resim/demo:demo_test` — 136 tests, 34 new.
+- New registry tests: every demo ships the config it names, names a metrics set
+  and dashboard that config actually defines, and no two demos share a project,
+  branch or cache key.
+- The metrics-set check earned its place immediately: the MuJoCo config was
+  written with `metrics_sets:`, and the platform's key is `metrics sets` with a
+  space. It would have synced with no metrics sets and rendered nothing.
+- Installed the wheel into a clean venv and confirmed `--demo` lists both.
+- End to end against staging. The artifact run used `--data-dir` against the
+  extracted bundle, so that path was proven before publishing rather than after:
+  both batches SUCCEEDED and the mcaps arrived as `FOXGLOVE_MCAP_LOG`. They come
+  out of the export as `MCAP_LOG`, which is what the source batch used and which
+  does not reach the viewer, so the suffix decides.
+- The dashboard's `Reward by Build Version` renders policy-v4 264.0 against
+  policy-v5 325.05, matching the source data.
+
+## Note on the published bundle
+
+The manifest previously carried `source_batch_id` and the internal batch name.
+The bundle is published to a public bucket, so the MuJoCo bundle was rebuilt
+without them and now contains only the replayed data and the names the demo
+shows.

--- a/resim/demo/README.md
+++ b/resim/demo/README.md
@@ -1,11 +1,12 @@
 # The SDK demos
 
 `resim-demo` replays real test data into a fresh ReSim project so you can see
-the platform working before wiring up your own. Pick one with `--demo`:
+the platform working before wiring up your own. Pick one with `--demo` — there
+is no default, and running `resim-demo` on its own lists them:
 
 | `--demo` | What it shows |
 | --- | --- |
-| `navigation` (default) | A hospital navigation suite. Dense telemetry across 34 scenarios, covering every chart type ReSim ships. |
+| `navigation` | A hospital navigation suite. Dense telemetry across a suite of scenarios, covering every chart type ReSim ships. |
 | `mujoco` | A bimanual manipulation policy in MuJoCo, one test per seed, compared across two policy builds. |
 
 Each demo is an entry in `DEMOS` (`run.py`) plus a metrics config in `data/`.
@@ -15,7 +16,7 @@ starting point we expect you to copy:
 ```python
 from resim.demo import config_path
 
-print(config_path().read_text())          # the navigation demo's config
+print(config_path("navigation").read_text())  # the navigation demo's config
 print(config_path("mujoco").read_text())  # the MuJoCo demo's config
 ```
 

--- a/resim/demo/README.md
+++ b/resim/demo/README.md
@@ -1,30 +1,39 @@
-# The SDK demo
+# The SDK demos
 
 `resim-demo` replays real test data into a fresh ReSim project so you can see
-the platform working before wiring up your own tests: two comparable batches of
-tests on one branch, and a dashboard that trends across them.
+the platform working before wiring up your own. Pick one with `--demo`:
 
-The interesting part is `data/config.resim.yml`. It is a real, working metrics
-config — not a toy — and it is the starting point we expect you to copy:
+| `--demo` | What it shows |
+| --- | --- |
+| `navigation` (default) | A hospital navigation suite. Dense telemetry across 34 scenarios, covering every chart type ReSim ships. |
+| `mujoco` | A bimanual manipulation policy in MuJoCo, one test per seed, compared across two policy builds. |
+
+Each demo is an entry in `DEMOS` (`run.py`) plus a metrics config in `data/`.
+The config is the interesting part — it is a real, working config, and the
+starting point we expect you to copy:
 
 ```python
 from resim.demo import config_path
 
-print(config_path().read_text())
+print(config_path().read_text())          # the navigation demo's config
+print(config_path("mujoco").read_text())  # the MuJoCo demo's config
 ```
 
 ## Where the replay data comes from
 
-The demo downloads a tarball of captured emissions and media, pinned by sha256,
-and replays it into two light batches that differ only by build version. That
-difference is what makes the A/B comparison and the trends dashboard
+Each demo downloads a tarball of captured emissions and media, pinned by
+sha256, and replays it into two light batches that differ only by build
+version. That is what makes the A/B comparison and the trends dashboard
 meaningful.
 
-The tarball is built from real batches by ReSim rather than generated here. The
-emissions come from runs that actually happened, downsampled so the bundle
-stays small; media is transcoded down and kept only for tests that have it on
-*both* sides, since an experience with video on one side reads as a broken pair
-in the A/B view; and the result is checksummed and published.
+The tarballs are built from real batches by ReSim, not generated here: the
+emissions are exported from runs that actually happened, downsampled so the
+bundle stays small, media is transcoded down and kept only for the tests that
+have it on *both* sides (an experience with video on one side reads as a broken
+pair in the A/B view), and the result is checksummed and published. Adding a
+demo therefore means publishing a bundle and adding a `DEMOS` entry — no
+changes to `run()`.
 
-The bundle carries no project or batch identifiers. It is published to a public
-bucket, so it holds only the replayed data and the names the demo itself shows.
+The bundles carry no project or batch identifiers. They are published to a
+public bucket, so they contain only the replayed data and the names the demo
+itself shows.

--- a/resim/demo/__init__.py
+++ b/resim/demo/__init__.py
@@ -19,9 +19,18 @@ Or from a shell, after ``pip install resim-open-core``::
 """
 
 from resim.demo.bundle import DemoDataError
-from resim.demo.run import DemoResult, config_path, run, templates_path
+from resim.demo.run import (
+    DEMOS,
+    Demo,
+    DemoResult,
+    config_path,
+    run,
+    templates_path,
+)
 
 __all__ = [
+    "DEMOS",
+    "Demo",
     "DemoDataError",
     "DemoResult",
     "config_path",

--- a/resim/demo/__main__.py
+++ b/resim/demo/__main__.py
@@ -77,8 +77,21 @@ def main() -> int:
     args = parser.parse_args()
 
     if args.demo is None:
-        # The demos are peers rather than one being the obvious choice, so
-        # rather than silently picking, say what is on offer.
+        # A bare invocation is someone looking around, so say what is on offer.
+        # Any other option means they meant to run something, and listing the
+        # demos while dropping their argument and exiting 0 reads as success.
+        supplied = [
+            flag
+            for flag, given in (
+                ("--project-name", args.project_name is not None),
+                ("--branch", args.branch is not None),
+                ("--data-dir", args.data_dir is not None),
+                ("--quiet", args.quiet),
+            )
+            if given
+        ]
+        if supplied:
+            parser.error(f"--demo is required when passing {', '.join(supplied)}")
         _list_demos()
         return 0
 

--- a/resim/demo/__main__.py
+++ b/resim/demo/__main__.py
@@ -8,11 +8,28 @@
 
 import argparse
 import sys
+import textwrap
 
 import httpx
 
 from resim.demo.bundle import DemoDataError
-from resim.demo.run import DEFAULT_BRANCH, DEFAULT_PROJECT_NAME, run
+from resim.demo.run import DEMOS, run
+
+
+def _list_demos() -> None:
+    """Print the demos and how to pick one."""
+    print("resim-demo replays real test data into your own ReSim project.\n")
+    print("Pick one with --demo:\n")
+    width = max(len(key) for key in DEMOS)
+    for key in sorted(DEMOS):
+        demo = DEMOS[key]
+        first, *rest = textwrap.wrap(demo.summary, 62)
+        print(f"  {key.ljust(width)}   {first}")
+        for line in rest:
+            print(f"  {' ' * width}   {line}")
+    # Suggest the fuller tour rather than whichever key sorts first.
+    suggested = "navigation" if "navigation" in DEMOS else sorted(DEMOS)[0]
+    print(f"\nFor example:\n  resim-demo --demo {suggested}")
 
 
 def main() -> int:
@@ -24,17 +41,25 @@ def main() -> int:
         ),
     )
     parser.add_argument(
+        "--demo",
+        default=None,
+        choices=sorted(DEMOS),
+        help="Which demo to run. Run with no arguments to see what each one is.",
+    )
+    parser.add_argument(
         "--project-name",
-        default=DEFAULT_PROJECT_NAME,
+        default=None,
         help=(
-            "Project to run in, created if it does not exist. "
-            f"Defaults to {DEFAULT_PROJECT_NAME!r}."
+            "Project to run in, created if it does not exist. Defaults to the "
+            "chosen demo's own project name."
         ),
     )
     parser.add_argument(
         "--branch",
-        default=DEFAULT_BRANCH,
-        help=f"Branch to create the batches on. Defaults to {DEFAULT_BRANCH!r}.",
+        default=None,
+        help=(
+            "Branch to create the batches on. Defaults to the chosen demo's own branch."
+        ),
     )
     parser.add_argument(
         "--data-dir",
@@ -51,9 +76,16 @@ def main() -> int:
     )
     args = parser.parse_args()
 
+    if args.demo is None:
+        # The demos are peers rather than one being the obvious choice, so
+        # rather than silently picking, say what is on offer.
+        _list_demos()
+        return 0
+
     try:
         run(
             args.project_name,
+            demo=args.demo,
             branch=args.branch,
             data_dir=args.data_dir,
             quiet=args.quiet,

--- a/resim/demo/bundle.py
+++ b/resim/demo/bundle.py
@@ -19,7 +19,7 @@ import sys
 import tarfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any, Callable, Optional, Union
 
 import httpx
 
@@ -110,6 +110,7 @@ def load(directory: Union[str, Path]) -> Bundle:
 def ensure(
     source: BundleSource,
     data_dir: Optional[Union[str, Path]] = None,
+    report: Optional[Callable[[str], None]] = None,
 ) -> Bundle:
     """Return a demo's data bundle, downloading and caching it if needed.
 
@@ -117,6 +118,8 @@ def ensure(
         source: Which bundle to fetch.
         data_dir: An already-extracted bundle to use instead of downloading.
             Useful for development and for air-gapped runs.
+        report: Called with progress while downloading. Left out, the download
+            is silent.
 
     Raises:
         DemoDataError: If the bundle cannot be downloaded, fails its checksum,
@@ -131,8 +134,10 @@ def ensure(
 
     archive = destination.parent / f"{destination.name}.tar.gz"
     archive.parent.mkdir(parents=True, exist_ok=True)
-    _download(source.url, archive)
+    _download(source.url, archive, report)
     try:
+        if report:
+            report("Checking it downloaded intact")
         _verify(archive, source.sha256, source.url)
         _extract(archive, destination)
     finally:
@@ -141,15 +146,26 @@ def ensure(
     return load(destination)
 
 
-def _download(url: str, destination: Path) -> None:
+def _download(
+    url: str, destination: Path, report: Optional[Callable[[str], None]] = None
+) -> None:
+    """Stream a bundle to disk, reporting progress as it goes.
+
+    The bundle runs to tens of megabytes, so a silent download reads as a hang
+    on a slow connection — the demo has not printed anything yet at this point.
+    """
     try:
         with httpx.stream(
             "GET", url, follow_redirects=True, timeout=_DOWNLOAD_TIMEOUT_SECONDS
         ) as response:
             response.raise_for_status()
+            total = int(response.headers.get("content-length") or 0)
+            progress = _Progress(total, report)
             with open(destination, "wb") as f:
                 for chunk in response.iter_bytes():
                     f.write(chunk)
+                    progress.advance(len(chunk))
+            progress.done()
     except httpx.HTTPError as e:
         destination.unlink(missing_ok=True)
         raise DemoDataError(
@@ -157,6 +173,53 @@ def _download(url: str, destination: Path) -> None:
             "The demo needs this data to run; check your network access to "
             "that host and try again."
         ) from e
+
+
+class _Progress:
+    """Prints download progress, at a pace that suits where it is going.
+
+    A terminal gets one line rewritten in place. Anything else — a log, a CI
+    job — gets a line per step, because carriage returns there produce one
+    unreadable line.
+    """
+
+    #: Fraction of the whole between printed steps when not on a terminal.
+    _STEP = 0.1
+
+    def __init__(self, total: int, report: Optional[Callable[[str], None]]) -> None:
+        self._total = total
+        self._report = report
+        self._seen = 0
+        self._next_step = self._STEP
+        self._tty = bool(report) and sys.stdout.isatty()
+        if report and total:
+            report(f"Downloading demo data ({total / 1e6:.0f} MB)")
+        elif report:
+            report("Downloading demo data")
+
+    def advance(self, size: int) -> None:
+        self._seen += size
+        if self._report is None or not self._total:
+            return
+        fraction = self._seen / self._total
+        if self._tty:
+            print(
+                f"\r  {self._seen / 1e6:.0f} / {self._total / 1e6:.0f} MB "
+                f"({fraction:.0%})",
+                end="",
+                flush=True,
+            )
+        elif fraction >= self._next_step:
+            # Step past every threshold this chunk crossed, rather than from
+            # where it landed: the latter drifts, so a big chunk silently
+            # widens the gap between lines.
+            while self._next_step <= fraction:
+                self._next_step += self._STEP
+            self._report(f"  {self._seen / 1e6:.0f} / {self._total / 1e6:.0f} MB")
+
+    def done(self) -> None:
+        if self._tty:
+            print(flush=True)
 
 
 def _verify(archive: Path, expected: str, url: str) -> None:

--- a/resim/demo/bundle.py
+++ b/resim/demo/bundle.py
@@ -23,16 +23,23 @@ from typing import Any, Optional, Union
 
 import httpx
 
-__all__ = ["Bundle", "DemoDataError", "ensure", "load"]
+__all__ = ["Bundle", "BundleSource", "DemoDataError", "ensure", "load"]
 
-BUNDLE_VERSION = "v1"
-BUNDLE_URL = (
-    "https://resim-public-assets.s3.us-east-1.amazonaws.com"
-    f"/sdk-demo/resim-sdk-demo-data-{BUNDLE_VERSION}.tar.gz"
-)
-# sha256 of the published tarball. Bump alongside BUNDLE_VERSION whenever the
-# data is regenerated, so a stale cache can never be mistaken for a fresh one.
-BUNDLE_SHA256 = "7bc5d26c14aaad8d849d131276af7c7287d163aeb3a9d2892f0ffba21889935d"
+
+@dataclass(frozen=True)
+class BundleSource:
+    """Where one demo's replay data lives, and how to know it arrived intact.
+
+    Spelled out per demo rather than derived from a naming convention, so what
+    gets downloaded is greppable and a bundle can be republished under any name.
+    """
+
+    url: str
+    sha256: str
+    # Cache directory name. Carries the bundle's version so regenerated data
+    # never collides with a stale copy of the old bundle.
+    cache_key: str
+
 
 MANIFEST_NAME = "manifest.json"
 
@@ -67,11 +74,16 @@ class Bundle:
         return dict((self.manifest.get("batches") or {}).get(side) or {})
 
 
-def cache_dir() -> Path:
-    """Directory the bundle is cached in, honouring ``XDG_CACHE_HOME``."""
+def cache_dir(source: Optional[BundleSource] = None) -> Path:
+    """Directory a bundle is cached in, honouring ``XDG_CACHE_HOME``.
+
+    Each demo caches under its own key, so switching demos does not re-download
+    the one you were using before.
+    """
     base = os.environ.get("XDG_CACHE_HOME")
     root = Path(base) if base else Path.home() / ".cache"
-    return root / "resim" / "sdk-demo" / BUNDLE_VERSION
+    cache = root / "resim" / "sdk-demo"
+    return cache / source.cache_key if source is not None else cache
 
 
 def load(directory: Union[str, Path]) -> Bundle:
@@ -95,10 +107,14 @@ def load(directory: Union[str, Path]) -> Bundle:
     return Bundle(root=root, manifest=manifest)
 
 
-def ensure(data_dir: Optional[Union[str, Path]] = None) -> Bundle:
-    """Return the demo's data bundle, downloading and caching it if needed.
+def ensure(
+    source: BundleSource,
+    data_dir: Optional[Union[str, Path]] = None,
+) -> Bundle:
+    """Return a demo's data bundle, downloading and caching it if needed.
 
     Args:
+        source: Which bundle to fetch.
         data_dir: An already-extracted bundle to use instead of downloading.
             Useful for development and for air-gapped runs.
 
@@ -109,15 +125,15 @@ def ensure(data_dir: Optional[Union[str, Path]] = None) -> Bundle:
     if data_dir is not None:
         return load(data_dir)
 
-    destination = cache_dir()
+    destination = cache_dir(source)
     if (destination / MANIFEST_NAME).is_file():
         return load(destination)
 
     archive = destination.parent / f"{destination.name}.tar.gz"
     archive.parent.mkdir(parents=True, exist_ok=True)
-    _download(BUNDLE_URL, archive)
+    _download(source.url, archive)
     try:
-        _verify(archive, BUNDLE_SHA256)
+        _verify(archive, source.sha256, source.url)
         _extract(archive, destination)
     finally:
         archive.unlink(missing_ok=True)
@@ -143,7 +159,7 @@ def _download(url: str, destination: Path) -> None:
         ) from e
 
 
-def _verify(archive: Path, expected: str) -> None:
+def _verify(archive: Path, expected: str, url: str) -> None:
     if not expected:
         return
     digest = hashlib.sha256()
@@ -153,7 +169,7 @@ def _verify(archive: Path, expected: str) -> None:
     actual = digest.hexdigest()
     if actual != expected:
         raise DemoDataError(
-            f"the demo data downloaded from {BUNDLE_URL} does not match its "
+            f"the demo data downloaded from {url} does not match its "
             f"expected checksum (got {actual}, expected {expected}). Refusing "
             "to use it."
         )

--- a/resim/demo/bundle_test.py
+++ b/resim/demo/bundle_test.py
@@ -54,23 +54,39 @@ def _valid_tarball() -> bytes:
     )
 
 
+SOURCE = bundle.BundleSource(
+    url="https://example.invalid/sdk-demo/demo-v1.tar.gz",
+    sha256="0" * 64,
+    cache_key="demo-v1",
+)
+
+
 class CacheDirTest(unittest.TestCase):
     def test_honours_xdg_cache_home(self) -> None:
         with patch.dict(os.environ, {"XDG_CACHE_HOME": "/somewhere/cache"}):
             self.assertEqual(
-                bundle.cache_dir(),
-                Path("/somewhere/cache") / "resim" / "sdk-demo" / bundle.BUNDLE_VERSION,
+                bundle.cache_dir(SOURCE),
+                Path("/somewhere/cache") / "resim" / "sdk-demo" / SOURCE.cache_key,
             )
 
     def test_falls_back_to_dot_cache(self) -> None:
         with patch.dict(os.environ, {}, clear=True):
             self.assertEqual(
-                bundle.cache_dir(),
-                Path.home() / ".cache" / "resim" / "sdk-demo" / bundle.BUNDLE_VERSION,
+                bundle.cache_dir(SOURCE),
+                Path.home() / ".cache" / "resim" / "sdk-demo" / SOURCE.cache_key,
             )
 
     def test_is_versioned_so_a_stale_bundle_is_never_reused(self) -> None:
-        self.assertIn(bundle.BUNDLE_VERSION, str(bundle.cache_dir()))
+        self.assertIn(SOURCE.cache_key, str(bundle.cache_dir(SOURCE)))
+
+    def test_each_demo_caches_separately(self) -> None:
+        # Switching demos must not make one re-download over the other's cache.
+        other = bundle.BundleSource(
+            url="https://example.invalid/sdk-demo/other-v1.tar.gz",
+            sha256="1" * 64,
+            cache_key="other-v1",
+        )
+        self.assertNotEqual(bundle.cache_dir(SOURCE), bundle.cache_dir(other))
 
 
 class LoadTest(unittest.TestCase):
@@ -255,15 +271,15 @@ class VerifyTest(unittest.TestCase):
         self.temp.cleanup()
 
     def test_accepts_matching_checksum(self) -> None:
-        bundle._verify(self.archive, hashlib.sha256(b"payload").hexdigest())
+        bundle._verify(self.archive, hashlib.sha256(b"payload").hexdigest(), SOURCE.url)
 
     def test_raises_on_mismatch(self) -> None:
         with self.assertRaises(DemoDataError) as ctx:
-            bundle._verify(self.archive, "0" * 64)
+            bundle._verify(self.archive, "0" * 64, SOURCE.url)
         self.assertIn("checksum", str(ctx.exception))
 
     def test_skips_when_no_checksum_pinned(self) -> None:
-        bundle._verify(self.archive, "")
+        bundle._verify(self.archive, "", SOURCE.url)
 
 
 class EnsureTest(unittest.TestCase):
@@ -277,7 +293,7 @@ class EnsureTest(unittest.TestCase):
     def test_explicit_data_dir_skips_download(self) -> None:
         (self.root / "manifest.json").write_text(json.dumps(MANIFEST))
         with patch.object(bundle, "_download") as download:
-            loaded = bundle.ensure(self.root)
+            loaded = bundle.ensure(SOURCE, self.root)
         download.assert_not_called()
         self.assertEqual(loaded.root, self.root)
 
@@ -289,7 +305,7 @@ class EnsureTest(unittest.TestCase):
             patch.object(bundle, "cache_dir", return_value=cache),
             patch.object(bundle, "_download") as download,
         ):
-            bundle.ensure()
+            bundle.ensure(SOURCE)
         download.assert_not_called()
 
     def test_cold_cache_downloads_verifies_and_extracts(self) -> None:
@@ -302,9 +318,14 @@ class EnsureTest(unittest.TestCase):
         with (
             patch.object(bundle, "cache_dir", return_value=cache),
             patch.object(bundle, "_download", side_effect=fake_download),
-            patch.object(bundle, "BUNDLE_SHA256", hashlib.sha256(payload).hexdigest()),
         ):
-            loaded = bundle.ensure()
+            loaded = bundle.ensure(
+                bundle.BundleSource(
+                    url=SOURCE.url,
+                    sha256=hashlib.sha256(payload).hexdigest(),
+                    cache_key=SOURCE.cache_key,
+                )
+            )
 
         self.assertEqual(loaded.manifest["version"], 1)
         self.assertFalse(
@@ -319,8 +340,8 @@ class EnsureTest(unittest.TestCase):
             patch("httpx.stream", side_effect=__import__("httpx").ConnectError("nope")),
         ):
             with self.assertRaises(DemoDataError) as ctx:
-                bundle.ensure()
-        self.assertIn(bundle.BUNDLE_URL, str(ctx.exception))
+                bundle.ensure(SOURCE)
+        self.assertIn(SOURCE.url, str(ctx.exception))
 
 
 if __name__ == "__main__":

--- a/resim/demo/bundle_test.py
+++ b/resim/demo/bundle_test.py
@@ -12,7 +12,7 @@ import tarfile
 import tempfile
 import unittest
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 from unittest.mock import MagicMock, patch
 
 from resim.demo import bundle
@@ -312,7 +312,7 @@ class EnsureTest(unittest.TestCase):
         cache = self.root / "cache"
         payload = _valid_tarball()
 
-        def fake_download(url: str, destination: Path) -> None:
+        def fake_download(url: str, destination: Path, report: Any = None) -> None:
             destination.write_bytes(payload)
 
         with (
@@ -342,6 +342,70 @@ class EnsureTest(unittest.TestCase):
             with self.assertRaises(DemoDataError) as ctx:
                 bundle.ensure(SOURCE)
         self.assertIn(SOURCE.url, str(ctx.exception))
+
+
+class ProgressTest(unittest.TestCase):
+    """The bundle runs to tens of megabytes, and nothing has printed yet when
+    it starts, so a silent download reads as a hang."""
+
+    def _lines(self, total: int, chunks: list[int], tty: bool) -> list[str]:
+        said: list[str] = []
+        with patch("sys.stdout") as stdout:
+            stdout.isatty.return_value = tty
+            progress = bundle._Progress(total, said.append)
+            for chunk in chunks:
+                progress.advance(chunk)
+            progress.done()
+        return said
+
+    def test_announces_the_size_up_front(self) -> None:
+        said = self._lines(20_000_000, [], tty=False)
+        self.assertIn("20 MB", said[0])
+
+    def test_a_log_gets_a_line_per_step(self) -> None:
+        # Carriage returns in a log or a CI job produce one unreadable line.
+        said = self._lines(10_000_000, [1_000_000] * 10, tty=False)
+        self.assertGreater(len(said), 1)
+        self.assertTrue(any("10 / 10 MB" in line for line in said))
+
+    def test_a_terminal_rewrites_one_line(self) -> None:
+        # On a terminal the updating line goes straight to stdout, so `report`
+        # only carries the opening announcement.
+        said = self._lines(10_000_000, [1_000_000] * 10, tty=True)
+        self.assertEqual(len(said), 1)
+
+    def test_a_server_that_sends_no_length_still_says_something(self) -> None:
+        # Without content-length there is no percentage to show, but silence is
+        # the thing being avoided.
+        said = self._lines(0, [1_000_000], tty=False)
+        self.assertEqual(said, ["Downloading demo data"])
+
+    def test_no_reporter_prints_nothing(self) -> None:
+        progress = bundle._Progress(1_000, None)
+        progress.advance(500)
+        progress.done()
+
+    def test_download_reports_through_to_the_caller(self) -> None:
+        said: list[str] = []
+        response = MagicMock()
+        response.headers = {"content-length": "4"}
+        response.iter_bytes.return_value = [b"ab", b"cd"]
+        response.__enter__ = lambda self=response: response
+        response.__exit__ = lambda *_: None
+
+        with tempfile.TemporaryDirectory() as tmp:
+            destination = Path(tmp) / "bundle.tar.gz"
+            with (
+                patch("httpx.stream", return_value=response),
+                patch("sys.stdout") as stdout,
+            ):
+                stdout.isatty.return_value = False
+                bundle._download(
+                    "https://example.invalid/b.tar.gz", destination, said.append
+                )
+
+            self.assertEqual(destination.read_bytes(), b"abcd")
+        self.assertTrue(said, "the download said nothing at all")
 
 
 if __name__ == "__main__":

--- a/resim/demo/bundle_test.py
+++ b/resim/demo/bundle_test.py
@@ -333,6 +333,34 @@ class EnsureTest(unittest.TestCase):
             "the downloaded archive should be cleaned up after extraction",
         )
 
+    def test_a_cold_cache_reports_each_stage(self) -> None:
+        # The download and the checksum both take a while on a large bundle,
+        # and nothing else has printed by this point, so both say so.
+        cache = self.root / "cache"
+        payload = _valid_tarball()
+        said: list[str] = []
+
+        def fake_download(url: str, destination: Path, report: Any = None) -> None:
+            destination.write_bytes(payload)
+
+        with (
+            patch.object(bundle, "cache_dir", return_value=cache),
+            patch.object(bundle, "_download", side_effect=fake_download),
+        ):
+            bundle.ensure(
+                bundle.BundleSource(
+                    url=SOURCE.url,
+                    sha256=hashlib.sha256(payload).hexdigest(),
+                    cache_key=SOURCE.cache_key,
+                ),
+                report=said.append,
+            )
+
+        self.assertTrue(
+            any("downloaded intact" in line for line in said),
+            f"the integrity check said nothing: {said}",
+        )
+
     def test_download_failure_surfaces_the_url(self) -> None:
         cache = self.root / "cache"
         with (

--- a/resim/demo/config_test.py
+++ b/resim/demo/config_test.py
@@ -41,8 +41,8 @@ METRIC_TYPES = frozenset({"test", "batch", "dashboard"})
 BUILTIN_TABLES = frozenset({"metadata", "container_performance", "test_length_seconds"})
 
 
-def _load() -> dict[str, Any]:
-    config = resources.files("resim.demo") / "data" / "config.resim.yml"
+def _load(config_file: str) -> dict[str, Any]:
+    config = resources.files("resim.demo") / "data" / config_file
     loaded = yaml.safe_load(config.read_text(encoding="utf8"))
     assert isinstance(loaded, dict), "the metrics config must be a YAML mapping"
     return loaded
@@ -82,6 +82,15 @@ def _tables_in(query: str) -> set[str]:
 
 
 class ConfigTest(unittest.TestCase):
+    """Mirrors the checks the platform's own config validator applies.
+
+    Every shipped demo config runs through this, so a new demo cannot land a
+    config that only fails once someone runs it.
+    """
+
+    #: Config this case checks. Subclasses point at the other demos'.
+    config_file = "config.resim.yml"
+
     config: dict[str, Any]
     topics: dict[str, Any]
     metrics: dict[str, Any]
@@ -90,7 +99,7 @@ class ConfigTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.config = _load()
+        cls.config = _load(cls.config_file)
         cls.topics = cls.config.get("topics") or {}
         cls.metrics = cls.config.get("metrics") or {}
         cls.metrics_sets = cls.config.get("metrics sets") or {}
@@ -175,13 +184,23 @@ class ConfigTest(unittest.TestCase):
                     f"metric {name!r} references a template that is not shipped",
                 )
 
-    def test_every_shipped_template_is_used(self) -> None:
-        referenced = {
-            metric.get("template_file")
-            for metric in self.metrics.values()
-            if metric.get("template_type") == "custom"
-        }
-        self.assertEqual(_templates() - referenced, set())
+    def test_joined_queries_qualify_ambiguous_columns(self) -> None:
+        # `metadata` and every topic both carry these, so a bare reference in a
+        # joined query is rejected at render time with "column name ... exists
+        # in more than one joined topic" — a failure that only shows up once
+        # the chart runs against real data.
+        shared = ("job_id", "batch_id", "project_id", "build_version", "run_counter")
+        for name, metric in self.metrics.items():
+            query = metric.get("query_string") or ""
+            if not re.search(r"\bJOIN\b", query, re.IGNORECASE):
+                continue
+            for column in shared:
+                bare = re.search(rf"(?<![.\w\"]){column}\b", query)
+                self.assertIsNone(
+                    bare,
+                    f"metric {name!r} joins tables but references {column!r} "
+                    "without a table alias",
+                )
 
     def test_metrics_declare_a_template_and_a_query(self) -> None:
         for name, metric in self.metrics.items():
@@ -255,6 +274,29 @@ class ConfigTest(unittest.TestCase):
                 "block", status, f"metric {name!r} status needs a block value"
             )
 
+    def test_covers_test_batch_and_dashboard_metrics(self) -> None:
+        self.assertEqual(
+            METRIC_TYPES - {metric["type"] for metric in self.metrics.values()}, set()
+        )
+
+
+class MujocoConfigTest(ConfigTest):
+    """The MuJoCo demo's config, held to exactly the same rules."""
+
+    config_file = "mujoco.resim.yml"
+
+
+class NavigationCoverageTest(ConfigTest):
+    """Ambitions specific to the default demo, not rules every config must meet.
+
+    The default demo exists to show the whole surface, so a template going
+    unused there is a gap. Other demos cover what their data honestly supports
+    — the MuJoCo runs report a few summary numbers per episode, so they have no
+    time series to draw a line from and no events to populate that tab.
+    """
+
+    config_file = "config.resim.yml"
+
     def test_covers_every_system_template(self) -> None:
         # The demo exists to show what the platform can render, so a template
         # going unused is a gap in the demo rather than a config error.
@@ -265,16 +307,19 @@ class ConfigTest(unittest.TestCase):
         }
         self.assertEqual(SYSTEM_TEMPLATES - used, set())
 
-    def test_covers_test_batch_and_dashboard_metrics(self) -> None:
-        self.assertEqual(
-            METRIC_TYPES - {metric["type"] for metric in self.metrics.values()}, set()
-        )
-
     def test_declares_an_event_topic(self) -> None:
         self.assertTrue(
             any(topic.get("event") for topic in self.topics.values()),
             "the demo should populate the Events tab",
         )
+
+    def test_every_shipped_template_is_used(self) -> None:
+        referenced = {
+            metric.get("template_file")
+            for metric in self.metrics.values()
+            if metric.get("template_type") == "custom"
+        }
+        self.assertEqual(_templates() - referenced, set())
 
 
 if __name__ == "__main__":

--- a/resim/demo/config_test.py
+++ b/resim/demo/config_test.py
@@ -270,8 +270,11 @@ class ConfigTest(unittest.TestCase):
                 1,
                 f"metric {name!r} status query must have exactly one ? parameter",
             )
-            self.assertIn(
-                "block", status, f"metric {name!r} status needs a block value"
+            # Either threshold on its own is valid — a check that only warns
+            # never blocks a run, which is a real thing to want.
+            self.assertTrue(
+                {"block", "warn"} & set(status),
+                f"metric {name!r} status needs a block or warn value",
             )
 
     def test_covers_test_batch_and_dashboard_metrics(self) -> None:

--- a/resim/demo/data/mujoco.resim.yml
+++ b/resim/demo/data/mujoco.resim.yml
@@ -1,17 +1,12 @@
-# Metrics config for the ReSim SDK demo's MuJoCo tour (resim-demo --demo mujoco).
+# Metrics config for `resim-demo --demo mujoco`: a bimanual manipulation policy
+# evaluated in MuJoCo, one test per random seed.
 #
-# The data is a bimanual manipulation policy evaluated in MuJoCo: one test per
-# random seed, each reporting how well the policy did on that episode, plus a
-# recording of the attempt.
-#
-# Compared with the default demo this is a deliberately small config. The source
-# runs report a handful of summary numbers per episode rather than dense
-# telemetry, so the metrics here are the ones that data genuinely supports —
-# there is no invented signal to fill out the template list.
+# Small on purpose. Each source run reports a few summary numbers per episode
+# rather than dense telemetry, so these are the metrics that data supports.
 version: 1
 
 topics:
-  # One row per test: how the policy did on that seed's episode.
+  # One row per test.
   summary_metrics:
     schema:
       overall_success_rate: float
@@ -19,8 +14,8 @@ topics:
       overall_average_max_reward: float
       total_evaluation_time: float
 
-  # The rendered episode. Image and video columns cannot share a topic, so the
-  # clip and the animation are separate topics over the same recording.
+  # Two topics over the same recording: a topic may not carry both an image
+  # and a video column.
   episode_video:
     schema:
       filename: video
@@ -61,8 +56,8 @@ metrics:
   Peak Reward:
     type: test
     description: >
-      Best single-step reward reached. A high peak with a low total means the
-      policy got close and then lost the task.
+      Best single-step reward reached. High peak with a low total means the
+      policy got close, then lost the task.
     query_string: |
       SELECT
         overall_average_max_reward AS "Max Reward"
@@ -73,8 +68,8 @@ metrics:
   Evaluation Time:
     type: test
     description: >
-      Wall-clock time to evaluate this seed. Episodes that fail tend to run to
-      the step limit, so a long evaluation is itself a signal.
+      Wall-clock time to evaluate this seed. Failing episodes run to the step
+      limit, so a long evaluation is itself a signal.
     query_string: |
       SELECT
         total_evaluation_time AS "Evaluation Time (s)"
@@ -143,9 +138,8 @@ metrics:
   Reward Distribution:
     type: batch
     description: >
-      How reward is spread across seeds. A policy that works on most seeds and
-      collapses on a few looks very different here from one that is uniformly
-      mediocre.
+      How reward is spread across seeds. Separates a policy that fails on a few
+      seeds from one that is uniformly mediocre.
     query_string: |
       SELECT overall_average_sum_reward AS "Sum Reward"
       FROM summary_metrics;
@@ -208,7 +202,7 @@ metrics:
   Reward by Build Version:
     type: dashboard
     description: >
-      Mean reward for each policy build. A build that drops here has regressed,
+      Mean reward per policy build. A build that drops here has regressed,
       whatever its pass count says.
     query_string: |
       SELECT

--- a/resim/demo/data/mujoco.resim.yml
+++ b/resim/demo/data/mujoco.resim.yml
@@ -1,8 +1,8 @@
-# Metrics config for `resim-demo --demo mujoco`: a bimanual manipulation policy
-# evaluated in MuJoCo, one test per random seed.
+# Metrics for the ALOHA transfer-cube policy evaluation, one test per seed.
 #
-# Small on purpose. Each source run reports a few summary numbers per episode
-# rather than dense telemetry, so these are the metrics that data supports.
+# The per-step topics are emitted from the evaluation loop, see
+# src/aloha_honua/emissions.py. `summary_metrics` carries the field names the
+# ReSim SDK demo's config already queries, so both read the same data.
 version: 1
 
 topics:
@@ -13,202 +13,311 @@ topics:
       overall_average_sum_reward: float
       overall_average_max_reward: float
       total_evaluation_time: float
+      # Over the whole episode, unlike stage_timing's per-stage count.
+      total_regressions: int
 
-  # Two topics over the same recording: a topic may not carry both an image
-  # and a video column.
-  episode_video:
+  # One row per simulation step.
+  step_reward:
     schema:
-      filename: video
+      reward: float
 
-  output_gif:
+  # Which rung of the reward ladder the episode is on, per step.
+  task_stage:
+    schema:
+      state: string
+
+  # World position of the cube. The handover counts as complete once x
+  # crosses -0.10, which is what the environment's reward function checks.
+  cube_pose:
+    schema:
+      x: float
+      y: float
+      z: float
+
+  # One row per stage the episode reached. The same numbers ride on the
+  # stage_reached event, but flat here so they chart and aggregate.
+  stage_timing:
+    schema:
+      stage: string
+      seconds_from_start: float
+      seconds_from_previous: float
+      regressions: int
+
+  # A Plotly figure the eval draws directly, rendered by a custom template.
+  cube_trajectory:
+    schema:
+      raw_metric: string
+
+  # The whole episode as a looping animation.
+  episode_gif:
     schema:
       filename: image
 
+  # Raised the first time an episode reaches each stage, carrying the timings
+  # that explain the transition.
+  stage_reached:
+    event: true
+    schema:
+      name: string
+      description: string
+      status: status
+      tags: string[]
+      metrics: metric[]
+
 metrics:
-  # ---------------------------------------------------------------- test level
-  Task Success:
+  # ------------------------------------------------------------- test level
+  Task Stage:
     type: test
     description: >
-      Share of episodes on this seed where the policy completed the task.
-      Warns on any failure, blocks when nothing succeeded.
+      Which stage of the transfer the policy had reached, over the episode.
     query_string: |
       SELECT
-        overall_success_rate AS "Success Rate (%)"
-      FROM summary_metrics;
-    status:
-      query_string: SELECT 1 FROM summary_metrics WHERE overall_success_rate <= ? LIMIT 1
-      block: 0
-      warn: 99.9
+        'Transfer' AS "System",
+        timestamp,
+        state
+      FROM task_stage;
     template_type: system
-    template: scalar
-    units: percent
+    template: state_timeline
 
-  Episode Reward:
-    type: test
-    description: Total reward the policy accumulated over the episode.
-    query_string: |
-      SELECT
-        overall_average_sum_reward AS "Sum Reward"
-      FROM summary_metrics;
-    template_type: system
-    template: scalar
-
-  Peak Reward:
+  Reward Over Time:
     type: test
     description: >
-      Best single-step reward reached. High peak with a low total means the
-      policy got close, then lost the task.
+      The staged reward over the episode: 1 on contact, 2 lifted, 3 transfer
+      attempted, 4 handover complete.
     query_string: |
       SELECT
-        overall_average_max_reward AS "Max Reward"
-      FROM summary_metrics;
+        'Reward' AS group_name,
+        timestamp / 1E9 AS "Time (s)",
+        reward AS "Reward"
+      FROM step_reward;
     template_type: system
-    template: scalar
+    template: line
 
-  Evaluation Time:
+  Handover Progress:
     type: test
     description: >
-      Wall-clock time to evaluate this seed. Failing episodes run to the step
-      limit, so a long evaluation is itself a signal.
+      How far the cube is past the handover line, over the episode. Zero is
+      the line; the handover counts as complete once this goes positive.
     query_string: |
       SELECT
-        total_evaluation_time AS "Evaluation Time (s)"
-      FROM summary_metrics;
+        'Margin' AS group_name,
+        timestamp / 1E9 AS "Time (s)",
+        (-0.10 - x) AS "Handover Margin (m)"
+      FROM cube_pose;
     template_type: system
-    template: scalar
-    units: seconds
+    template: line
+
+  Cube Height:
+    type: test
+    description: >
+      The cube's height over the episode. It sits at 0.05 m on the table, so a
+      rise here is the lift and a drop back is a lost grasp.
+    query_string: |
+      SELECT
+        'Height' AS group_name,
+        timestamp / 1E9 AS "Time (s)",
+        z AS "Cube Height (m)"
+      FROM cube_pose;
+    template_type: system
+    template: line
 
   Episode Summary:
     type: test
-    description: Everything the evaluation reported for this seed, in one place.
+    description: >
+      Everything the episode reported for this seed. Furthest stage runs from
+      0 for no contact to 4 for a completed handover, and an episode that runs
+      to the step limit is one the policy did not finish.
     query_string: |
-      SELECT * FROM (
-        SELECT 1 AS sort_order, 'Success Rate' AS "Metric",
-               CONCAT(CAST(ROUND(overall_success_rate, 1) AS VARCHAR), '%') AS "Value"
+      SELECT "Metric", "Value" FROM (
+        SELECT 1 AS sort_order, 'Handover Completed' AS "Metric",
+               CASE WHEN overall_success_rate > 0 THEN 'Yes' ELSE 'No' END AS "Value"
         FROM summary_metrics
         UNION ALL
-        SELECT 2 AS sort_order, 'Sum Reward' AS "Metric",
+        SELECT 2 AS sort_order, 'Furthest Stage' AS "Metric",
+               CAST(CAST(overall_average_max_reward AS INTEGER) AS VARCHAR) AS "Value"
+        FROM summary_metrics
+        UNION ALL
+        SELECT 3 AS sort_order, 'Episode Length' AS "Metric",
+               CONCAT(CAST(ROUND(total_evaluation_time, 2) AS VARCHAR), 's') AS "Value"
+        FROM summary_metrics
+        UNION ALL
+        SELECT 4 AS sort_order, 'Sum Reward' AS "Metric",
                CAST(ROUND(overall_average_sum_reward, 1) AS VARCHAR) AS "Value"
         FROM summary_metrics
         UNION ALL
-        SELECT 3 AS sort_order, 'Max Reward' AS "Metric",
-               CAST(ROUND(overall_average_max_reward, 2) AS VARCHAR) AS "Value"
-        FROM summary_metrics
-        UNION ALL
-        SELECT 4 AS sort_order, 'Evaluation Time' AS "Metric",
-               CONCAT(CAST(ROUND(total_evaluation_time, 2) AS VARCHAR), 's') AS "Value"
+        SELECT 5 AS sort_order, 'Ladder Regressions' AS "Metric",
+               CAST(total_regressions AS VARCHAR) AS "Value"
         FROM summary_metrics
         ORDER BY sort_order
       );
+    # Completing the handover passes; anything short of it warns. The task is
+    # hard enough that a seed the policy cannot solve is not a broken build,
+    # so nothing here blocks.
+    status:
+      query_string: SELECT 1 FROM summary_metrics WHERE overall_success_rate <= ? LIMIT 1
+      warn: 0
     template_type: system
     template: table
 
-  Episode Recording:
+  Episode Replay:
     type: test
-    description: The policy attempting the task on this seed.
-    query_string: SELECT filename FROM episode_video;
-    skip_if_no_data: true
-    template_type: system
-    template: video
-
-  Episode Animation:
-    type: test
-    description: The same attempt as a looping animation.
-    query_string: SELECT filename FROM output_gif;
+    description: The policy attempting the handover on this seed, start to finish.
+    query_string: SELECT filename FROM episode_gif;
     skip_if_no_data: true
     template_type: system
     template: image
 
-  # --------------------------------------------------------------- batch level
-  Reward by Seed:
-    type: batch
-    description: Total reward on each seed, across the run.
+  Cube Path:
+    type: test
+    description: >
+      Top-down view of the path the cube took, coloured by the stage the
+      episode was in. The per-axis charts each project this motion onto one
+      axis against time, so only this shows the shape of the path.
+    query_string: SELECT raw_metric FROM cube_trajectory;
+    skip_if_no_data: true
+    template_type: custom
+    template_file: raw.liquid
+
+  Stage Latency:
+    type: test
+    description: >
+      Simulated seconds from the start of the episode to each stage it
+      reached. A bar rather than a table column so that an A/B comparison can
+      overlay two runs on one set of axes.
     query_string: |
       SELECT
-        'Sum Reward' AS group_name,
-        m.experience_name AS "Seed",
-        AVG(s.overall_average_sum_reward) AS "Sum Reward"
-      FROM summary_metrics s
-      JOIN metadata m ON s.job_id = m.job_id
-      GROUP BY m.experience_name
-      ORDER BY m.experience_name;
+        'Time to Stage' AS group_name,
+        stage AS "Stage",
+        seconds_from_start AS "Time to Stage (s)"
+      FROM stage_timing
+      ORDER BY seconds_from_start;
     template_type: system
     template: bar
 
-  Reward Distribution:
+  Stage Timeline:
+    type: test
+    description: >
+      Each stage the episode reached, when it got there, how long the stage
+      before it took, and how many times it had fallen back by then.
+    query_string: |
+      SELECT
+        stage AS "Stage",
+        CONCAT(CAST(ROUND(seconds_from_start, 2) AS VARCHAR), 's') AS "Reached At",
+        CONCAT(CAST(ROUND(seconds_from_previous, 2) AS VARCHAR), 's') AS "Previous Stage Took",
+        CAST(regressions AS VARCHAR) AS "Regressions So Far"
+      FROM stage_timing
+      ORDER BY seconds_from_start;
+    template_type: system
+    template: table
+
+  # ------------------------------------------------------------ batch level
+  Mean Time Per Stage:
     type: batch
     description: >
-      How reward is spread across seeds. Separates a policy that fails on a few
-      seeds from one that is uniformly mediocre.
-    query_string: |
-      SELECT overall_average_sum_reward AS "Sum Reward"
-      FROM summary_metrics;
-    template_type: system
-    template: histogram
-
-  Evaluation Time by Seed:
-    type: batch
-    description: Wall-clock evaluation time per seed.
+      Average simulated seconds each stage took across the seeds that reached
+      it. A stage that slows down between builds shows up here.
     query_string: |
       SELECT
-        'Evaluation Time' AS group_name,
-        m.experience_name AS "Seed",
-        AVG(s.total_evaluation_time) AS "Evaluation Time (s)"
-      FROM summary_metrics s
-      JOIN metadata m ON s.job_id = m.job_id
-      GROUP BY m.experience_name
-      ORDER BY m.experience_name;
+        'Mean' AS group_name,
+        stage AS "Stage",
+        AVG(seconds_from_previous) AS "Stage Duration (s)"
+      FROM stage_timing
+      GROUP BY stage
+      ORDER BY 3;
     template_type: system
     template: bar
 
-  Seeds Solved:
+  Seeds Reaching Each Stage:
     type: batch
-    description: Share of seeds where the policy completed the task at least once.
+    description: How many seeds got as far as each stage.
     query_string: |
       SELECT
-        100.0 * AVG(CASE WHEN overall_success_rate > 0 THEN 1.0 ELSE 0.0 END)
-          AS "Seeds Solved (%)"
-      FROM summary_metrics;
+        'Seeds' AS group_name,
+        stage AS "Stage",
+        COUNT(*) AS "Seed Count"
+      FROM stage_timing
+      GROUP BY stage
+      ORDER BY 3 DESC;
     template_type: system
-    template: scalar
-    units: percent
+    template: bar
 
-  Evaluation Summary:
+  Furthest Stage Distribution:
     type: batch
-    description: Headline numbers for the whole run.
+    description: >
+      How far the policy got, as a share of the seeds in the batch. Parts of a
+      whole, so a pie rather than a bar.
     query_string: |
-      SELECT * FROM (
+      SELECT
+        CASE CAST(overall_average_max_reward AS INTEGER)
+          WHEN 0 THEN 'no contact'
+          WHEN 1 THEN 'right gripper contact'
+          WHEN 2 THEN 'lifted'
+          WHEN 3 THEN 'transfer attempted'
+          WHEN 4 THEN 'handover complete'
+          ELSE 'unknown'
+        END AS "Furthest Stage",
+        COUNT(*) AS "Seeds"
+      FROM summary_metrics
+      GROUP BY 1;
+    template_type: system
+    template: pie
+
+  Run Summary:
+    type: batch
+    description: Headline numbers for every seed in the batch.
+    query_string: |
+      SELECT "Metric", "Value" FROM (
         SELECT 1 AS sort_order, 'Seeds Evaluated' AS "Metric",
                CAST(COUNT(*) AS VARCHAR) AS "Value"
         FROM summary_metrics
         UNION ALL
-        SELECT 2 AS sort_order, 'Mean Success Rate' AS "Metric",
-               CONCAT(CAST(ROUND(AVG(overall_success_rate), 1) AS VARCHAR), '%') AS "Value"
+        SELECT 2 AS sort_order, 'Seeds Solved' AS "Metric",
+               CONCAT(CAST(ROUND(100.0 * AVG(CASE WHEN overall_success_rate > 0
+                 THEN 1.0 ELSE 0.0 END), 1) AS VARCHAR), '%') AS "Value"
         FROM summary_metrics
         UNION ALL
         SELECT 3 AS sort_order, 'Mean Sum Reward' AS "Metric",
                CAST(ROUND(AVG(overall_average_sum_reward), 1) AS VARCHAR) AS "Value"
         FROM summary_metrics
         UNION ALL
-        SELECT 4 AS sort_order, 'Mean Evaluation Time' AS "Metric",
+        SELECT 4 AS sort_order, 'Mean Episode Length' AS "Metric",
                CONCAT(CAST(ROUND(AVG(total_evaluation_time), 2) AS VARCHAR), 's') AS "Value"
+        FROM summary_metrics
+        UNION ALL
+        SELECT 5 AS sort_order, 'Mean Ladder Regressions' AS "Metric",
+               CAST(ROUND(AVG(total_regressions), 2) AS VARCHAR) AS "Value"
         FROM summary_metrics
         ORDER BY sort_order
       );
     template_type: system
     template: table
 
-  # ----------------------------------------------------------- dashboard level
-  Reward by Build Version:
-    type: dashboard
-    description: >
-      Mean reward per policy build. A build that drops here has regressed,
-      whatever its pass count says.
+  Reward Distribution:
+    type: batch
+    description: Spread of total episode reward across the seeds in the batch.
     query_string: |
       SELECT
-        'Mean Sum Reward' AS group_name,
+        'Sum Reward' AS group_name,
+        overall_average_sum_reward AS "Sum Reward"
+      FROM summary_metrics;
+    template_type: system
+    template: histogram
+
+  # --------------------------------------------------------- dashboard level
+  # These group by build_version, so each policy configuration becomes one
+  # category. Bars rather than lines: with a handful of builds a line is a
+  # couple of points, and bars stay readable as more accumulate.
+  Success Rate by Build Version:
+    type: dashboard
+    description: >
+      Share of seeds where the policy completed the handover, per build. The
+      headline number, and the one a policy change is trying to move.
+    query_string: |
+      SELECT
+        'Seeds Solved' AS group_name,
         m.build_version AS "Build Version",
-        AVG(s.overall_average_sum_reward) AS "Sum Reward",
+        100.0 * AVG(CASE WHEN s.overall_success_rate > 0 THEN 1.0 ELSE 0.0 END)
+          AS "Seeds Solved (%)",
         '/projects/' || ARBITRARY(m.project_id) || '/batches/' || ARBITRARY(m.batch_id)
           AS link_path
       FROM summary_metrics s
@@ -240,38 +349,131 @@ metrics:
     template_type: system
     template: bar
 
-  Tests Run:
+  Furthest Stage by Build Version:
     type: dashboard
-    description: Seeds evaluated in the window.
-    query_string: SELECT COUNT(*) AS "Tests Run" FROM metadata;
+    description: >
+      Where each build's seeds ended up on the reward ladder. A build can hold
+      its pass count while its failures move between stages, and that shift is
+      the more informative signal.
+    query_string: |
+      SELECT
+        CASE CAST(s.overall_average_max_reward AS INTEGER)
+          WHEN 0 THEN 'no contact'
+          WHEN 1 THEN 'right gripper contact'
+          WHEN 2 THEN 'lifted'
+          WHEN 3 THEN 'transfer attempted'
+          WHEN 4 THEN 'handover complete'
+          ELSE 'unknown'
+        END AS group_name,
+        m.build_version AS "Build Version",
+        COUNT(*) AS "Seeds",
+        '/projects/' || ARBITRARY(m.project_id) || '/batches/' || ARBITRARY(m.batch_id)
+          AS link_path
+      FROM summary_metrics s
+      JOIN metadata m ON s.job_id = m.job_id
+      WHERE m.build_version IS NOT NULL
+      GROUP BY 1, m.build_version
+      ORDER BY m.build_version, 1;
+    skip_if_no_data: true
     template_type: system
-    template: scalar
+    template: bar
+
+  Time to Handover by Build Version:
+    type: dashboard
+    description: >
+      Mean simulated seconds to complete the handover, counting only the seeds
+      that completed it. Separates getting there from getting there quickly.
+    query_string: |
+      SELECT
+        'Mean Time to Handover' AS group_name,
+        m.build_version AS "Build Version",
+        AVG(t.seconds_from_start) AS "Time to Handover (s)",
+        '/projects/' || ARBITRARY(m.project_id) || '/batches/' || ARBITRARY(m.batch_id)
+          AS link_path
+      FROM stage_timing t
+      JOIN metadata m ON t.job_id = m.job_id
+      WHERE m.build_version IS NOT NULL
+        AND t.stage = 'handover complete'
+      GROUP BY m.build_version
+      ORDER BY m.build_version;
+    skip_if_no_data: true
+    template_type: system
+    template: bar
+
+  Reward by Build Version:
+    type: dashboard
+    description: >
+      Mean total episode reward per build. A build that drops here has
+      regressed, whatever its pass count says.
+    query_string: |
+      SELECT
+        'Mean Sum Reward' AS group_name,
+        m.build_version AS "Build Version",
+        AVG(s.overall_average_sum_reward) AS "Sum Reward",
+        '/projects/' || ARBITRARY(m.project_id) || '/batches/' || ARBITRARY(m.batch_id)
+          AS link_path
+      FROM summary_metrics s
+      JOIN metadata m ON s.job_id = m.job_id
+      WHERE m.build_version IS NOT NULL
+      GROUP BY m.build_version
+      ORDER BY m.build_version;
+    skip_if_no_data: true
+    template_type: system
+    template: bar
+
+  Trend Summary:
+    type: dashboard
+    description: Scope of what the dashboard is looking at.
+    query_string: |
+      SELECT "Metric", "Value" FROM (
+        SELECT 1 AS sort_order, 'Builds Compared' AS "Metric",
+               CAST(COUNT(DISTINCT build_version) AS VARCHAR) AS "Value"
+        FROM metadata WHERE build_version IS NOT NULL
+        UNION ALL
+        SELECT 2 AS sort_order, 'Tests Run' AS "Metric",
+               CAST(COUNT(*) AS VARCHAR) AS "Value"
+        FROM metadata
+        UNION ALL
+        SELECT 3 AS sort_order, 'Batches' AS "Metric",
+               CAST(COUNT(DISTINCT batch_id) AS VARCHAR) AS "Value"
+        FROM metadata
+        ORDER BY sort_order
+      );
+    template_type: system
+    template: table
 
 metrics sets:
-  MuJoCo Metrics:
+  ALOHA Metrics:
     metrics:
-      - Task Success
-      - Episode Reward
-      - Peak Reward
-      - Evaluation Time
+      - Task Stage
+      - Reward Over Time
+      - Handover Progress
+      - Cube Height
       - Episode Summary
-      - Episode Recording
-      - Episode Animation
-      - Reward by Seed
+      - Episode Replay
+      - Cube Path
+      - Stage Latency
+      - Stage Timeline
+      - Mean Time Per Stage
+      - Seeds Reaching Each Stage
+      - Furthest Stage Distribution
+      - Run Summary
       - Reward Distribution
-      - Evaluation Time by Seed
-      - Seeds Solved
-      - Evaluation Summary
 
-  MuJoCo Trends:
+  ALOHA Trends:
     metrics:
-      - Reward by Build Version
+      - Success Rate by Build Version
       - Test Outcomes by Build Version
-      - Tests Run
+      - Furthest Stage by Build Version
+      - Time to Handover by Build Version
+      - Reward by Build Version
+      - Trend Summary
 
 dashboards:
-  MuJoCo Demo Trends:
-    metrics_set: MuJoCo Trends
-    description: How the policy trends across builds of the MuJoCo demo.
+  ALOHA Policy Trends:
+    metrics_set: ALOHA Trends
+    description: >
+      How the transfer-cube policy trends across configurations. Each build
+      version is one policy configuration.
     refresh: auto
     day_range: 30

--- a/resim/demo/data/mujoco.resim.yml
+++ b/resim/demo/data/mujoco.resim.yml
@@ -1,0 +1,283 @@
+# Metrics config for the ReSim SDK demo's MuJoCo tour (resim-demo --demo mujoco).
+#
+# The data is a bimanual manipulation policy evaluated in MuJoCo: one test per
+# random seed, each reporting how well the policy did on that episode, plus a
+# recording of the attempt.
+#
+# Compared with the default demo this is a deliberately small config. The source
+# runs report a handful of summary numbers per episode rather than dense
+# telemetry, so the metrics here are the ones that data genuinely supports —
+# there is no invented signal to fill out the template list.
+version: 1
+
+topics:
+  # One row per test: how the policy did on that seed's episode.
+  summary_metrics:
+    schema:
+      overall_success_rate: float
+      overall_average_sum_reward: float
+      overall_average_max_reward: float
+      total_evaluation_time: float
+
+  # The rendered episode. Image and video columns cannot share a topic, so the
+  # clip and the animation are separate topics over the same recording.
+  episode_video:
+    schema:
+      filename: video
+
+  output_gif:
+    schema:
+      filename: image
+
+metrics:
+  # ---------------------------------------------------------------- test level
+  Task Success:
+    type: test
+    description: >
+      Share of episodes on this seed where the policy completed the task.
+      Warns on any failure, blocks when nothing succeeded.
+    query_string: |
+      SELECT
+        overall_success_rate AS "Success Rate (%)"
+      FROM summary_metrics;
+    status:
+      query_string: SELECT 1 FROM summary_metrics WHERE overall_success_rate <= ? LIMIT 1
+      block: 0
+      warn: 99.9
+    template_type: system
+    template: scalar
+    units: percent
+
+  Episode Reward:
+    type: test
+    description: Total reward the policy accumulated over the episode.
+    query_string: |
+      SELECT
+        overall_average_sum_reward AS "Sum Reward"
+      FROM summary_metrics;
+    template_type: system
+    template: scalar
+
+  Peak Reward:
+    type: test
+    description: >
+      Best single-step reward reached. A high peak with a low total means the
+      policy got close and then lost the task.
+    query_string: |
+      SELECT
+        overall_average_max_reward AS "Max Reward"
+      FROM summary_metrics;
+    template_type: system
+    template: scalar
+
+  Evaluation Time:
+    type: test
+    description: >
+      Wall-clock time to evaluate this seed. Episodes that fail tend to run to
+      the step limit, so a long evaluation is itself a signal.
+    query_string: |
+      SELECT
+        total_evaluation_time AS "Evaluation Time (s)"
+      FROM summary_metrics;
+    template_type: system
+    template: scalar
+    units: seconds
+
+  Episode Summary:
+    type: test
+    description: Everything the evaluation reported for this seed, in one place.
+    query_string: |
+      SELECT * FROM (
+        SELECT 1 AS sort_order, 'Success Rate' AS "Metric",
+               CONCAT(CAST(ROUND(overall_success_rate, 1) AS VARCHAR), '%') AS "Value"
+        FROM summary_metrics
+        UNION ALL
+        SELECT 2 AS sort_order, 'Sum Reward' AS "Metric",
+               CAST(ROUND(overall_average_sum_reward, 1) AS VARCHAR) AS "Value"
+        FROM summary_metrics
+        UNION ALL
+        SELECT 3 AS sort_order, 'Max Reward' AS "Metric",
+               CAST(ROUND(overall_average_max_reward, 2) AS VARCHAR) AS "Value"
+        FROM summary_metrics
+        UNION ALL
+        SELECT 4 AS sort_order, 'Evaluation Time' AS "Metric",
+               CONCAT(CAST(ROUND(total_evaluation_time, 2) AS VARCHAR), 's') AS "Value"
+        FROM summary_metrics
+        ORDER BY sort_order
+      );
+    template_type: system
+    template: table
+
+  Episode Recording:
+    type: test
+    description: The policy attempting the task on this seed.
+    query_string: SELECT filename FROM episode_video;
+    skip_if_no_data: true
+    template_type: system
+    template: video
+
+  Episode Animation:
+    type: test
+    description: The same attempt as a looping animation.
+    query_string: SELECT filename FROM output_gif;
+    skip_if_no_data: true
+    template_type: system
+    template: image
+
+  # --------------------------------------------------------------- batch level
+  Reward by Seed:
+    type: batch
+    description: Total reward on each seed, across the run.
+    query_string: |
+      SELECT
+        'Sum Reward' AS group_name,
+        m.experience_name AS "Seed",
+        AVG(s.overall_average_sum_reward) AS "Sum Reward"
+      FROM summary_metrics s
+      JOIN metadata m ON s.job_id = m.job_id
+      GROUP BY m.experience_name
+      ORDER BY m.experience_name;
+    template_type: system
+    template: bar
+
+  Reward Distribution:
+    type: batch
+    description: >
+      How reward is spread across seeds. A policy that works on most seeds and
+      collapses on a few looks very different here from one that is uniformly
+      mediocre.
+    query_string: |
+      SELECT overall_average_sum_reward AS "Sum Reward"
+      FROM summary_metrics;
+    template_type: system
+    template: histogram
+
+  Evaluation Time by Seed:
+    type: batch
+    description: Wall-clock evaluation time per seed.
+    query_string: |
+      SELECT
+        'Evaluation Time' AS group_name,
+        m.experience_name AS "Seed",
+        AVG(s.total_evaluation_time) AS "Evaluation Time (s)"
+      FROM summary_metrics s
+      JOIN metadata m ON s.job_id = m.job_id
+      GROUP BY m.experience_name
+      ORDER BY m.experience_name;
+    template_type: system
+    template: bar
+
+  Seeds Solved:
+    type: batch
+    description: Share of seeds where the policy completed the task at least once.
+    query_string: |
+      SELECT
+        100.0 * AVG(CASE WHEN overall_success_rate > 0 THEN 1.0 ELSE 0.0 END)
+          AS "Seeds Solved (%)"
+      FROM summary_metrics;
+    template_type: system
+    template: scalar
+    units: percent
+
+  Evaluation Summary:
+    type: batch
+    description: Headline numbers for the whole run.
+    query_string: |
+      SELECT * FROM (
+        SELECT 1 AS sort_order, 'Seeds Evaluated' AS "Metric",
+               CAST(COUNT(*) AS VARCHAR) AS "Value"
+        FROM summary_metrics
+        UNION ALL
+        SELECT 2 AS sort_order, 'Mean Success Rate' AS "Metric",
+               CONCAT(CAST(ROUND(AVG(overall_success_rate), 1) AS VARCHAR), '%') AS "Value"
+        FROM summary_metrics
+        UNION ALL
+        SELECT 3 AS sort_order, 'Mean Sum Reward' AS "Metric",
+               CAST(ROUND(AVG(overall_average_sum_reward), 1) AS VARCHAR) AS "Value"
+        FROM summary_metrics
+        UNION ALL
+        SELECT 4 AS sort_order, 'Mean Evaluation Time' AS "Metric",
+               CONCAT(CAST(ROUND(AVG(total_evaluation_time), 2) AS VARCHAR), 's') AS "Value"
+        FROM summary_metrics
+        ORDER BY sort_order
+      );
+    template_type: system
+    template: table
+
+  # ----------------------------------------------------------- dashboard level
+  Reward by Build Version:
+    type: dashboard
+    description: >
+      Mean reward for each policy build. A build that drops here has regressed,
+      whatever its pass count says.
+    query_string: |
+      SELECT
+        'Mean Sum Reward' AS group_name,
+        m.build_version AS "Build Version",
+        AVG(s.overall_average_sum_reward) AS "Sum Reward",
+        '/projects/' || ARBITRARY(m.project_id) || '/batches/' || ARBITRARY(m.batch_id)
+          AS link_path
+      FROM summary_metrics s
+      JOIN metadata m ON s.job_id = m.job_id
+      WHERE m.build_version IS NOT NULL
+      GROUP BY m.build_version
+      ORDER BY m.build_version;
+    skip_if_no_data: true
+    template_type: system
+    template: bar
+
+  Test Outcomes by Build Version:
+    type: dashboard
+    description: >
+      How each build's seeds turned out, one bar per outcome. Click a bar to
+      open a batch that build ran in.
+    query_string: |
+      SELECT
+        job_conflated_status AS group_name,
+        build_version AS "Build Version",
+        COUNT(*) AS "Tests",
+        '/projects/' || ARBITRARY(project_id) || '/batches/' || ARBITRARY(batch_id) AS link_path
+      FROM metadata
+      WHERE build_version IS NOT NULL
+        AND job_conflated_status IS NOT NULL
+      GROUP BY job_conflated_status, build_version
+      ORDER BY build_version, job_conflated_status;
+    skip_if_no_data: true
+    template_type: system
+    template: bar
+
+  Tests Run:
+    type: dashboard
+    description: Seeds evaluated in the window.
+    query_string: SELECT COUNT(*) AS "Tests Run" FROM metadata;
+    template_type: system
+    template: scalar
+
+metrics sets:
+  MuJoCo Metrics:
+    metrics:
+      - Task Success
+      - Episode Reward
+      - Peak Reward
+      - Evaluation Time
+      - Episode Summary
+      - Episode Recording
+      - Episode Animation
+      - Reward by Seed
+      - Reward Distribution
+      - Evaluation Time by Seed
+      - Seeds Solved
+      - Evaluation Summary
+
+  MuJoCo Trends:
+    metrics:
+      - Reward by Build Version
+      - Test Outcomes by Build Version
+      - Tests Run
+
+dashboards:
+  MuJoCo Demo Trends:
+    metrics_set: MuJoCo Trends
+    description: How the policy trends across builds of the MuJoCo demo.
+    refresh: auto
+    day_range: 30

--- a/resim/demo/main_test.py
+++ b/resim/demo/main_test.py
@@ -18,7 +18,7 @@ from unittest.mock import MagicMock, patch
 import httpx
 
 from resim.demo.bundle import DemoDataError
-from resim.demo.run import DEFAULT_BRANCH, DEFAULT_PROJECT_NAME
+from resim.demo.run import DEMOS
 
 main_module = import_module("resim.demo.__main__")
 
@@ -33,21 +33,47 @@ class MainTest(unittest.TestCase):
         return code, run
 
     def test_returns_zero_on_success(self) -> None:
-        code, _ = self._main()
+        code, _ = self._main("--demo", "navigation")
         self.assertEqual(code, 0)
 
-    def test_defaults_match_the_library_defaults(self) -> None:
-        # The CLI and `run()` disagreeing about where the demo lands would be a
-        # nasty surprise, so the defaults are asserted rather than duplicated.
-        _, run = self._main()
+    def test_no_demo_lists_them_instead_of_picking_one(self) -> None:
+        # The demos are peers. Running one the caller did not ask for would be
+        # a surprise, and a bare error would not say what is available.
+        with patch("sys.stdout") as stdout:
+            code, run = self._main()
+        run.assert_not_called()
+        self.assertEqual(code, 0)
+        printed = "".join(str(c.args[0]) for c in stdout.write.call_args_list if c.args)
+        self.assertIn("--demo", printed)
+        for key in DEMOS:
+            self.assertIn(key, printed)
+
+    def test_defaults_defer_to_the_chosen_demo(self) -> None:
+        # The CLI passes None for project and branch so `run()` fills in the
+        # demo's own values; hardcoding them here would silently drift when a
+        # demo changes its project name.
+        _, run = self._main("--demo", "navigation")
         run.assert_called_once()
-        self.assertEqual(run.call_args.args[0], DEFAULT_PROJECT_NAME)
-        self.assertEqual(run.call_args.kwargs["branch"], DEFAULT_BRANCH)
+        self.assertIsNone(run.call_args.args[0])
+        self.assertIsNone(run.call_args.kwargs["branch"])
+        self.assertEqual(run.call_args.kwargs["demo"], "navigation")
         self.assertIsNone(run.call_args.kwargs["data_dir"])
         self.assertFalse(run.call_args.kwargs["quiet"])
 
+    def test_demo_flag_is_passed_through(self) -> None:
+        _, run = self._main("--demo", "mujoco")
+        self.assertEqual(run.call_args.kwargs["demo"], "mujoco")
+
+    def test_unknown_demo_is_refused_by_argparse(self) -> None:
+        with patch("sys.argv", ["resim-demo", "--demo", "nope"]), patch("sys.stderr"):
+            with self.assertRaises(SystemExit) as ctx:
+                main_module.main()
+        self.assertNotEqual(ctx.exception.code, 0)
+
     def test_passes_every_option_through(self) -> None:
         _, run = self._main(
+            "--demo",
+            "navigation",
             "--project-name",
             "other",
             "--branch",
@@ -68,7 +94,7 @@ class MainTest(unittest.TestCase):
                 "run",
                 side_effect=DemoDataError("no data at https://example/x"),
             ),
-            patch("sys.argv", ["resim-demo"]),
+            patch("sys.argv", ["resim-demo", "--demo", "navigation"]),
             patch("sys.stderr") as stderr,
         ):
             code = main_module.main()
@@ -84,7 +110,7 @@ class MainTest(unittest.TestCase):
             patch.object(
                 main_module, "run", side_effect=httpx.ConnectError("reset by peer")
             ),
-            patch("sys.argv", ["resim-demo"]),
+            patch("sys.argv", ["resim-demo", "--demo", "navigation"]),
             patch("sys.stderr") as stderr,
         ):
             code = main_module.main()
@@ -98,7 +124,7 @@ class MainTest(unittest.TestCase):
         # reported as a tidy failure.
         with (
             patch.object(main_module, "run", side_effect=RuntimeError("boom")),
-            patch("sys.argv", ["resim-demo"]),
+            patch("sys.argv", ["resim-demo", "--demo", "navigation"]),
         ):
             with self.assertRaises(RuntimeError):
                 main_module.main()

--- a/resim/demo/main_test.py
+++ b/resim/demo/main_test.py
@@ -48,6 +48,32 @@ class MainTest(unittest.TestCase):
         for key in DEMOS:
             self.assertIn(key, printed)
 
+    def test_options_without_a_demo_are_an_error_not_a_listing(self) -> None:
+        # Listing the demos and exiting 0 while dropping the argument reads as
+        # success: a script would see the run succeed having done nothing.
+        for argv in (
+            ["--project-name", "my project"],
+            ["--branch", "b"],
+            ["--data-dir", "/tmp/d"],
+            ["--quiet"],
+        ):
+            with self.subTest(argv=argv):
+                with (
+                    patch.object(main_module, "run") as run,
+                    patch("sys.argv", ["resim-demo", *argv]),
+                    patch("sys.stderr") as stderr,
+                ):
+                    with self.assertRaises(SystemExit) as ctx:
+                        main_module.main()
+
+                self.assertNotEqual(ctx.exception.code, 0)
+                run.assert_not_called()
+                written = "".join(
+                    str(c.args[0]) for c in stderr.write.call_args_list if c.args
+                )
+                self.assertIn("--demo", written)
+                self.assertIn(argv[0], written)
+
     def test_defaults_defer_to_the_chosen_demo(self) -> None:
         # The CLI passes None for project and branch so `run()` fills in the
         # demo's own values; hardcoding them here would silently drift when a

--- a/resim/demo/run.py
+++ b/resim/demo/run.py
@@ -81,22 +81,22 @@ DEMOS: dict[str, Demo] = {
     "mujoco": Demo(
         key="mujoco",
         summary=(
-            "A bimanual manipulation policy in MuJoCo: one test per seed, "
-            "compared across two policy builds."
+            "An ALOHA bimanual manipulation policy in MuJoCo: one test per "
+            "cube placement, compared across two policy builds."
         ),
         project_name="ReSim SDK Demo (MuJoCo)",
         branch="sdk-demo-mujoco",
         bundle=bundle.BundleSource(
             url=(
                 "https://resim-public-assets.s3.us-east-1.amazonaws.com"
-                "/sdk-demo/resim-sdk-demo-mujoco-v3.tar.gz"
+                "/sdk-demo/resim-sdk-demo-mujoco-v4.tar.gz"
             ),
-            sha256="7962cf30362dafffe7ebf8b42e657b904d8cea84a418cacef5c76e8794ab7b2c",
-            cache_key="mujoco-v3",
+            sha256="bde0c251f3d0df421c004aae7969617aa71596678228787026c1e96c87d9da2f",
+            cache_key="mujoco-v4",
         ),
         config_file="mujoco.resim.yml",
-        metrics_set="MuJoCo Metrics",
-        dashboard_name="MuJoCo Demo Trends",
+        metrics_set="ALOHA Metrics",
+        dashboard_name="ALOHA Policy Trends",
     ),
 }
 

--- a/resim/demo/run.py
+++ b/resim/demo/run.py
@@ -29,7 +29,7 @@ from resim.sdk.bff_client.dashboards import find_dashboard_id
 from resim.sdk.client import AuthenticatedClient
 from resim.sdk.client.api.projects import create_project, list_projects
 from resim.sdk.client.models.create_project_input import CreateProjectInput
-from resim.sdk.test import Test
+from resim.sdk.test import LogType, Test
 
 __all__ = ["DEMOS", "Demo", "DemoResult", "config_path", "run", "templates_path"]
 
@@ -89,10 +89,10 @@ DEMOS: dict[str, Demo] = {
         bundle=bundle.BundleSource(
             url=(
                 "https://resim-public-assets.s3.us-east-1.amazonaws.com"
-                "/sdk-demo/resim-sdk-demo-mujoco-v1.tar.gz"
+                "/sdk-demo/resim-sdk-demo-mujoco-v2.tar.gz"
             ),
-            sha256="f5bb2f84808fc5fad2253e3b73a2f51e0e718adfc314dca3567d5f8181f8479d",
-            cache_key="mujoco-v1",
+            sha256="5c639c5d5cc9d3e535c1d9291aa1ac1198a1cc9194380f2ff3ed013833ebeb48",
+            cache_key="mujoco-v2",
         ),
         config_file="mujoco.resim.yml",
         metrics_set="MuJoCo Metrics",
@@ -314,8 +314,8 @@ def replay_job(
     """
     job_dir = data.root / str(job["directory"])
     test = Test(client, batch, str(job["experience_name"]))
-    for file_name in job.get("media") or []:
-        test.attach_log(str(job_dir / file_name))
+    for file_name, log_type in _attachments(job):
+        test.attach_log(str(job_dir / file_name), log_type)
     for topic, payload, timestamp, is_event in _emissions(
         job_dir / str(job["emissions"])
     ):
@@ -332,6 +332,43 @@ def replay_job(
     # would litter the directory the demo was run from.
     scratch.unlink(missing_ok=True)
     return test
+
+
+def _attachments(job: dict[str, Any]) -> list[tuple[str, Optional[LogType]]]:
+    """The files to upload alongside a job's emissions, and how to type each.
+
+    The log type decides what ReSim can do with a file — an ``.mcap`` sent as
+    ``FOXGLOVE_MCAP_LOG`` opens in the viewer, where the same bytes sent as
+    something else are only a download — so the bundle records the type its
+    source batch used rather than leaving it to be guessed from the name.
+
+    ``media`` is the older bundle shape, which carried filenames alone.
+    """
+    attachments: list[tuple[str, Optional[LogType]]] = [
+        (str(entry["file"]), _log_type(entry.get("log_type")))
+        for entry in job.get("artifacts") or []
+    ]
+    known = {file_name for file_name, _ in attachments}
+    attachments.extend(
+        (str(file_name), None)
+        for file_name in job.get("media") or []
+        if str(file_name) not in known
+    )
+    return attachments
+
+
+def _log_type(name: Optional[str]) -> Optional[LogType]:
+    """Parse a log type from the manifest, ignoring one this SDK does not know.
+
+    A bundle can name a type added after this version shipped; falling back to
+    None lets ReSim infer from the filename rather than failing the run.
+    """
+    if not name:
+        return None
+    try:
+        return LogType(name)
+    except ValueError:
+        return None
 
 
 def _emissions(

--- a/resim/demo/run.py
+++ b/resim/demo/run.py
@@ -31,15 +31,89 @@ from resim.sdk.client.api.projects import create_project, list_projects
 from resim.sdk.client.models.create_project_input import CreateProjectInput
 from resim.sdk.test import Test
 
-__all__ = ["DemoResult", "config_path", "run", "templates_path"]
-
-DEFAULT_PROJECT_NAME = "ReSim SDK Demo"
-DEFAULT_BRANCH = "sdk-demo"
-
-METRICS_SET = "Demo Metrics"
-DASHBOARD_NAME = "SDK Demo Trends"
+__all__ = ["DEMOS", "Demo", "DemoResult", "config_path", "run", "templates_path"]
 
 PROJECT_DESCRIPTION = "Created by the ReSim Python SDK demo (resim.demo.run)."
+
+
+@dataclass(frozen=True)
+class Demo:
+    """One runnable demo: its data, its metrics config, and where it lands.
+
+    Everything that differs between demos lives here, so adding another is a
+    registry entry plus a config file rather than a change to ``run``.
+    """
+
+    #: Value of ``--demo``.
+    key: str
+    #: One line, shown in ``--help``.
+    summary: str
+    project_name: str
+    branch: str
+    bundle: bundle.BundleSource
+    #: Metrics config shipped in ``resim/demo/data``.
+    config_file: str
+    metrics_set: str
+    dashboard_name: str
+
+
+DEMOS: dict[str, Demo] = {
+    "navigation": Demo(
+        key="navigation",
+        summary=(
+            "A hospital navigation suite: dense telemetry across 34 scenarios, "
+            "covering every chart type ReSim ships."
+        ),
+        project_name="ReSim SDK Demo",
+        branch="sdk-demo",
+        bundle=bundle.BundleSource(
+            url=(
+                "https://resim-public-assets.s3.us-east-1.amazonaws.com"
+                "/sdk-demo/resim-sdk-demo-data-v1.tar.gz"
+            ),
+            sha256="7bc5d26c14aaad8d849d131276af7c7287d163aeb3a9d2892f0ffba21889935d",
+            cache_key="navigation-v1",
+        ),
+        config_file="config.resim.yml",
+        metrics_set="Demo Metrics",
+        dashboard_name="SDK Demo Trends",
+    ),
+    "mujoco": Demo(
+        key="mujoco",
+        summary=(
+            "A bimanual manipulation policy in MuJoCo: one test per seed, "
+            "compared across two policy builds."
+        ),
+        project_name="ReSim SDK Demo (MuJoCo)",
+        branch="sdk-demo-mujoco",
+        bundle=bundle.BundleSource(
+            url=(
+                "https://resim-public-assets.s3.us-east-1.amazonaws.com"
+                "/sdk-demo/resim-sdk-demo-mujoco-v1.tar.gz"
+            ),
+            sha256="f5bb2f84808fc5fad2253e3b73a2f51e0e718adfc314dca3567d5f8181f8479d",
+            cache_key="mujoco-v1",
+        ),
+        config_file="mujoco.resim.yml",
+        metrics_set="MuJoCo Metrics",
+        dashboard_name="MuJoCo Demo Trends",
+    ),
+}
+
+
+def get_demo(key: str) -> Demo:
+    """Look a demo up by ``--demo`` value.
+
+    Raises:
+        DemoDataError: If no demo goes by that name.
+    """
+    try:
+        return DEMOS[key]
+    except KeyError:
+        raise DemoDataError(
+            f"unknown demo {key!r}. Available: {', '.join(sorted(DEMOS))}"
+        ) from None
+
 
 # Environment overrides for pointing the demo at a non-production deployment.
 # Undocumented on the command line on purpose: customers should never need
@@ -65,10 +139,11 @@ class DemoResult:
 
 
 def run(
-    project_name: str = DEFAULT_PROJECT_NAME,
+    project_name: Optional[str] = None,
     *,
+    demo: str,
     client: Optional[AuthenticatedClient] = None,
-    branch: str = DEFAULT_BRANCH,
+    branch: Optional[str] = None,
     data_dir: Optional[Union[str, Path]] = None,
     quiet: bool = False,
 ) -> DemoResult:
@@ -82,9 +157,12 @@ def run(
 
     Args:
         project_name: Project to run in. Created if it does not exist.
+            Defaults to the chosen demo's own project name.
+        demo: Which demo to run. See :data:`DEMOS`.
         client: An authenticated ReSim API client. Defaults to interactive
             device code authentication against production.
         branch: Branch to create the batches on. Both batches share it.
+            Defaults to the chosen demo's own branch.
         data_dir: An already-extracted demo data bundle to replay instead of
             downloading one. Mainly useful for development.
         quiet: Suppress progress and result output.
@@ -101,22 +179,26 @@ def run(
         if not quiet:
             print(message, flush=True)
 
+    chosen = get_demo(demo)
+    project_name = chosen.project_name if project_name is None else project_name
+    branch = chosen.branch if branch is None else branch
+
     # Fetch the data before authenticating: there is no point sending someone
     # through a browser login only to fail on a download afterwards.
-    data = bundle.ensure(data_dir)
+    data = bundle.ensure(chosen.bundle, data_dir)
 
     if client is None:
         client = default_client()
 
     project_id = resolve_project(client, project_name, say)
 
-    config_path, templates_path = _package_data()
+    config_resource, templates_resource = _package_data(chosen)
 
     batch_ids: dict[str, str] = {}
     dashboard_id: Optional[str] = None
     with (
-        resources.as_file(config_path) as config,
-        resources.as_file(templates_path) as templates,
+        resources.as_file(config_resource) as config,
+        resources.as_file(templates_resource) as templates,
     ):
         for side in SIDES:
             details = data.batch(side)
@@ -131,14 +213,17 @@ def run(
                 branch=branch,
                 name=str(details.get("name") or f"SDK Demo {side.upper()}"),
                 version=str(details.get("version") or ""),
-                metrics_set_name=METRICS_SET,
+                metrics_set_name=chosen.metrics_set,
                 metrics_config_path=str(config),
                 templates_path=str(templates),
             ) as batch:
                 batch_ids[side] = batch.id
                 if dashboard_id is None:
                     dashboard_id = find_dashboard_id(
-                        client, project_id, batch.branch_id, DASHBOARD_NAME
+                        client,
+                        project_id,
+                        batch.branch_id,
+                        chosen.dashboard_name,
                     )
                 tests: list[Test] = []
                 try:
@@ -275,36 +360,43 @@ def _emissions(
                 ) from e
 
 
-def config_path() -> Path:
-    """Return the path to the metrics config the demo runs with.
+def config_path(demo: str) -> Path:
+    """Return the path to the metrics config a demo runs with.
 
     Copy it as the starting point for your own config, or read it to see how
     the charts in the demo are defined::
 
         from resim.demo import config_path
 
-        print(config_path().read_text())
+        print(config_path("navigation").read_text())
+        print(config_path("mujoco").read_text())
+
+    Args:
+        demo: Which demo's config to return. See :data:`DEMOS`.
 
     Returns:
         A real filesystem path. The templates the config references live in
         :func:`templates_path`.
     """
-    return _materialise(_package_data()[0])
+    return _materialise(_package_data(get_demo(demo))[0])
 
 
-def templates_path() -> Path:
-    """Return the path to the ``.liquid`` templates the demo's config uses.
+def templates_path(demo: str) -> Path:
+    """Return the path to the ``.liquid`` templates a demo's config uses.
+
+    Args:
+        demo: Which demo's templates to return. See :data:`DEMOS`.
 
     Returns:
         A real filesystem path to the directory holding them.
     """
-    return _materialise(_package_data()[1])
+    return _materialise(_package_data(get_demo(demo))[1])
 
 
-def _package_data() -> tuple[Any, Any]:
-    """Locate the shipped metrics config and template directory."""
+def _package_data(demo: Demo) -> tuple[Any, Any]:
+    """Locate a demo's shipped metrics config and template directory."""
     root = resources.files("resim.demo") / "data"
-    return root / "config.resim.yml", root / "templates"
+    return root / demo.config_file, root / "templates"
 
 
 def _materialise(resource: Any) -> Path:

--- a/resim/demo/run.py
+++ b/resim/demo/run.py
@@ -89,10 +89,10 @@ DEMOS: dict[str, Demo] = {
         bundle=bundle.BundleSource(
             url=(
                 "https://resim-public-assets.s3.us-east-1.amazonaws.com"
-                "/sdk-demo/resim-sdk-demo-mujoco-v2.tar.gz"
+                "/sdk-demo/resim-sdk-demo-mujoco-v3.tar.gz"
             ),
-            sha256="5c639c5d5cc9d3e535c1d9291aa1ac1198a1cc9194380f2ff3ed013833ebeb48",
-            cache_key="mujoco-v2",
+            sha256="7962cf30362dafffe7ebf8b42e657b904d8cea84a418cacef5c76e8794ab7b2c",
+            cache_key="mujoco-v3",
         ),
         config_file="mujoco.resim.yml",
         metrics_set="MuJoCo Metrics",
@@ -185,7 +185,7 @@ def run(
 
     # Fetch the data before authenticating: there is no point sending someone
     # through a browser login only to fail on a download afterwards.
-    data = bundle.ensure(chosen.bundle, data_dir)
+    data = bundle.ensure(chosen.bundle, data_dir, None if quiet else say)
 
     if client is None:
         client = default_client()

--- a/resim/demo/run_test.py
+++ b/resim/demo/run_test.py
@@ -30,6 +30,7 @@ from httpx import URL
 from resim.demo.bundle import DemoDataError
 from resim.demo.run import resolve_project, run
 from resim.sdk.metrics.emissions import Emitter
+from resim.sdk.test import LogType
 
 # resim.demo exports a `run` function, which shadows the `resim.demo.run`
 # module attribute, so the module has to be fetched by name to patch into it.
@@ -503,6 +504,55 @@ class ResolveProjectTest(unittest.TestCase):
         ) as listed:
             self.assertEqual(resolve_project(self.client, "mine"), "id-mine")
         self.assertEqual(listed.call_count, 2)
+
+
+class AttachmentsTest(unittest.TestCase):
+    """What gets uploaded alongside a job's emissions, and how it is typed."""
+
+    def test_artifacts_keep_the_log_type_the_bundle_recorded(self) -> None:
+        # An .mcap sent as FOXGLOVE_MCAP_LOG opens in the viewer; the same
+        # bytes typed as anything else are only a download.
+        job = {
+            "artifacts": [
+                {"file": "run.mcap", "log_type": "FOXGLOVE_MCAP_LOG"},
+                {"file": "worker.log", "log_type": "EXECUTION_LOG"},
+            ]
+        }
+        self.assertEqual(
+            run_module._attachments(job),
+            [
+                ("run.mcap", LogType.FOXGLOVE_MCAP_LOG),
+                ("worker.log", LogType.EXECUTION_LOG),
+            ],
+        )
+
+    def test_media_without_a_type_is_left_for_resim_to_infer(self) -> None:
+        job = {"media": ["episode.mp4", "episode.gif"]}
+        self.assertEqual(
+            run_module._attachments(job),
+            [("episode.mp4", None), ("episode.gif", None)],
+        )
+
+    def test_a_file_named_twice_is_uploaded_once(self) -> None:
+        # Bundles carry media in both lists during the changeover; uploading
+        # the same file twice would show it twice on the test.
+        job = {
+            "artifacts": [{"file": "episode.mp4", "log_type": "MP4_LOG"}],
+            "media": ["episode.mp4", "episode.gif"],
+        }
+        self.assertEqual(
+            run_module._attachments(job),
+            [("episode.mp4", LogType.MP4_LOG), ("episode.gif", None)],
+        )
+
+    def test_an_unknown_log_type_falls_back_to_inference(self) -> None:
+        # A bundle may name a type added after this SDK shipped. Inferring from
+        # the filename beats failing the whole run.
+        job = {"artifacts": [{"file": "x.bin", "log_type": "INVENTED_LOG"}]}
+        self.assertEqual(run_module._attachments(job), [("x.bin", None)])
+
+    def test_a_job_with_nothing_attached_is_fine(self) -> None:
+        self.assertEqual(run_module._attachments({}), [])
 
 
 class DemoRegistryTest(unittest.TestCase):

--- a/resim/demo/run_test.py
+++ b/resim/demo/run_test.py
@@ -551,6 +551,14 @@ class AttachmentsTest(unittest.TestCase):
         job = {"artifacts": [{"file": "x.bin", "log_type": "INVENTED_LOG"}]}
         self.assertEqual(run_module._attachments(job), [("x.bin", None)])
 
+    def test_an_artifact_with_no_log_type_is_left_for_inference(self) -> None:
+        # A bundle built before log types were recorded lists the file alone.
+        # Uploading it untyped is right; refusing it would strand the bundle.
+        job = {"artifacts": [{"file": "run.mcap"}, {"file": "x.log", "log_type": ""}]}
+        self.assertEqual(
+            run_module._attachments(job), [("run.mcap", None), ("x.log", None)]
+        )
+
     def test_a_job_with_nothing_attached_is_fine(self) -> None:
         self.assertEqual(run_module._attachments({}), [])
 

--- a/resim/demo/run_test.py
+++ b/resim/demo/run_test.py
@@ -18,6 +18,8 @@ import json
 import os
 import tempfile
 import unittest
+
+import yaml
 from importlib import import_module, resources
 from pathlib import Path
 from typing import Any
@@ -26,12 +28,15 @@ from unittest.mock import MagicMock, patch
 from httpx import URL
 
 from resim.demo.bundle import DemoDataError
-from resim.demo.run import DASHBOARD_NAME, METRICS_SET, resolve_project, run
+from resim.demo.run import resolve_project, run
 from resim.sdk.metrics.emissions import Emitter
 
 # resim.demo exports a `run` function, which shadows the `resim.demo.run`
 # module attribute, so the module has to be fetched by name to patch into it.
 run_module = import_module("resim.demo.run")
+
+#: Demo the orchestration tests exercise.
+DEMO = "navigation"
 
 EXPERIENCES = ["Corridor - Bright", "Corridor - Dark"]
 
@@ -232,7 +237,7 @@ class RunTest(unittest.TestCase):
         self.temp.cleanup()
 
     def _run(self) -> Any:
-        return run(client=fake_client(), data_dir=self.root, quiet=True)
+        return run(demo=DEMO, client=fake_client(), data_dir=self.root, quiet=True)
 
     def test_runs_both_batches(self) -> None:
         result = self._run()
@@ -248,7 +253,8 @@ class RunTest(unittest.TestCase):
         branches = {kwargs["branch"] for kwargs in FakeBatch.created}
         self.assertEqual(len(branches), 1, "one dashboard cannot span two branches")
         self.assertEqual(
-            {kwargs["metrics_set_name"] for kwargs in FakeBatch.created}, {METRICS_SET}
+            {kwargs["metrics_set_name"] for kwargs in FakeBatch.created},
+            {run_module.DEMOS[DEMO].metrics_set},
         )
 
     def test_batches_differ_by_version(self) -> None:
@@ -309,7 +315,10 @@ class RunTest(unittest.TestCase):
     def test_looks_the_dashboard_up_by_name(self) -> None:
         self._run()
         run_module.find_dashboard_id.assert_called_with(
-            unittest.mock.ANY, "project-1", "branch-1", DASHBOARD_NAME
+            unittest.mock.ANY,
+            "project-1",
+            "branch-1",
+            run_module.DEMOS[DEMO].dashboard_name,
         )
 
     def test_falls_back_to_the_dashboards_list_when_not_found(self) -> None:
@@ -323,7 +332,7 @@ class RunTest(unittest.TestCase):
 
     def test_prints_every_link(self) -> None:
         with patch("builtins.print") as printed:
-            result = run(client=fake_client(), data_dir=self.root)
+            result = run(demo=DEMO, client=fake_client(), data_dir=self.root)
         output = "\n".join(
             str(call.args[0]) for call in printed.call_args_list if call.args
         )
@@ -343,7 +352,7 @@ class RunTest(unittest.TestCase):
         with patch.object(
             run_module, "default_client", return_value=fake_client()
         ) as default:
-            run(data_dir=self.root, quiet=True)
+            run(demo=DEMO, data_dir=self.root, quiet=True)
         default.assert_called_once_with()
 
     def test_blank_lines_in_the_emissions_file_are_skipped(self) -> None:
@@ -496,6 +505,57 @@ class ResolveProjectTest(unittest.TestCase):
         self.assertEqual(listed.call_count, 2)
 
 
+class DemoRegistryTest(unittest.TestCase):
+    """Every registered demo has to be runnable, not just declared."""
+
+    def test_every_demo_ships_its_config(self) -> None:
+        for key in run_module.DEMOS:
+            with self.subTest(demo=key):
+                path = run_module.config_path(key)
+                self.assertTrue(path.is_file(), f"{key}: {path} missing")
+
+    def test_every_demo_declares_the_sets_its_config_defines(self) -> None:
+        # A demo naming a metrics set or dashboard the config does not define
+        # syncs cleanly and then renders nothing, which is hard to spot.
+        for key, demo in run_module.DEMOS.items():
+            with self.subTest(demo=key):
+                config = yaml.safe_load(
+                    run_module.config_path(key).read_text(encoding="utf8")
+                )
+                # The platform spells this key with a space, not an
+                # underscore; a config using the wrong one syncs with no sets
+                # at all and renders nothing.
+                self.assertIn(demo.metrics_set, config.get("metrics sets") or {})
+                self.assertIn(demo.dashboard_name, config.get("dashboards") or {})
+
+    def test_demos_do_not_collide(self) -> None:
+        # Two demos sharing a project, branch or cache key would overwrite each
+        # other's results.
+        for field in ("project_name", "branch"):
+            values = [getattr(d, field) for d in run_module.DEMOS.values()]
+            self.assertEqual(len(values), len(set(values)), f"duplicate {field}")
+        keys = [d.bundle.cache_key for d in run_module.DEMOS.values()]
+        self.assertEqual(len(keys), len(set(keys)), "duplicate bundle cache_key")
+
+    def test_bundle_sources_are_pinned(self) -> None:
+        for key, demo in run_module.DEMOS.items():
+            with self.subTest(demo=key):
+                self.assertRegex(demo.bundle.sha256, r"^[0-9a-f]{64}$")
+                self.assertTrue(demo.bundle.url.startswith("https://"))
+
+    def test_registry_keys_match_their_entries(self) -> None:
+        for key, demo in run_module.DEMOS.items():
+            self.assertEqual(key, demo.key)
+
+    def test_unknown_demo_is_reported_with_the_alternatives(self) -> None:
+        with self.assertRaises(DemoDataError) as ctx:
+            run_module.get_demo("nope")
+        message = str(ctx.exception)
+        self.assertIn("nope", message)
+        for key in run_module.DEMOS:
+            self.assertIn(key, message)
+
+
 class PackageDataTest(unittest.TestCase):
     """The shipped config and templates are part of the public API.
 
@@ -504,13 +564,13 @@ class PackageDataTest(unittest.TestCase):
     """
 
     def test_config_path_points_at_a_readable_config(self) -> None:
-        path = run_module.config_path()
+        path = run_module.config_path(DEMO)
         self.assertTrue(path.is_file(), f"{path} is not a file")
         self.assertEqual(path.name, "config.resim.yml")
         self.assertIn("metrics:", path.read_text(encoding="utf8"))
 
     def test_templates_path_points_at_the_liquid_templates(self) -> None:
-        path = run_module.templates_path()
+        path = run_module.templates_path(DEMO)
         self.assertTrue(path.is_dir(), f"{path} is not a directory")
         self.assertTrue(
             list(path.glob("*.liquid")),
@@ -519,9 +579,9 @@ class PackageDataTest(unittest.TestCase):
 
     def test_the_demo_runs_with_exactly_what_it_publishes(self) -> None:
         # If these ever drift, someone copies a config the demo does not use.
-        config, templates = run_module._package_data()
-        self.assertEqual(str(run_module.config_path()), str(config))
-        self.assertEqual(str(run_module.templates_path()), str(templates))
+        config, templates = run_module._package_data(run_module.get_demo(DEMO))
+        self.assertEqual(str(run_module.config_path(DEMO)), str(config))
+        self.assertEqual(str(run_module.templates_path(DEMO)), str(templates))
 
     def test_package_data_outside_the_filesystem_is_copied_out(self) -> None:
         # A zip import has no real path, so the data is copied somewhere that


### PR DESCRIPTION
Stacked on #296.

## What

`resim-demo --demo mujoco` runs a second demo, built from MuJoCo policy evaluations, alongside the existing hospital navigation one. There is no default: `resim-demo` on its own lists what ships.

```
resim-demo
  mujoco       A bimanual manipulation policy in MuJoCo: one test per seed,
               compared across two policy builds.
  navigation   A hospital navigation suite: dense telemetry across 34
               scenarios, covering every chart type ReSim ships.
```

## Why

The demo replayed one fixed dataset. It tours the chart types well, because that source data is dense telemetry, but it is one domain. A second demo shows a different shape of data and a different question — is this policy build better than the last one.

Two runs of the same 20 seeds against consecutive builds, so the A/B has a real difference:

| | baseline | candidate |
| --- | --- | --- |
| Passed / warned | 7 / 13 | 12 / 8 |
| Mean success rate | 35% | 60% |
| Mean sum reward | 264 | 325 |
| Mean evaluation time | 10.4s | 9.2s |

Seeds are identical on both sides, so tests pair by name with no positional alignment.

## How

A demo is a registry entry plus a config file. `run()` keeps its shape, so a third demo is data rather than code. Bundle URL, checksum, config, metrics set, dashboard, project and branch all live on the entry, spelled out rather than derived so what gets downloaded is greppable. Each demo caches under its own key.

No default anywhere — `run()`, `config_path()` and `templates_path()` all require a demo. The demos are peers, so picking one for the caller is a surprise, and a reader of any of those learns demos exist.

## Artifacts

Following the pattern in rerobot's `eval/resim_ingest.py`, each file goes up with the log type ReSim can do most with rather than one inferred from the filename. An `.mcap` sent as `FOXGLOVE_MCAP_LOG` opens in the viewer; the same bytes typed otherwise are only a download.

Per batch, verified on staging:

| Log type | Count |
| --- | --- |
| `FOXGLOVE_MCAP_LOG` | 4 |
| `MP4_LOG` | 4 |
| `OTHER_LOG` | 4 |
| `CONTAINER_LOG` | 40 |
| `EXECUTION_LOG` | 40 |
| `EMISSIONS_LOG` | 20 |

112 attachments per batch, against 24 before.

**Carrying all of it was not viable.** Everything both runs produced is 271MB, downloaded on first run against a 4.8MB bundle today: mcap 91.9MB, mp4 77.9MB, `videos.zip` 77.0MB, gif 19.5MB. `videos.zip` is the same footage as the mp4 beside it and is dropped outright; the `.mcap` rides along only for the jobs that already carry media. The bundle lands at **24MB**. An `.mcap` on all forty tests would take it to roughly 110MB, which the viewer does not need in order to demonstrate itself.

## What this data does not support

Each MuJoCo test emits four summary numbers and a recording. That is all there is to replay: the source project's richer charts come from `metrics.binproto`, which a light batch does not reproduce, and its other emissions files carry `container_performance` and `test_length_seconds`, whose names are reserved.

So the config covers scalar, table, bar, histogram, video and image, and **not** line, state_timeline or pie. Inventing a signal to fill out the template list would make the demo less honest, not more complete. The default demo stays the full tour, and `config_test.py` reflects that — the platform-validator checks now run against every shipped demo config, while the three asserting a full template sweep stay scoped to the default one.

## Testing

`bazel test //resim/demo:demo_test` — 147 tests. Verified end to end against staging twice.

Three bugs surfaced that no static check would have caught, each now with a test that fails without its fix:

- the config used `metrics_sets:` where the platform expects `metrics sets`, with a space — it would have synced with no metrics sets and rendered nothing;
- its dashboard query left `build_version`, `project_id` and `batch_id` unqualified across a join, which rendered as `ERROR` only once the chart ran on real data;
- the `.mcap` came out of the export as `MCAP_LOG`, which is what the source batch used and which does not reach the viewer.

## Note on the published bundle

The manifest carried `source_batch_id` and the internal batch name. It is published to a public bucket, so it now holds only the replayed data and the names the demo itself shows.

Plan: `docs/plans/WOB-4405-mujoco-demo.md`