### PR TITLE
Fix core image build: Bazel apt key URL returns 404

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -43,7 +43,7 @@ RUN echo "source /etc/bash_completion" >> /root/.bashrc
 
 # Install Bazel
 RUN apt install -y apt-transport-https curl gnupg
-RUN curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor >bazel-archive-keyring.gpg
+RUN curl -fsSL https://storage.googleapis.com/bazel-apt/doc/apt-key.pub.gpg | gpg --dearmor >bazel-archive-keyring.gpg
 RUN mv bazel-archive-keyring.gpg /usr/share/keyrings
 RUN echo "deb [arch=amd64 signed-by=/usr/share/keyrings/bazel-archive-keyring.gpg] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
 RUN apt-get update && apt-get -y install bazel=7.6.1

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ terraform.tfstate*
 *.swp
 *.swo
 
+# Python
+*.pyc
+
 # Mkdocs build output
 /site/
 


### PR DESCRIPTION
## Description of change

`https://bazel.build/bazel-release.pub.gpg` now 404s, so `curl -fsSL` exits
non-zero and the core image build fails on every push to `main`:

```
curl: (22) The requested URL returned error: 404
```

Fetch the key from `storage.googleapis.com/bazel-apt/doc/apt-key.pub.gpg`, the
same bucket the apt repo on the next line already uses. Checked by hand: the old
URL 404s, the new one does not.

Also adds `*.pyc` to `.gitignore`.

## Guide to reproduce test results

`build-image.yml` only runs on push to `main`, so this PR's checks never touch
the changed line. `docker build .devcontainer` reaches it in about a minute.

## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [ ] This change is covered by tests that are already landed, or in this PR.
