### PR TITLE
Parallel log uploads with retries in resim.sdk

### DIFF
--- a/resim/sdk/test.py
+++ b/resim/sdk/test.py
@@ -1,10 +1,16 @@
+import concurrent.futures
 import hashlib
+import logging
 import os
+import random
 import tempfile
+import threading
+import time
 import traceback
 import httpx
+from httpx import TransportError
 from types import TracebackType
-from typing import Optional
+from typing import Callable, Optional, Sequence, TypeVar
 
 from pathlib import Path
 from resim.sdk.batch import Batch
@@ -22,14 +28,100 @@ from resim.sdk.client.models.create_job_for_batch_input import CreateJobForBatch
 from resim.sdk.client.models.create_job_log_input import CreateJobLogInput
 from resim.sdk.client.models.log_type import LogType
 
-__all__ = ["Test", "LogType"]
+__all__ = ["Test", "LogType", "LogUploadError"]
+
+logger = logging.getLogger(__name__)
+
+# Number of threads used for background log uploads within a single test.
+UPLOAD_WORKERS = 4
+# Total tries per upload step, including the first one.
+UPLOAD_ATTEMPTS = 3
+# Seconds allowed for a single socket operation, not for the upload as a whole.
+# The httpx default of 5 seconds is far too short for a large log.
+UPLOAD_TIMEOUT_S = 300.0
+
+# Responses worth another try: the server is busy or briefly unavailable.
+_RETRYABLE_STATUS_CODES = frozenset({408, 425, 429, 500, 502, 503, 504})
+_RETRY_BASE_DELAY_S = 0.5
+_CHECKSUM_CHUNK_SIZE = 1024 * 1024
+
+T = TypeVar("T")
+
+
+class LogUploadError(Exception):
+    """One or more log uploads failed after all tries.
+
+    Attributes:
+        failures: (file_name, exception) pairs, one per failed upload.
+    """
+
+    def __init__(self, failures: Sequence[tuple[str, BaseException]]):
+        self.failures = list(failures)
+        detail = "; ".join(f"{name}: {error!r}" for name, error in self.failures)
+        super().__init__(f"{len(self.failures)} log upload(s) failed: {detail}")
+
+
+class _RetryableUploadError(Exception):
+    """Internal marker for a response that deserves another try."""
+
+
+def _retry(
+    operation: Callable[[], T],
+    *,
+    description: str,
+    attempts: int,
+) -> T:
+    """Run an operation, retrying transient failures with exponential backoff.
+
+    Args:
+        operation: Callable to run. Must be safe to call more than once.
+        description: Short label used in retry log messages.
+        attempts: Total number of tries, including the first one.
+
+    Returns:
+        Whatever the operation returns.
+
+    Raises:
+        Exception: The last failure, if every try fails.
+    """
+    delay = _RETRY_BASE_DELAY_S
+    for attempt in range(1, attempts + 1):
+        try:
+            return operation()
+        except (_RetryableUploadError, TransportError) as error:
+            if attempt >= attempts:
+                raise
+            # Jitter keeps a batch of parallel uploads from retrying in lockstep.
+            sleep_for = delay + random.uniform(0.0, delay / 2)
+            logger.warning(
+                "%s failed (try %d of %d), retrying in %.1fs: %r",
+                description,
+                attempt,
+                attempts,
+                sleep_for,
+                error,
+            )
+            time.sleep(sleep_for)
+            delay *= 2
+    raise AssertionError("unreachable")
 
 
 class Test(Emitter):
     def __init__(self, client: AuthenticatedClient, batch: Batch, name: str):
+        """Create a test (job) inside a batch.
+
+        Args:
+            client: Authenticated API client.
+            batch: The batch this test belongs to.
+            name: Display name for the test.
+        """
         self._client = client
         self._batch = batch
         self.name = name
+        self._executor: Optional[concurrent.futures.ThreadPoolExecutor] = None
+        self._http_client: Optional[httpx.Client] = None
+        self._pending: list[tuple[str, "concurrent.futures.Future[None]"]] = []
+        self._pending_lock = threading.Lock()
 
         body = CreateJobForBatchInput(name=self.name)
         response = create_job_for_batch.sync_detailed(
@@ -55,28 +147,121 @@ class Test(Emitter):
         file_path: str,
         log_type: Optional[LogType] = None,
         file_name: Optional[str] = None,
+        *,
+        wait: bool = False,
     ) -> None:
         """Upload a local file as a log attachment for this test.
 
+        The upload runs on a background pool, so several uploads overlap with
+        each other and with the rest of the test. Closing the test waits for
+        every background upload and reports the ones that failed. Transient
+        failures are retried either way.
+
         Args:
-            file_path: Path to the local file to upload.
+            file_path: Path to the local file to upload. Unless wait is True,
+                the file must still exist, complete and unchanged, when the
+                upload runs.
             log_type: The log type classification. Defaults to None, which lets
                 ReSim infer the log type from the file name.
             file_name: Override the filename used when uploading. Defaults to
                 the basename of file_path.
+            wait: Block until this upload finishes instead of backgrounding it.
+                Use it when the file is about to be deleted or rewritten, or
+                when the failure has to surface at the call site.
+
+        Raises:
+            Exception: If the upload failed and wait is True. Background
+                failures are raised by close() as a LogUploadError instead.
         """
