### PR TITLE
Fix possible fix(deps): 4 vulnerable dependencies in requirements.txt

### DIFF
--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -1,5 +1,5 @@
-Jinja2==3.1.2
-Markdown==3.3.6
+Jinja2==3.1.5
+Markdown==3.8.1
 MarkupSafe==2.1.1
 mkdocs==1.3.0
-pip==22.0.4
+pip==26.1.2


### PR DESCRIPTION
Small change to `.devcontainer/requirements.txt` — a scan flagged the code below and it looked genuine. It is around line 1.

Vulnerability: CVE-2024-56201 in Jinja2 3.1.2 (fixed in 3.1.5). A bug in the Jinja bytecode compiler allows arbitrary Python code execution when an attacker controls BOTH the content and the filename of a template. Critically, this bypass works even when Jinja's sandbox (SandboxedEnvironment) is enabled, so relying on the sandbox as a mitigation is not sufficient. Impact: Remote Code Execution (RCE) in any application that renders untrusted templates where template filenames are attacker-influenced (e.g., user-uploaded templates stored under user-controlled paths/names). Risk: MEDIUM-to-HIGH — the vulnerable pin lives in .devcontainer/requirements.txt, which limits direct production exposure, but if the same version constraint is mirrored in production requirements or dev environments render untrusted content, the impact escalates to critical RCE. Recommendation: upgrade to Jinja2 >= 3.1.5 everywhere the dependency is declared, and as defense-in-depth, ensure template filenames are generated/sanitized server-side rather than derived from user input.

Update Jinja2, Markdown, and pip to versions that address reported CVEs.

For reference: rule `CVE-2024-56201`. Rated high.

I do not know the codebase, so please check the change fits how the rest of it works. Happy to adjust it or close this if the reasoning is off.

---
*Found with automated scanning ([RedGem](https://code.redgem.net)) and reviewed before opening. If it is not useful, closing it is completely fine.*