+        if wait:
+            self._upload(file_path, log_type, file_name)
+            return
+
+        name = file_name if file_name is not None else Path(file_path).name
+        future = self._pool().submit(self._upload, file_path, log_type, file_name)
+        with self._pending_lock:
+            self._pending.append((name, future))
+
+    def attach_system_log(
+        self,
+        file_path: str,
+        file_name: Optional[str] = None,
+        *,
+        wait: bool = False,
+    ) -> None:
+        """Upload a local file as a system log for this test.
+
+        Args:
+            file_path: Path to the local file to upload.
+            file_name: Override the filename used when uploading. Defaults to
+                the basename of file_path.
+            wait: Whether to block until the upload finishes. See attach_log.
+        """
+        self.attach_log(
+            file_path, log_type=LogType.SYSTEM_LOG, file_name=file_name, wait=wait
+        )
+
+    def _pool(self) -> concurrent.futures.ThreadPoolExecutor:
+        """Return this test's upload pool, creating it on first use."""
+        with self._pending_lock:
+            if self._executor is None:
+                self._executor = concurrent.futures.ThreadPoolExecutor(
+                    max_workers=UPLOAD_WORKERS,
+                    thread_name_prefix="resim-log-upload",
+                )
+            return self._executor
+
+    def _http(self) -> httpx.Client:
+        """Return this test's HTTP client, creating it on first use.
+
+        One client per test keeps the connection to the object store alive
+        between uploads. Without it every log pays a fresh TLS handshake, which
+        dominates the time spent on a small log.
+        """
+        with self._pending_lock:
+            if self._http_client is None:
+                self._http_client = httpx.Client(timeout=UPLOAD_TIMEOUT_S)
+            return self._http_client
+
+    def _upload(
+        self,
+        file_path: str,
+        log_type: Optional[LogType],
+        file_name: Optional[str],
+    ) -> None:
+        """Register a log with the API and upload its contents."""
         if file_name is None:
             file_name = Path(file_path).name
 
-        h = hashlib.sha256()
-        with open(file_path, "rb") as f:
-            for chunk in iter(lambda: f.read(8192), b""):
-                h.update(chunk)
+        file_size = os.path.getsize(file_path)
+        checksum = _checksum(file_path)
 
+        upload_url, upload_headers = _retry(
+            lambda: self._create_log(file_name, file_size, checksum, log_type),
+            description=f"creating job log {file_name}",
+            attempts=UPLOAD_ATTEMPTS,
+        )
+
+        _retry(
+            lambda: self._put_file(
+                file_path, file_name, file_size, upload_url, upload_headers
+            ),
+            description=f"uploading log {file_name}",
+            attempts=UPLOAD_ATTEMPTS,
+        )
+
+    def _create_log(
+        self,
+        file_name: str,
+        file_size: int,
+        checksum: str,
+        log_type: Optional[LogType],
+    ) -> tuple[str, dict[str, str]]:
+        """Register a log with the API and return its upload URL and headers."""
         body = CreateJobLogInput(
             file_name=file_name,
-            file_size=os.path.getsize(file_path),
-            checksum=h.hexdigest(),
+            file_size=file_size,
+            checksum=checksum,
             log_type=log_type if log_type is not None else UNSET,
         )
         response = create_job_log.sync_detailed(
@@ -87,38 +272,45 @@ class Test(Emitter):
             body=body,
         )
         if response.status_code != 201:
-            raise Exception(
+            message = (
                 f"failed to create job log {response.status_code}: {response.content}"
             )
+            if response.status_code in _RETRYABLE_STATUS_CODES:
+                raise _RetryableUploadError(message)
+            raise Exception(message)
 
         log_output = response.parsed
         assert log_output is not None, "Failed to parse job log response"
-        upload_url = log_output.upload_url
-        upload_headers = {}
+        upload_headers: dict[str, str] = {}
         if not isinstance(log_output.required_headers, Unset):
             upload_headers = log_output.required_headers.to_dict()
+        return log_output.upload_url, upload_headers
 
-        with open(file_path, "rb") as f:
-            r = httpx.put(upload_url, headers=upload_headers, content=f.read())
-
-        if r.status_code != 200:
-            raise Exception(
-                f"failed to upload log {file_name}. Got response {r.status_code}: {r.content}"
-            )
-
-    def attach_system_log(
+    def _put_file(
         self,
         file_path: str,
-        file_name: Optional[str] = None,
+        file_name: str,
+        file_size: int,
+        upload_url: str,
+        upload_headers: dict[str, str],
     ) -> None:
-        """Upload a local file as a system log for this test.
+        # Stream from the file handle instead of reading it into memory. The
+        # explicit Content-Length keeps httpx from using chunked encoding, which
+        # object stores reject. The handle is reopened on every try so a retry
+        # starts from the beginning of the file.
+        headers = dict(upload_headers)
+        headers["Content-Length"] = str(file_size)
+        with open(file_path, "rb") as f:
+            response = self._http().put(upload_url, headers=headers, content=f)
 
-        Args:
-            file_path: Path to the local file to upload.
-            file_name: Override the filename used when uploading. Defaults to
-                the basename of file_path.
-        """
-        self.attach_log(file_path, log_type=LogType.SYSTEM_LOG, file_name=file_name)
+        if response.status_code != 200:
+            message = (
+                f"failed to upload log {file_name}. "
+                f"Got response {response.status_code}: {response.content!r}"
+            )
+            if response.status_code in _RETRYABLE_STATUS_CODES:
+                raise _RetryableUploadError(message)
+            raise Exception(message)
 
     def __enter__(self) -> "Test":
         return self
@@ -145,9 +337,17 @@ class Test(Emitter):
                 traceback.print_exception(exc_type, exc_value, tb, file=f)
                 tmp_path = f.name
             try:
+                # wait=True: the temp file is deleted as soon as this returns.
                 self.attach_log(
-                    tmp_path, LogType.CONTAINER_LOG, file_name="stacktrace.log"
+                    tmp_path,
+                    LogType.CONTAINER_LOG,
+                    file_name="stacktrace.log",
+                    wait=True,
                 )
+            except Exception as upload_error:
+                # The test already failed. Closing the job and reporting the
+                # original exception matters more than the stacktrace upload.
+                logger.warning("failed to upload stacktrace: %r", upload_error)
             finally:
                 os.unlink(tmp_path)
         self.close(
@@ -160,14 +360,37 @@ class Test(Emitter):
         status: LightJobStatus = LightJobStatus.SUCCEEDED,
         error: str | None = None,
     ) -> None:
+        """Finish the test: flush emissions, drain uploads, and close the job.
+
+        Waits for every background upload. If any of them failed, the job is
+        closed with an ERROR status and the failures are raised once the job
+        is closed.
+
+        Args:
+            status: Status to close the job with.
+            error: Optional error message to record on the job.
+
+        Raises:
+            LogUploadError: If any log upload failed after all tries.
+        """
         if self.file is None:
             return
         super().close()
+
         self.attach_log(
             str(self.output_path),
             LogType.EMISSIONS_LOG,
             file_name="emissions.resim.jsonl",
         )
+        failures = self._drain_uploads()
+
+        upload_error: Optional[LogUploadError] = None
+        if failures:
+            upload_error = LogUploadError(failures)
+            if status == LightJobStatus.SUCCEEDED:
+                status = LightJobStatus.ERROR
+                error = str(upload_error)
+
         body = CloseJobInput(status=status)
         if error:
             body.error_message = error
@@ -182,3 +405,47 @@ class Test(Emitter):
             raise Exception(
                 f"failed to close test. Expected 204 response, got {response.status_code} instead"
             )
+        if upload_error is not None:
+            raise upload_error
+
+    def _drain_uploads(self) -> list[tuple[str, BaseException]]:
+        """Wait for every background upload and return the ones that failed."""
+        with self._pending_lock:
+            pending = self._pending
+            self._pending = []
+            executor = self._executor
+            self._executor = None
+
+        failures = _collect_failures(pending)
+        if executor is not None:
+            executor.shutdown(wait=True)
+
+        # Only now can the client be closed: a worker that had not started yet
+        # would otherwise create a replacement after this ran.
+        with self._pending_lock:
+            http_client = self._http_client
+            self._http_client = None
+        if http_client is not None:
+            http_client.close()
+        return failures
+
+
+def _collect_failures(
+    pending: Sequence[tuple[str, "concurrent.futures.Future[None]"]],
+) -> list[tuple[str, BaseException]]:
+    """Wait for each future and return (file_name, exception) for the failures."""
+    failures: list[tuple[str, BaseException]] = []
+    for name, future in pending:
+        try:
+            future.result()
+        except Exception as error:
+            failures.append((name, error))
+    return failures
+
+
+def _checksum(file_path: str) -> str:
+    h = hashlib.sha256()
+    with open(file_path, "rb") as f:
+        for chunk in iter(lambda: f.read(_CHECKSUM_CHUNK_SIZE), b""):
+            h.update(chunk)
+    return h.hexdigest()

--- a/resim/sdk/test_test.py
+++ b/resim/sdk/test_test.py
@@ -1,9 +1,14 @@
+import os
+import tempfile
+import threading
 import unittest
 from pathlib import Path
-from typing import Any
-from unittest.mock import MagicMock, patch, mock_open
+from typing import Any, Union
+from unittest.mock import MagicMock, patch
 
-from resim.sdk.test import Test, LogType
+import httpx
+
+from resim.sdk.test import Test, LogType, LogUploadError, UPLOAD_TIMEOUT_S
 from resim.sdk.client.models.light_job_status import LightJobStatus
 from resim.sdk.client.types import Unset
 
@@ -12,327 +17,379 @@ BATCH_ID = "batch-789"
 JOB_ID = "job-456"
 TEST_NAME = "my-test"
 CONFIG_PATH = "/fake/path/config.resim.yml"
-UPLOAD_URL = "https://upload.example.com/emissions"
+UPLOAD_URL_PREFIX = "https://upload.example.com"
+
+
+def _response(status_code: int) -> MagicMock:
+    return MagicMock(status_code=status_code, content=b"")
+
+
+def _create_log_response(*_args: Any, **kwargs: Any) -> MagicMock:
+    """Answer create_job_log with an upload URL that identifies the file."""
+    response = MagicMock()
+    response.status_code = 201
+    response.parsed.upload_url = f"{UPLOAD_URL_PREFIX}/{kwargs['body'].file_name}"
+    response.parsed.required_headers.to_dict.return_value = {}
+    return response
+
+
+class _UploadResponder:
+    """Thread-safe stand-in for httpx.put that answers per destination file.
+
+    Uploads run in parallel, so responses are keyed by the file name in the
+    upload URL rather than by call order. Files with no queued outcome get the
+    default status.
+    """
+
+    def __init__(self, default_status: int = 200):
+        self._queued: dict[str, list[Union[int, BaseException]]] = {}
+        self._default_status = default_status
+        self._lock = threading.Lock()
+
+    def queue(self, file_name: str, outcomes: list[Union[int, BaseException]]) -> None:
+        """Queue the outcomes for successive upload attempts of one file."""
+        self._queued[file_name] = list(outcomes)
+
+    def __call__(self, url: str, **_kwargs: Any) -> MagicMock:
+        file_name = url.rsplit("/", 1)[-1]
+        with self._lock:
+            queue = self._queued.get(file_name)
+            outcome: Union[int, BaseException] = (
+                queue.pop(0) if queue else self._default_status
+            )
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return _response(outcome)
 
 
 class TestTest(unittest.TestCase):
-    @patch("resim.sdk.test.httpx")
-    @patch("resim.sdk.test.close_job")
-    @patch("resim.sdk.test.create_job_log")
-    @patch("resim.sdk.test.create_job_for_batch")
-    def test_test_creation(
-        self,
-        mock_create_job: Any,
-        mock_create_log: Any,
-        mock_close_job: Any,
-        mock_httpx: Any,
-    ) -> None:
-        mock_client = MagicMock()
+    """Tests for the Test lifecycle and its log uploads.
 
-        mock_batch = MagicMock()
-        mock_batch.project_id = PROJECT_ID
-        mock_batch.id = BATCH_ID
-        mock_batch.metrics_config_path = CONFIG_PATH
+    Each test runs in its own temporary working directory, because the emitter
+    writes its emissions file relative to the current directory. Log files on
+    disk are real, so checksums and uploads run the same code as production.
+    """
 
-        mock_create_response = MagicMock()
-        mock_create_response.status_code = 201
-        mock_create_response.parsed.job_id = JOB_ID
-        mock_create_job.sync_detailed.return_value = mock_create_response
+    def setUp(self) -> None:
+        self._tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp_dir.cleanup)
+        previous_dir = os.getcwd()
+        os.chdir(self._tmp_dir.name)
+        self.addCleanup(os.chdir, previous_dir)
 
-        mock_log_response = MagicMock()
-        mock_log_response.status_code = 201
-        mock_log_response.parsed.upload_url = UPLOAD_URL
-        mock_create_log.sync_detailed.return_value = mock_log_response
+        self.client = MagicMock()
+        self.batch = MagicMock()
+        self.batch.project_id = PROJECT_ID
+        self.batch.id = BATCH_ID
+        self.batch.metrics_config_path = CONFIG_PATH
 
-        mock_httpx.put.return_value = MagicMock(status_code=200)
+        self.mock_create_job = self._patch("resim.sdk.test.create_job_for_batch")
+        self.mock_create_log = self._patch("resim.sdk.test.create_job_log")
+        self.mock_close_job = self._patch("resim.sdk.test.close_job")
+        self.mock_httpx = self._patch("resim.sdk.test.httpx")
+        # Retry backoff would otherwise add seconds to the suite.
+        self.mock_sleep = self._patch("resim.sdk.test.time.sleep")
 
-        mock_close_response = MagicMock()
-        mock_close_response.status_code = 204
-        mock_close_job.sync_detailed.return_value = mock_close_response
+        create_job_response = MagicMock()
+        create_job_response.status_code = 201
+        create_job_response.parsed.job_id = JOB_ID
+        self.mock_create_job.sync_detailed.return_value = create_job_response
+        self.mock_create_log.sync_detailed.side_effect = _create_log_response
+        self.mock_close_job.sync_detailed.return_value = _response(204)
 
-        emissions_content = b"fake emissions data"
-        m = mock_open(read_data=emissions_content)
-        # mock_open returns the same value on every read(), so iter(f.read, b"") would
-        # loop forever. Give read() a side_effect that returns data once then b"" (EOF).
-        m.return_value.__enter__.return_value.read.side_effect = [
-            emissions_content,
-            b"",  # SHA256 chunked read in attach_log
-            emissions_content,  # httpx.put content read in attach_log
+        # Uploads go through a per-test httpx.Client, not the module function.
+        self.mock_client_instance = self.mock_httpx.Client.return_value
+        self.put = self.mock_client_instance.put
+        self.uploads = _UploadResponder()
+        self.put.side_effect = self.uploads
+
+    def _patch(self, target: str) -> MagicMock:
+        patcher = patch(target)
+        mock = patcher.start()
+        self.addCleanup(patcher.stop)
+        return mock
+
+    def _write_file(self, name: str, content: bytes = b"log data") -> str:
+        path = Path(self._tmp_dir.name) / name
+        path.write_bytes(content)
+        return str(path)
+
+    def _create_log_bodies(self) -> list[Any]:
+        return [
+            call.kwargs["body"]
+            for call in self.mock_create_log.sync_detailed.call_args_list
         ]
-        with (
-            patch("builtins.open", m),
-            patch("os.path.getsize", return_value=len(emissions_content)),
-        ):
-            with Test(mock_client, mock_batch, TEST_NAME) as test:
-                self.assertEqual(test.name, TEST_NAME)
+
+    def _create_log_body(self, file_name: str) -> Any:
+        """Find the create_job_log body for one file, whatever order it ran in."""
+        for body in self._create_log_bodies():
+            if body.file_name == file_name:
+                return body
+        raise AssertionError(f"no log was created for {file_name}")
+
+    def _close_job_body(self) -> Any:
+        return self.mock_close_job.sync_detailed.call_args_list[0].kwargs["body"]
+
+    def test_test_creation(self) -> None:
+        with Test(self.client, self.batch, TEST_NAME) as test:
+            self.assertEqual(test.name, TEST_NAME)
 
         self.assertEqual(test.config_paths, [Path(CONFIG_PATH)])
-        mock_create_job.sync_detailed.assert_called_once()
-        mock_create_log.sync_detailed.assert_called_once()
-        mock_httpx.put.assert_called_once()
-        mock_close_job.sync_detailed.assert_called_once()
+        self.mock_create_job.sync_detailed.assert_called_once()
+        # Only the emissions file is uploaded on close.
+        self.mock_create_log.sync_detailed.assert_called_once()
+        self.put.assert_called_once()
+        self.mock_close_job.sync_detailed.assert_called_once()
+        self.assertEqual(self._close_job_body().status, LightJobStatus.SUCCEEDED)
 
-    @patch("resim.sdk.test.httpx")
-    @patch("resim.sdk.test.close_job")
-    @patch("resim.sdk.test.create_job_log")
-    @patch("resim.sdk.test.create_job_for_batch")
-    def test_attach_log(
-        self,
-        mock_create_job: Any,
-        mock_create_log: Any,
-        mock_close_job: Any,
-        mock_httpx: Any,
-    ) -> None:
-        mock_client = MagicMock()
+    def test_attach_log(self) -> None:
+        content = b"fake image data"
+        log_path = self._write_file("some_image.jpeg", content)
 
-        mock_batch = MagicMock()
-        mock_batch.project_id = PROJECT_ID
-        mock_batch.id = BATCH_ID
-        mock_batch.metrics_config_path = CONFIG_PATH
-
-        mock_create_response = MagicMock()
-        mock_create_response.status_code = 201
-        mock_create_response.parsed.job_id = JOB_ID
-        mock_create_job.sync_detailed.return_value = mock_create_response
-
-        mock_log_response = MagicMock()
-        mock_log_response.status_code = 201
-        mock_log_response.parsed.upload_url = UPLOAD_URL
-        mock_create_log.sync_detailed.return_value = mock_log_response
-
-        mock_httpx.put.return_value = MagicMock(status_code=200)
-
-        mock_close_response = MagicMock()
-        mock_close_response.status_code = 204
-        mock_close_job.sync_detailed.return_value = mock_close_response
-
-        emissions_content = b"fake emissions data"
-        extra_log_content = b"fake image data"
-        m = mock_open(read_data=emissions_content)
-        # Each attach_log call reads the file twice: once for SHA256 (chunked, needs EOF
-        # sentinel b"") and once for the httpx.put upload. Two attach_log calls total:
-        # first for the explicit attach, second for the emissions file on close.
-        m.return_value.__enter__.return_value.read.side_effect = [
-            extra_log_content,
-            b"",  # SHA256 for extra log
-            extra_log_content,  # httpx.put upload for extra log
-            emissions_content,
-            b"",  # SHA256 for emissions
-            emissions_content,  # httpx.put upload for emissions
-        ]
-        with (
-            patch("builtins.open", m),
-            patch("os.path.getsize", return_value=len(emissions_content)),
-        ):
-            with Test(mock_client, mock_batch, TEST_NAME) as test:
-                test.attach_log("some_image.jpeg", LogType.MP4_LOG)
+        with Test(self.client, self.batch, TEST_NAME) as test:
+            test.attach_log(log_path, LogType.MP4_LOG, wait=True)
 
         # Two create_job_log calls: one for the extra log, one for emissions on exit
-        self.assertEqual(mock_create_log.sync_detailed.call_count, 2)
-        self.assertEqual(mock_httpx.put.call_count, 2)
+        self.assertEqual(self.mock_create_log.sync_detailed.call_count, 2)
+        self.assertEqual(self.put.call_count, 2)
 
-        first_call_body = mock_create_log.sync_detailed.call_args_list[0].kwargs["body"]
-        self.assertEqual(first_call_body.log_type, LogType.MP4_LOG)
+        body = self._create_log_bodies()[0]
+        self.assertEqual(body.log_type, LogType.MP4_LOG)
+        self.assertEqual(body.file_name, "some_image.jpeg")
+        self.assertEqual(body.file_size, len(content))
 
-    @patch("resim.sdk.test.httpx")
-    @patch("resim.sdk.test.close_job")
-    @patch("resim.sdk.test.create_job_log")
-    @patch("resim.sdk.test.create_job_for_batch")
-    def test_attach_log_without_log_type(
-        self,
-        mock_create_job: Any,
-        mock_create_log: Any,
-        mock_close_job: Any,
-        mock_httpx: Any,
-    ) -> None:
-        mock_client = MagicMock()
+    def test_upload_declares_content_length(self) -> None:
+        content = b"fake image data"
+        log_path = self._write_file("some_image.jpeg", content)
 
-        mock_batch = MagicMock()
-        mock_batch.project_id = PROJECT_ID
-        mock_batch.id = BATCH_ID
-        mock_batch.metrics_config_path = CONFIG_PATH
+        with Test(self.client, self.batch, TEST_NAME) as test:
+            test.attach_log(log_path, wait=True)
 
-        mock_create_response = MagicMock()
-        mock_create_response.status_code = 201
-        mock_create_response.parsed.job_id = JOB_ID
-        mock_create_job.sync_detailed.return_value = mock_create_response
+        # Object stores reject chunked transfer encoding, so the streamed upload
+        # must declare its length.
+        headers = self.put.call_args_list[0].kwargs["headers"]
+        self.assertEqual(headers["Content-Length"], str(len(content)))
 
-        mock_log_response = MagicMock()
-        mock_log_response.status_code = 201
-        mock_log_response.parsed.upload_url = UPLOAD_URL
-        mock_create_log.sync_detailed.return_value = mock_log_response
+    def test_attach_log_without_log_type(self) -> None:
+        log_path = self._write_file("some_image.jpeg")
 
-        mock_httpx.put.return_value = MagicMock(status_code=200)
-
-        mock_close_response = MagicMock()
-        mock_close_response.status_code = 204
-        mock_close_job.sync_detailed.return_value = mock_close_response
-
-        emissions_content = b"fake emissions data"
-        extra_log_content = b"fake image data"
-        m = mock_open(read_data=emissions_content)
-        m.return_value.__enter__.return_value.read.side_effect = [
-            extra_log_content,
-            b"",  # SHA256 for extra log
-            extra_log_content,  # httpx.put upload for extra log
-            emissions_content,
-            b"",  # SHA256 for emissions
-            emissions_content,  # httpx.put upload for emissions
-        ]
-        with (
-            patch("builtins.open", m),
-            patch("os.path.getsize", return_value=len(emissions_content)),
-        ):
-            with Test(mock_client, mock_batch, TEST_NAME) as test:
-                test.attach_log("some_image.jpeg")
+        with Test(self.client, self.batch, TEST_NAME) as test:
+            test.attach_log(log_path, wait=True)
 
         # Omitting log_type leaves it off the request body so the server can
         # infer it from the file name.
-        first_call_body = mock_create_log.sync_detailed.call_args_list[0].kwargs["body"]
-        self.assertIsInstance(first_call_body.log_type, Unset)
-        self.assertNotIn("logType", first_call_body.to_dict())
+        body = self._create_log_bodies()[0]
+        self.assertIsInstance(body.log_type, Unset)
+        self.assertNotIn("logType", body.to_dict())
 
-    @patch("resim.sdk.test.httpx")
-    @patch("resim.sdk.test.close_job")
-    @patch("resim.sdk.test.create_job_log")
-    @patch("resim.sdk.test.create_job_for_batch")
-    def test_attach_system_log(
-        self,
-        mock_create_job: Any,
-        mock_create_log: Any,
-        mock_close_job: Any,
-        mock_httpx: Any,
-    ) -> None:
-        mock_client = MagicMock()
+    def test_attach_system_log(self) -> None:
+        log_path = self._write_file("run.log")
 
-        mock_batch = MagicMock()
-        mock_batch.project_id = PROJECT_ID
-        mock_batch.id = BATCH_ID
-        mock_batch.metrics_config_path = CONFIG_PATH
-
-        mock_create_response = MagicMock()
-        mock_create_response.status_code = 201
-        mock_create_response.parsed.job_id = JOB_ID
-        mock_create_job.sync_detailed.return_value = mock_create_response
-
-        mock_log_response = MagicMock()
-        mock_log_response.status_code = 201
-        mock_log_response.parsed.upload_url = UPLOAD_URL
-        mock_create_log.sync_detailed.return_value = mock_log_response
-
-        mock_httpx.put.return_value = MagicMock(status_code=200)
-
-        mock_close_response = MagicMock()
-        mock_close_response.status_code = 204
-        mock_close_job.sync_detailed.return_value = mock_close_response
-
-        emissions_content = b"fake emissions data"
-        system_log_content = b"fake system log data"
-        m = mock_open(read_data=emissions_content)
-        m.return_value.__enter__.return_value.read.side_effect = [
-            system_log_content,
-            b"",  # SHA256 for system log
-            system_log_content,  # httpx.put upload for system log
-            emissions_content,
-            b"",  # SHA256 for emissions
-            emissions_content,  # httpx.put upload for emissions
-        ]
-        with (
-            patch("builtins.open", m),
-            patch("os.path.getsize", return_value=len(system_log_content)),
-        ):
-            with Test(mock_client, mock_batch, TEST_NAME) as test:
-                test.attach_system_log("logs/run.log", file_name="robot.log")
+        with Test(self.client, self.batch, TEST_NAME) as test:
+            test.attach_system_log(log_path, file_name="robot.log")
 
         # System logs are always uploaded as SYSTEM_LOG, and the file_name
         # override is passed through.
-        self.assertEqual(mock_create_log.sync_detailed.call_count, 2)
-        first_call_body = mock_create_log.sync_detailed.call_args_list[0].kwargs["body"]
-        self.assertEqual(first_call_body.log_type, LogType.SYSTEM_LOG)
-        self.assertEqual(first_call_body.file_name, "robot.log")
+        self.assertEqual(self.mock_create_log.sync_detailed.call_count, 2)
+        body = self._create_log_body("robot.log")
+        self.assertEqual(body.log_type, LogType.SYSTEM_LOG)
+
+    def test_background_uploads_are_awaited_on_close(self) -> None:
+        paths = [self._write_file(f"log_{i}.log") for i in range(5)]
+
+        with Test(self.client, self.batch, TEST_NAME) as test:
+            for path in paths:
+                test.attach_log(path, LogType.CONTAINER_LOG)
+
+        # Every background upload finished before the job was closed.
+        self.assertEqual(self.put.call_count, 6)
+        uploaded = {body.file_name for body in self._create_log_bodies()}
+        self.assertEqual(
+            uploaded,
+            {f"log_{i}.log" for i in range(5)} | {"emissions.resim.jsonl"},
+        )
+        self.assertEqual(self._close_job_body().status, LightJobStatus.SUCCEEDED)
+
+    def test_background_upload_does_not_block_the_caller(self) -> None:
+        # attach_log(wait=False) hands the work to the pool and returns, so the
+        # test body keeps running while the upload is still in flight.
+        release = threading.Event()
+        started = threading.Event()
+
+        def block_until_released(*_args: Any, **_kwargs: Any) -> MagicMock:
+            started.set()
+            release.wait(timeout=5)
+            return _response(200)
+
+        self.put.side_effect = block_until_released
+        log_path = self._write_file("background.log")
+
+        with Test(self.client, self.batch, TEST_NAME) as test:
+            test.attach_log(log_path)
+            self.assertTrue(started.wait(timeout=5))
+            release.set()
+
+    def test_upload_retries_transient_failures(self) -> None:
+        log_path = self._write_file("flaky.log")
+        self.uploads.queue(
+            "flaky.log", [httpx.ConnectError("connection reset"), 503, 200]
+        )
+
+        with Test(self.client, self.batch, TEST_NAME) as test:
+            test.attach_log(log_path)
+
+        # Three tries for the flaky log, plus the emissions upload.
+        self.assertEqual(self.put.call_count, 4)
+        self.mock_sleep.assert_called()
+        self.assertEqual(self._close_job_body().status, LightJobStatus.SUCCEEDED)
+
+    def test_create_log_retries_transient_failures(self) -> None:
+        log_path = self._write_file("flaky.log")
+        failed_once: set[str] = set()
+
+        def fail_first_time(*args: Any, **kwargs: Any) -> MagicMock:
+            name = kwargs["body"].file_name
+            if name not in failed_once:
+                failed_once.add(name)
+                return _response(502)
+            return _create_log_response(*args, **kwargs)
+
+        self.mock_create_log.sync_detailed.side_effect = fail_first_time
+
+        with Test(self.client, self.batch, TEST_NAME) as test:
+            test.attach_log(log_path, wait=True)
+
+        # One retry each for the log and for the emissions file.
+        self.assertEqual(self.mock_create_log.sync_detailed.call_count, 4)
+
+    def test_upload_does_not_retry_client_errors(self) -> None:
+        log_path = self._write_file("rejected.log")
+        self.uploads.queue("rejected.log", [403])
+
+        with self.assertRaises(Exception) as caught:
+            with Test(self.client, self.batch, TEST_NAME) as test:
+                test.attach_log(log_path, wait=True)
+
+        self.assertIn("403", str(caught.exception))
+        # One try for the rejected log, then the stacktrace and emissions uploads.
+        self.assertEqual(self.put.call_count, 3)
+
+    def test_blocking_upload_raises_at_the_call_site(self) -> None:
+        log_path = self._write_file("rejected.log")
+        self.uploads.queue("rejected.log", [403])
+        raised = None
+
+        with self.assertRaises(Exception):
+            with Test(self.client, self.batch, TEST_NAME) as test:
+                try:
+                    test.attach_log(log_path, wait=True)
+                except Exception as error:  # noqa: BLE001 - recorded, then re-raised
+                    raised = error
+                    raise
+
+        # wait=True reports the failure where the caller can catch it, rather
+        # than deferring it to close().
+        self.assertIn("403", str(raised))
+
+    def test_failed_background_upload_closes_job_with_error(self) -> None:
+        log_path = self._write_file("doomed.log")
+        self.uploads.queue("doomed.log", [500, 500, 500])
+
+        with self.assertRaises(LogUploadError) as caught:
+            with Test(self.client, self.batch, TEST_NAME) as test:
+                test.attach_log(log_path)
+
+        self.assertEqual(
+            [name for name, _ in caught.exception.failures], ["doomed.log"]
+        )
+        # Three tries for the failing log, plus the emissions upload. The job is
+        # still closed so it does not hang open, but with an ERROR status.
+        self.assertEqual(self.put.call_count, 4)
+        body = self._close_job_body()
+        self.assertEqual(body.status, LightJobStatus.ERROR)
+        self.assertIn("doomed.log", body.error_message)
+
+    def test_every_failed_upload_is_reported(self) -> None:
+        paths = [self._write_file(f"log_{i}.log") for i in range(2)]
+        self.uploads.queue("log_0.log", [400])
+        self.uploads.queue("log_1.log", [400])
+
+        with self.assertRaises(LogUploadError) as caught:
+            with Test(self.client, self.batch, TEST_NAME) as test:
+                for path in paths:
+                    test.attach_log(path)
+
+        # Every file is attempted even after the first one fails.
+        self.assertEqual(
+            sorted(name for name, _ in caught.exception.failures),
+            ["log_0.log", "log_1.log"],
+        )
+
+    def test_one_http_client_is_shared_and_closed(self) -> None:
+        paths = [self._write_file(f"log_{i}.log") for i in range(4)]
+
+        with Test(self.client, self.batch, TEST_NAME) as test:
+            for path in paths:
+                test.attach_log(path)
+
+        # One client for the whole test, so the connection to the object store
+        # is reused instead of re-handshaked per log.
+        self.mock_httpx.Client.assert_called_once()
+        self.assertEqual(self.put.call_count, 5)
+        self.mock_client_instance.close.assert_called_once()
+
+    def test_http_client_carries_the_upload_timeout(self) -> None:
+        with Test(self.client, self.batch, TEST_NAME):
+            pass
+
+        # The timeout lives on the client, so every upload inherits it.
+        self.assertEqual(
+            self.mock_httpx.Client.call_args.kwargs["timeout"], UPLOAD_TIMEOUT_S
+        )
 
     @patch("resim.sdk.test.os.unlink")
     @patch("resim.sdk.test.tempfile.NamedTemporaryFile")
-    @patch("resim.sdk.test.httpx")
-    @patch("resim.sdk.test.close_job")
-    @patch("resim.sdk.test.create_job_log")
-    @patch("resim.sdk.test.create_job_for_batch")
     def test_exception_uploads_stacktrace_and_closes_with_error(
         self,
-        mock_create_job: Any,
-        mock_create_log: Any,
-        mock_close_job: Any,
-        mock_httpx: Any,
         mock_named_tmp_file: Any,
         mock_unlink: Any,
     ) -> None:
-        mock_client = MagicMock()
-
-        mock_batch = MagicMock()
-        mock_batch.project_id = PROJECT_ID
-        mock_batch.id = BATCH_ID
-        mock_batch.metrics_config_path = CONFIG_PATH
-
-        mock_create_response = MagicMock()
-        mock_create_response.status_code = 201
-        mock_create_response.parsed.job_id = JOB_ID
-        mock_create_job.sync_detailed.return_value = mock_create_response
-
-        mock_log_response = MagicMock()
-        mock_log_response.status_code = 201
-        mock_log_response.parsed.upload_url = UPLOAD_URL
-        mock_create_log.sync_detailed.return_value = mock_log_response
-
-        mock_httpx.put.return_value = MagicMock(status_code=200)
-
-        mock_close_response = MagicMock()
-        mock_close_response.status_code = 204
-        mock_close_job.sync_detailed.return_value = mock_close_response
-
-        STACKTRACE_PATH = "/tmp/execution_log_test.txt"
+        stacktrace_path = self._write_file("execution_log_test.txt", b"")
         mock_tmp_file = MagicMock()
         mock_tmp_file.__enter__ = MagicMock(return_value=mock_tmp_file)
         mock_tmp_file.__exit__ = MagicMock(return_value=None)
-        mock_tmp_file.name = STACKTRACE_PATH
+        mock_tmp_file.name = stacktrace_path
         mock_named_tmp_file.return_value = mock_tmp_file
 
-        stacktrace_content = b"fake stacktrace"
-        emissions_content = b"fake emissions data"
-        m = mock_open()
-        # Two attach_log calls: stacktrace (CONTAINER_LOG) then emissions (EMISSIONS_LOG).
-        # Each reads the file twice: once for SHA256 (chunked, needs b"" EOF sentinel)
-        # and once for the httpx.put upload.
-        m.return_value.__enter__.return_value.read.side_effect = [
-            stacktrace_content,
-            b"",  # SHA256 EOF for stacktrace
-            stacktrace_content,  # httpx.put upload for stacktrace
-            emissions_content,
-            b"",  # SHA256 EOF for emissions
-            emissions_content,  # httpx.put upload for emissions
-        ]
-
         test_exception = RuntimeError("test error")
-        with (
-            patch("builtins.open", m),
-            patch("os.path.getsize", return_value=len(stacktrace_content)),
-        ):
-            with self.assertRaises(RuntimeError):
-                with Test(mock_client, mock_batch, TEST_NAME):
-                    raise test_exception
+        with self.assertRaises(RuntimeError):
+            with Test(self.client, self.batch, TEST_NAME):
+                raise test_exception
 
         # First log call should be the stacktrace (CONTAINER_LOG)
-        self.assertEqual(mock_create_log.sync_detailed.call_count, 2)
-        first_call_body = mock_create_log.sync_detailed.call_args_list[0].kwargs["body"]
-        self.assertEqual(first_call_body.log_type, LogType.CONTAINER_LOG)
+        self.assertEqual(self.mock_create_log.sync_detailed.call_count, 2)
+        self.assertEqual(self._create_log_bodies()[0].log_type, LogType.CONTAINER_LOG)
 
         # close_job should be called with ERROR status and the error message
-        self.assertEqual(mock_httpx.put.call_count, 2)
-        close_call_body = mock_close_job.sync_detailed.call_args_list[0].kwargs["body"]
-        self.assertEqual(close_call_body.status, LightJobStatus.ERROR)
-        self.assertEqual(close_call_body.error_message, repr(test_exception))
+        self.assertEqual(self.put.call_count, 2)
+        body = self._close_job_body()
+        self.assertEqual(body.status, LightJobStatus.ERROR)
+        self.assertEqual(body.error_message, repr(test_exception))
 
         # Temp file should be cleaned up
-        mock_unlink.assert_called_once_with(STACKTRACE_PATH)
+        mock_unlink.assert_called_once_with(stacktrace_path)
+
+    def test_stacktrace_upload_failure_still_closes_job(self) -> None:
+        # The test already failed; a broken stacktrace upload must not stop the
+        # job from closing or hide the original exception.
+        self.uploads.queue("stacktrace.log", [400])
+
+        with self.assertRaises(RuntimeError):
+            with Test(self.client, self.batch, TEST_NAME):
+                raise RuntimeError("test error")
+
+        self.mock_close_job.sync_detailed.assert_called_once()
+        self.assertEqual(self._close_job_body().status, LightJobStatus.ERROR)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description of change

3 changes:
1. Add new `wait` kwarg: `test.attach_log("big.mcap", wait=False)`. When `wait=False` this returns immediately, enqueues the upload in the background, and uploads via a worker pool. The `with Test(...)` block with block until all uploads are done, otherwise we may trigger metrics2.0 workflows before the emissions file is uploaded.
2. Switch `httpx.put` to use a shared `httpx.Client` to avoid the cost of construction and negotiation on every single request
3. `attach_log` will retry up to 3 times, for both the `CreateJobLog` call and the S3 PUT call

Before and after:
```python
test.attach_log("robot.png")                  # blocks until uploaded, as before
test.attach_log("big.mcap", wait=False)       # uploads on a background pool
```

```
Created batch upload benchmark (1ad432f1-5600-4db7-9175-15a8de89a40f).
3 tests, each with 10 1MB files.

                 wait=True    wait=False + shared httpx.Client
----------------------------------------
test 1                 10.7s          2.8s
test 2                 10.0s          2.4s
test 3                 10.9s          2.1s
----------------------------------------
mean                   10.5s          2.4s
total                 31.6s          7.3s

Each test uploaded 10 MB.
```

### Also fixed while in here

- `httpx.put` ran with the httpx default 5 second timeout, which a large log
  cannot finish inside. Now 300s.
- Uploads stream from the file handle instead of `f.read()` into memory. At four
  workers that was four whole files resident at once.
- A failed emissions upload used to leave the job open forever. The job now
  closes with an `ERROR` status listing the failures, then raises.
- A failed stacktrace upload used to hide the test's own exception. Now logged.

## Guide to reproduce test results

```
bazel test //resim/sdk:sdk_test
```

## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
